### PR TITLE
refactor(ui): extract spectrum bar rendering to dedicated module with…

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,6 +25,7 @@ pub mod sample_rate;
 pub mod signal_metrics;
 pub mod signal_strip;
 pub mod spectrum;
+pub mod spectrum_bars;
 pub mod sweep_panel;
 pub mod sweep_strip;
 pub mod system_resources;

--- a/src/ui/spectrum.rs
+++ b/src/ui/spectrum.rs
@@ -4,10 +4,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{
-        canvas::{Canvas, Line as CanvasLine, Points},
-        Block, BorderType, Borders, Paragraph,
-    },
+    widgets::{Block, BorderType, Borders, Paragraph},
     Frame,
 };
 
@@ -15,6 +12,7 @@ use crate::palette::{magnitude_to_color_themed, ColorDepth};
 use crate::state::SdrMetrics;
 use crate::ui::band_plan::BAND_PLAN;
 use crate::ui::panel::Panel;
+use crate::ui::spectrum_bars::{self, Bar, Overlays, VLine};
 
 // ── Spectrum step sizes ───────────────────────────────────────────────────────
 
@@ -51,12 +49,6 @@ fn fmt_khz(hz: u64) -> String {
 pub fn fmt_spectrum_step(hz: u64) -> String {
     if hz >= 1_000_000 { format!("{} MHz", hz / 1_000_000) }
     else { format!("{} kHz", hz / 1_000) }
-}
-
-fn freq_to_canvas_x(freq_hz: f64, left_hz: f64, bw: f64, n: f64) -> Option<f64> {
-    if bw <= 0.0 { return None; }
-    let frac = (freq_hz - left_hz) / bw;
-    if (0.0..=1.0).contains(&frac) { Some(frac * (n - 1.0)) } else { None }
 }
 
 pub struct SpectrumPanel;
@@ -150,7 +142,6 @@ impl Panel for SpectrumPanel {
 
                 let n_bins = frame.bins_dbfs.len();
                 if n_bins == 0 { return; }
-                let n = n_bins as f64;
                 let bw = frame.sample_rate;
                 if bw <= 0.0 { return; }
                 let left_hz  = frame.center_freq_hz as f64 - bw / 2.0;
@@ -159,8 +150,6 @@ impl Panel for SpectrumPanel {
                 // Dynamic y-range from state (user-controlled zoom)
                 let y_min_f = state.spectrum.y_min;
                 let y_max_f = state.spectrum.y_max;
-                let y_min   = y_min_f as f64;
-                let y_max   = y_max_f as f64;
 
                 let depth = ColorDepth::detect();
                 // Arc::clone is O(1) — no data copied
@@ -168,65 +157,10 @@ impl Panel for SpectrumPanel {
                 let peaks = Arc::clone(&frame.peak_hold);
                 let noise_floor = frame.noise_floor;
 
-                // Per-bin colors pre-computed outside the closure (closure can't borrow Theme)
-                let bin_colors: Vec<ratatui::style::Color> = bins.iter()
-                    .map(|&db| magnitude_to_color_themed(db, y_min_f, y_max_f, depth, theme))
-                    .collect();
-                let peak_hold_color   = theme.peak_hold;
-                let noise_floor_color = theme.noise_floor;
-
                 // Hold ghost: Arc clone, O(1)
                 let held_bins = state.spectrum.hold.clone();
-                let hold_color = theme.border_dim;
 
-                // Cursor: canvas x-coordinate (0..n-1)
-                let cursor_x_canvas = state.spectrum.cursor_freq.and_then(|cf| {
-                    let frac = (cf as f64 - left_hz) / bw;
-                    if (0.0..=1.0).contains(&frac) { Some(frac * (n - 1.0)) } else { None }
-                });
-                let cursor_color = theme.value_hi;
-
-                // Marker canvas x-coordinates + optional BW boundary pairs
-                struct MarkerCanvas {
-                    x:      Option<f64>,
-                    bw_lo:  Option<f64>,
-                    bw_hi:  Option<f64>,
-                }
-                let marker_data: Vec<MarkerCanvas> = state.spectrum.markers.iter()
-                    .filter_map(|mk| {
-                        let x = freq_to_canvas_x(mk.freq_hz as f64, left_hz, bw, n);
-                        let (bw_lo, bw_hi) = if let Some(ch_bw) = mk.channel_bw_hz {
-                            let half = ch_bw as f64 / 2.0;
-                            let lo_frac = (mk.freq_hz as f64 - half - left_hz) / bw;
-                            let hi_frac = (mk.freq_hz as f64 + half - left_hz) / bw;
-                            (
-                                if (0.0..=1.0).contains(&lo_frac) { Some(lo_frac * (n - 1.0)) } else { None },
-                                if (0.0..=1.0).contains(&hi_frac) { Some(hi_frac * (n - 1.0)) } else { None },
-                            )
-                        } else {
-                            (None, None)
-                        };
-
-                        let overlaps_view = if let Some(ch_bw) = mk.channel_bw_hz {
-                            let half = ch_bw as f64 / 2.0;
-                            let lo_frac = (mk.freq_hz as f64 - half - left_hz) / bw;
-                            let hi_frac = (mk.freq_hz as f64 + half - left_hz) / bw;
-                            lo_frac <= 1.0 && hi_frac >= 0.0
-                        } else {
-                            x.is_some()
-                        };
-
-                        if overlaps_view {
-                            Some(MarkerCanvas { x, bw_lo, bw_hi })
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                let marker_color    = theme.status_warn;
-                let bw_border_color = theme.border_accent;
-
-                // Cursor power (read before closure)
+                // Cursor power
                 let cursor_power: Option<f32> = state.spectrum.cursor_freq.and_then(|cf| {
                     let frac = (cf as f64 - left_hz) / bw;
                     if (0.0..=1.0).contains(&frac) {
@@ -237,70 +171,70 @@ impl Panel for SpectrumPanel {
                 let cursor_freq_mhz = state.spectrum.cursor_freq
                     .map(|f| f as f64 / 1_000_000.0);
 
-                // ── Canvas ────────────────────────────────────────────────
-                f.render_widget(
-                    Canvas::default()
-                        .x_bounds([0.0, n - 1.0])
-                        .y_bounds([y_min, y_max])
-                        .paint(move |ctx| {
-                            // 1. Hold ghost (behind live signal)
-                            if let Some(ref held) = held_bins {
-                                for i in 1..held.len() {
-                                    let y0 = held[i - 1].clamp(y_min_f, y_max_f) as f64;
-                                    let y1 = held[i].clamp(y_min_f, y_max_f) as f64;
-                                    ctx.draw(&CanvasLine {
-                                        x1: (i - 1) as f64, y1: y0,
-                                        x2: i as f64,       y2: y1,
-                                        color: hold_color,
-                                    });
-                                }
+                // ── Block-bar render (replaces braille Canvas) ────────────
+                let width = canvas_area.width as usize;
+                if width > 0 {
+                    let col_db   = spectrum_bars::downsample_max(&bins, width);
+                    let col_peak = spectrum_bars::downsample_max(&peaks, width);
+                    let col_hold = held_bins
+                        .as_ref()
+                        .map(|h| spectrum_bars::downsample_max(h, width))
+                        .unwrap_or_default();
+
+                    let bars: Vec<Bar> = col_db
+                        .iter()
+                        .map(|&db| Bar {
+                            db,
+                            color: magnitude_to_color_themed(db, y_min_f, y_max_f, depth, theme),
+                        })
+                        .collect();
+
+                    let freq_to_col = |freq_hz: f64| -> Option<u16> {
+                        let frac = (freq_hz - left_hz) / bw;
+                        if (0.0..=1.0).contains(&frac) {
+                            Some(((frac * (width.saturating_sub(1)) as f64).round() as usize)
+                                .min(width - 1) as u16)
+                        } else {
+                            None
+                        }
+                    };
+
+                    let mut vlines: Vec<VLine> = Vec::new();
+                    for mk in &state.spectrum.markers {
+                        if let Some(c) = freq_to_col(mk.freq_hz as f64) {
+                            vlines.push(VLine { col: c, color: theme.status_warn });
+                        }
+                        if let Some(ch_bw) = mk.channel_bw_hz {
+                            let half = ch_bw as f64 / 2.0;
+                            if let Some(c) = freq_to_col(mk.freq_hz as f64 - half) {
+                                vlines.push(VLine { col: c, color: theme.border_accent });
                             }
-                            // 2. Filled columns
-                            for i in 0..bins.len() {
-                                let y_top = bins[i].clamp(y_min_f, y_max_f) as f64;
-                                ctx.draw(&CanvasLine {
-                                    x1: i as f64, y1: y_min,
-                                    x2: i as f64, y2: y_top,
-                                    color: bin_colors[i],
-                                });
+                            if let Some(c) = freq_to_col(mk.freq_hz as f64 + half) {
+                                vlines.push(VLine { col: c, color: theme.border_accent });
                             }
-                            // 3. Outline
-                            for i in 1..bins.len() {
-                                let y0 = bins[i - 1].clamp(y_min_f, y_max_f) as f64;
-                                let y1 = bins[i].clamp(y_min_f, y_max_f) as f64;
-                                ctx.draw(&CanvasLine {
-                                    x1: (i - 1) as f64, y1: y0,
-                                    x2: i as f64,       y2: y1,
-                                    color: bin_colors[i - 1],
-                                });
-                            }
-                            // 4. Peak hold
-                            for (i, &db) in peaks.iter().enumerate() {
-                                let y = db.clamp(y_min_f, y_max_f) as f64;
-                                ctx.draw(&Points { coords: &[(i as f64, y)], color: peak_hold_color });
-                            }
-                            // 5. Noise floor
-                            let nf = noise_floor.clamp(y_min_f, y_max_f) as f64;
-                            ctx.draw(&CanvasLine { x1: 0.0, y1: nf, x2: n - 1.0, y2: nf, color: noise_floor_color });
-                            // 6. Marker lines + channel BW boundaries
-                            for md in &marker_data {
-                                if let Some(cx) = md.x {
-                                    ctx.draw(&CanvasLine { x1: cx, y1: y_min, x2: cx, y2: y_max, color: marker_color });
-                                }
-                                if let Some(lo) = md.bw_lo {
-                                    ctx.draw(&CanvasLine { x1: lo, y1: y_min, x2: lo, y2: y_max, color: bw_border_color });
-                                }
-                                if let Some(hi) = md.bw_hi {
-                                    ctx.draw(&CanvasLine { x1: hi, y1: y_min, x2: hi, y2: y_max, color: bw_border_color });
-                                }
-                            }
-                            // 7. Cursor line
-                            if let Some(cx) = cursor_x_canvas {
-                                ctx.draw(&CanvasLine { x1: cx, y1: y_min, x2: cx, y2: y_max, color: cursor_color });
-                            }
-                        }),
-                    canvas_area,
-                );
+                        }
+                    }
+                    if let Some(cf) = state.spectrum.cursor_freq {
+                        if let Some(c) = freq_to_col(cf as f64) {
+                            vlines.push(VLine { col: c, color: theme.value_hi });
+                        }
+                    }
+
+                    let ov = Overlays {
+                        bar_db:      &col_db,
+                        peak_db:     &col_peak,
+                        hold_db:     &col_hold,
+                        vlines:      &vlines,
+                        noise_floor,
+                        peak_color:  theme.peak_hold,
+                        hold_color:  theme.border_dim,
+                        noise_color: theme.noise_floor,
+                    };
+
+                    let buf = f.buffer_mut();
+                    spectrum_bars::paint_bars(buf, canvas_area, &bars, y_min_f, y_max_f);
+                    spectrum_bars::paint_overlays(buf, canvas_area, &ov, y_min_f, y_max_f);
+                }
 
                 // ── Band plan overlay (text on top of canvas, top row) ────
                 if canvas_area.height >= 2 && canvas_area.width > 4 {

--- a/src/ui/spectrum_bars.rs
+++ b/src/ui/spectrum_bars.rs
@@ -1,0 +1,277 @@
+//! Filled block-bar spectrum renderer (replaces the braille Canvas).
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+
+/// Reduce `bins` (dBFS) to exactly `cols` columns, taking the MAX dBFS of each
+/// column's covering bin range. Max preserves narrow peaks; mean would smear
+/// them. Empty/zero cases yield an empty Vec.
+pub fn downsample_max(bins: &[f32], cols: usize) -> Vec<f32> {
+    if bins.is_empty() || cols == 0 {
+        return Vec::new();
+    }
+    let n = bins.len();
+    (0..cols)
+        .map(|c| {
+            let lo = c * n / cols;
+            let hi = ((c + 1) * n / cols).max(lo + 1).min(n);
+            bins[lo..hi].iter().copied().fold(f32::NEG_INFINITY, f32::max)
+        })
+        .collect()
+}
+
+/// Eighth-block glyphs indexed 0..=8. Index 0 is a space (empty), index 8 is a
+/// full block. A partial top cell uses indices 1..=7.
+pub const EIGHTHS: [&str; 9] = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+/// Map a dBFS value to a vertical fill over `rows` cells.
+/// Returns `(full_cells, top_eighth)` where `full_cells` cells are full blocks
+/// (`EIGHTHS[8]`) and, if `top_eighth > 0`, one more cell above them shows
+/// `EIGHTHS[top_eighth]`.
+pub fn column_fill(db: f32, y_min: f32, y_max: f32, rows: u16) -> (u16, u8) {
+    if rows == 0 || y_max <= y_min {
+        return (0, 0);
+    }
+    let frac = ((db - y_min) / (y_max - y_min)).clamp(0.0, 1.0);
+    let total_eighths = (frac * rows as f32 * 8.0).round() as u32;
+    let full = (total_eighths / 8) as u16;
+    let rem = (total_eighths % 8) as u8;
+    (full, rem)
+}
+
+/// Per-column bar input: downsampled dBFS and its palette color.
+pub struct Bar {
+    pub db: f32,
+    pub color: Color,
+}
+
+/// Paint filled bars into `area` of `buf`. `bars.len()` should equal
+/// `area.width`; extra/short slices are clamped. Bars grow up from the bottom
+/// row. The top partial cell uses the matching eighth glyph.
+pub fn paint_bars(buf: &mut Buffer, area: Rect, bars: &[Bar], y_min: f32, y_max: f32) {
+    let rows = area.height;
+    if rows == 0 || area.width == 0 {
+        return;
+    }
+    let bottom = area.y + rows - 1;
+    let cols = (area.width as usize).min(bars.len());
+    for (cx, bar) in bars.iter().enumerate().take(cols) {
+        let (full, rem) = column_fill(bar.db, y_min, y_max, rows);
+        let x = area.x + cx as u16;
+        for r in 0..full.min(rows) {
+            let y = bottom - r;
+            buf.get_mut(x, y).set_symbol(EIGHTHS[8]).set_fg(bar.color);
+        }
+        if rem > 0 && full < rows {
+            let y = bottom - full;
+            buf.get_mut(x, y).set_symbol(EIGHTHS[rem as usize]).set_fg(bar.color);
+        }
+    }
+}
+
+/// First empty row index (0 = bottom) above the bar for a column of value `db`.
+fn empty_floor(db: f32, y_min: f32, y_max: f32, rows: u16) -> u16 {
+    let (full, rem) = column_fill(db, y_min, y_max, rows);
+    (full + u16::from(rem > 0)).min(rows)
+}
+
+/// A vertical overlay line (marker / channel-BW boundary / cursor) at a column.
+pub struct VLine {
+    pub col: u16,
+    pub color: Color,
+}
+
+/// Inputs for the overlay pass. Per-column slices share the bars length;
+/// `peak_db`/`hold_db` may be empty to skip them.
+pub struct Overlays<'a> {
+    pub bar_db: &'a [f32],
+    pub peak_db: &'a [f32],
+    pub hold_db: &'a [f32],
+    pub vlines: &'a [VLine],
+    pub noise_floor: f32,
+    pub peak_color: Color,
+    pub hold_color: Color,
+    pub noise_color: Color,
+}
+
+/// Paint overlays into `area`, only into empty cells above each bar.
+pub fn paint_overlays(buf: &mut Buffer, area: Rect, ov: &Overlays, y_min: f32, y_max: f32) {
+    let rows = area.height;
+    if rows == 0 || area.width == 0 {
+        return;
+    }
+    let bottom = area.y + rows - 1;
+    let cols = area.width as usize;
+
+    let row_of = |db: f32| -> u16 {
+        let frac = ((db - y_min) / (y_max - y_min)).clamp(0.0, 1.0);
+        (frac * (rows.saturating_sub(1)) as f32).round() as u16
+    };
+
+    for (slice, glyph, color) in [
+        (ov.hold_db, "▔", ov.hold_color),
+        (ov.peak_db, "▔", ov.peak_color),
+    ] {
+        for (cx, &db_val) in slice.iter().enumerate().take(cols.min(slice.len())) {
+            let floor = empty_floor(ov.bar_db.get(cx).copied().unwrap_or(y_min), y_min, y_max, rows);
+            let r = row_of(db_val);
+            if r >= floor && r < rows {
+                let x = area.x + cx as u16;
+                let y = bottom - r;
+                buf.get_mut(x, y).set_symbol(glyph).set_fg(color);
+            }
+        }
+    }
+
+    if ov.noise_floor > y_min {
+        let r = row_of(ov.noise_floor);
+        if r < rows {
+            let y = bottom - r;
+            for cx in 0..cols.min(ov.bar_db.len()) {
+                let floor = empty_floor(ov.bar_db[cx], y_min, y_max, rows);
+                if r >= floor {
+                    let x = area.x + cx as u16;
+                    buf.get_mut(x, y).set_symbol("─").set_fg(ov.noise_color);
+                }
+            }
+        }
+    }
+
+    for vl in ov.vlines {
+        if (vl.col as usize) >= cols {
+            continue;
+        }
+        let floor = empty_floor(
+            ov.bar_db.get(vl.col as usize).copied().unwrap_or(y_min),
+            y_min, y_max, rows,
+        );
+        let x = area.x + vl.col;
+        for r in floor..rows {
+            let y = bottom - r;
+            buf.get_mut(x, y).set_symbol("│").set_fg(vl.color);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::style::Color;
+
+    fn sym(buf: &Buffer, x: u16, y: u16) -> String {
+        buf.get(x, y).symbol().to_string()
+    }
+
+    #[test]
+    fn downsample_identity_when_cols_equals_len() {
+        let bins = [-10.0, -20.0, -30.0, -40.0];
+        assert_eq!(downsample_max(&bins, 4), vec![-10.0, -20.0, -30.0, -40.0]);
+    }
+
+    #[test]
+    fn downsample_takes_max_not_mean() {
+        let bins = [-10.0, -90.0, -50.0, -40.0];
+        assert_eq!(downsample_max(&bins, 2), vec![-10.0, -40.0]);
+    }
+
+    #[test]
+    fn downsample_upsamples_when_cols_gt_len() {
+        let bins = [-10.0, -50.0];
+        assert_eq!(downsample_max(&bins, 4), vec![-10.0, -10.0, -50.0, -50.0]);
+    }
+
+    #[test]
+    fn downsample_empty_inputs() {
+        assert_eq!(downsample_max(&[], 8), Vec::<f32>::new());
+        assert_eq!(downsample_max(&[-10.0, -20.0], 0), Vec::<f32>::new());
+    }
+
+    #[test]
+    fn fill_below_min_is_empty() {
+        assert_eq!(column_fill(-100.0, -90.0, -20.0, 5), (0, 0));
+    }
+
+    #[test]
+    fn fill_at_or_above_max_is_full() {
+        assert_eq!(column_fill(-20.0, -90.0, -20.0, 5), (5, 0));
+        assert_eq!(column_fill(0.0, -90.0, -20.0, 5), (5, 0));
+    }
+
+    #[test]
+    fn fill_half_height() {
+        assert_eq!(column_fill(-55.0, -90.0, -20.0, 4), (2, 0));
+    }
+
+    #[test]
+    fn fill_partial_top_cell() {
+        assert_eq!(column_fill(-55.0, -90.0, -20.0, 1), (0, 4));
+    }
+
+    #[test]
+    fn fill_zero_rows() {
+        assert_eq!(column_fill(-20.0, -90.0, -20.0, 0), (0, 0));
+    }
+
+    #[test]
+    fn paint_bars_fills_from_bottom() {
+        let area = Rect::new(0, 0, 2, 4);
+        let mut buf = Buffer::empty(area);
+        let bars = vec![
+            Bar { db: -20.0, color: Color::Red },
+            Bar { db: -90.0, color: Color::Red },
+        ];
+        paint_bars(&mut buf, area, &bars, -90.0, -20.0);
+        for y in 0..4 {
+            assert_eq!(sym(&buf, 0, y), "█", "col0 row {y}");
+        }
+        assert_eq!(buf.get(0, 3).fg, Color::Red);
+        assert_eq!(sym(&buf, 1, 3), " ");
+    }
+
+    #[test]
+    fn peak_cap_sits_above_bar() {
+        let area = Rect::new(0, 0, 1, 4);
+        let mut buf = Buffer::empty(area);
+        let bars = vec![Bar { db: -55.0, color: Color::Red }];
+        paint_bars(&mut buf, area, &bars, -90.0, -20.0);
+        let ov = Overlays {
+            bar_db: &[-55.0],
+            peak_db: &[-20.0],
+            hold_db: &[],
+            vlines: &[],
+            noise_floor: -200.0,
+            peak_color: Color::White,
+            hold_color: Color::DarkGray,
+            noise_color: Color::Blue,
+        };
+        paint_overlays(&mut buf, area, &ov, -90.0, -20.0);
+        assert_eq!(sym(&buf, 0, 0), "▔");
+        assert_eq!(buf.get(0, 0).fg, Color::White);
+        assert_eq!(sym(&buf, 0, 3), "█");
+    }
+
+    #[test]
+    fn vline_only_fills_empty_region() {
+        let area = Rect::new(0, 0, 1, 4);
+        let mut buf = Buffer::empty(area);
+        let bars = vec![Bar { db: -55.0, color: Color::Red }];
+        paint_bars(&mut buf, area, &bars, -90.0, -20.0);
+        let ov = Overlays {
+            bar_db: &[-55.0],
+            peak_db: &[],
+            hold_db: &[],
+            vlines: &[VLine { col: 0, color: Color::Yellow }],
+            noise_floor: -200.0,
+            peak_color: Color::White,
+            hold_color: Color::DarkGray,
+            noise_color: Color::Blue,
+        };
+        paint_overlays(&mut buf, area, &ov, -90.0, -20.0);
+        assert_eq!(sym(&buf, 0, 0), "│");
+        assert_eq!(buf.get(0, 0).fg, Color::Yellow);
+        assert_eq!(sym(&buf, 0, 3), "█");
+    }
+}


### PR DESCRIPTION
… high-res blocks

Refactored the spectrum visualizer by removing the raw Canvas rendering pass and replacing it with a modular, block-based drawing architecture.

- Created `src/ui/spectrum_bars.rs` implementing `downsample_max` for peak-preserving downsampling.
- Implemented high-resolution sub-cell bar geometry using eighth-block characters (`EIGHTHS`) and `column_fill`.
- Added isolated rendering functions (`paint_bars`, `paint_overlays`) backed by 12 comprehensive unit tests.
- Cleaned up `src/ui/spectrum.rs` by offloading logic to the new module, resulting in a net reduction of dead code (-131 lines, +66).
- Registered the new module in `src/ui/mod.rs`.