### PR TITLE
fix(rtlsdr): use libc::c_char for USB string buffers to fix ARM build

### DIFF
--- a/src/hardware/rtlsdr/mod.rs
+++ b/src/hardware/rtlsdr/mod.rs
@@ -338,9 +338,12 @@ fn device_name(index: u32) -> String {
 }
 
 fn device_serial(index: u32) -> Option<String> {
-    let mut manufact = [0i8; 256];
-    let mut product = [0i8; 256];
-    let mut serial = [0i8; 256];
+    // `libc::c_char` is `i8` on x86_64 but `u8` on ARM Linux; tying the buffer
+    // element type to it keeps `.as_ptr()` matching the FFI's `*mut c_char`
+    // (and `CStr::from_ptr`'s `*const c_char`) on every platform.
+    let mut manufact = [0 as libc::c_char; 256];
+    let mut product = [0 as libc::c_char; 256];
+    let mut serial = [0 as libc::c_char; 256];
     unsafe {
         if rtlsdr_get_device_usb_strings(
             index,


### PR DESCRIPTION
device_serial() hardcoded `[0i8; 256]` for the C string buffers passed to rtlsdr_get_device_usb_strings() (and read back via CStr::from_ptr). The FFI takes `*mut c_char`, but `libc::c_char` is `i8` only on x86_64 — on ARM Linux (e.g. Raspberry Pi 5 / Kali) it is `u8`, so `.as_ptr()` produced `*mut i8` / `*const i8` and the build failed with E0308.

Tie the buffer element type to `libc::c_char` so the pointers match the FFI signature on every platform. Mirrors the existing approach in the HackRF backend (read_version).

Verified: reproduced the E0308 on an emulated aarch64 build before the change, and confirmed `cargo check` passes on both aarch64 and x86_64 after it. Also enumerated a real RTL2832U over USB on both arches (device_serial returns "00000001").

Fixes #3