### PR TITLE
Add tinySA spectrum backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -134,7 +140,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -173,6 +179,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,7 +215,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -274,6 +296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +411,17 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -479,7 +531,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -499,7 +551,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -556,6 +608,7 @@ dependencies = [
  "ratatui",
  "rustfft",
  "serde",
+ "serialport",
  "tokio",
  "toml",
 ]
@@ -587,7 +640,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -597,6 +650,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serialport"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f4ac56b5d3af3c40fbbee17be96d532cba02fa5853926aacdb77d926272ab"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "core-foundation",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "mach2",
+ "nix",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -653,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -693,7 +764,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -705,6 +776,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -732,7 +834,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -784,6 +886,15 @@ checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
 dependencies = [
  "num-integer",
  "strength_reduce",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -861,7 +972,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -879,13 +999,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -895,10 +1031,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -907,10 +1055,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -919,16 +1085,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ num-complex = "0.4"
 # exactly the binary it runs today and simply sees no Soapy devices. See
 # dev_docs/soapy-design.md, decision 1.
 libloading = "0.8"
+serialport = { version = "4", default-features = false }
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It's a hobby project built in my spare time, and honestly, I made it for *you* �
 > [!IMPORTANT]
 > **Project status: early development.** The TUI is feature-complete and the arc now is polish, sharper radio math and bug fixing, not more features.
 >
-> Two radios are **verified on hardware**: HackRF One and RTL-SDR. Anything with a **SoapySDR** driver also works, and that backend is **beta**: it was written from the API rather than from owning the radios, so treat it as "should work, nobody has confirmed it yet". [The docs say exactly which parts are confirmed](user_docs/hardware.md#soapysdr-the-honest-version). If you own one of those, an issue either way is worth a lot to me.
+> HackRF One, RTL-SDR and a tinySA Ultra ZS405 are **verified on hardware**. Anything with a **SoapySDR** driver also works, and that backend is **beta**: it was written from the API rather than from owning the radios, so treat it as "should work, nobody has confirmed it yet". [The docs say exactly which parts are confirmed](user_docs/hardware.md#soapysdr-the-honest-version). If you own one of those, an issue either way is worth a lot to me.
 >
 > Known issues: plenty 😄 If something looks broken, it's either a bug or an undocumented feature. Flip a coin, then open an issue.
 
@@ -270,6 +270,7 @@ The whole story, in order: [What's new](user_docs/whats-new.md).
 |---|---|---|
 | HackRF One | ✅ Full support | All diagnostics, gain stages, ADC metrics |
 | RTL-SDR (R820T, E4000, R828D) | ✅ Full support | Single tuner gain + AGC; no VGA, no BB filter, no Friis NF |
+| tinySA / Ultra / Ultra+ | ✅ Spectrum support | ZS405 verified; calibrated dBm spectrum and waterfall |
 | **Anything with a SoapySDR driver** | 🧪 **Beta** | Airspy, SDRplay, Pluto, Lime, bladeRF, USRP, SoapyRemote. Unconfirmed on anything but a HackRF |
 | PortaPack H4M (Mayhem) | ✅ Full support | HackRF mode: all HackRF diagnostics apply |
 | HackRF Pro | 🔲 Planned | Needs hardware |

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -113,7 +113,7 @@ impl App {
             // RTL-SDR reports a tuner instead of a board revision / USB-API version.
             if let Some(tuner) = &info.tuner_name {
                 m.push_log(format!("Tuner: {}", tuner));
-            } else {
+            } else if caps.acquisition == hardware::AcquisitionKind::IqSamples {
                 m.push_log(board);
             }
             // Anything the backend declined while opening. Both native paths

--- a/src/app/input/global/radio.rs
+++ b/src/app/input/global/radio.rs
@@ -87,16 +87,23 @@ pub(super) fn begin_frequency_input(ctx: &mut InputCtx<'_>) {
 /// `[S]` - type a sample rate, with the device's own legal range in the prompt.
 pub(super) fn begin_sample_rate_input(ctx: &mut InputCtx<'_>) {
     let Some(device) = ctx.device else { return };
-    let (lo, hi) = {
+    let (lo, hi, name) = {
         let c = device.capabilities();
-        (c.sample_rate_min_hz / 1e6, c.sample_rate_max_hz / 1e6)
+        (
+            c.sample_rate_min_hz / 1e6,
+            c.sample_rate_max_hz / 1e6,
+            if c.sample_rate_is_span {
+                "span"
+            } else {
+                "sample rate"
+            },
+        )
     };
     let mut m = metrics(ctx.state);
     m.ui.input_mode = InputMode::SampleRateInput;
     m.ui.input_buf.clear();
     m.push_log(format!(
-        "Enter sample rate in MHz ({:.1}\u{2013}{:.1}), then press Enter",
-        lo, hi
+        "Enter {name} in MHz ({lo:.1}\u{2013}{hi:.1}), then press Enter",
     ));
 }
 

--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -146,7 +146,7 @@ fn move_down(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
         MenuPane::Keys => {
             let last = {
                 let m = metrics(ctx.state);
-                keys::row_count(&m.caps.gain).saturating_sub(1)
+                keys::row_count_for(&m.caps).saturating_sub(1)
             };
             let next = if step >= 0 {
                 (state.scroll + 1).min(last)

--- a/src/app/input/text.rs
+++ b/src/app/input/text.rs
@@ -90,7 +90,12 @@ pub(super) fn sample_rate(
             let mut m = metrics(state);
             m.ui.input_mode = InputMode::Normal;
             m.ui.input_buf.clear();
-            m.push_log("Sample rate input cancelled");
+            let name = if m.caps.sample_rate_is_span {
+                "Span"
+            } else {
+                "Sample rate"
+            };
+            m.push_log(format!("{name} input cancelled"));
         }
         KeyCode::Backspace => {
             metrics(state).ui.input_buf.pop();
@@ -118,6 +123,11 @@ pub(super) fn sample_rate(
                 // rx_callback thread that needs the same lock to return.
                 let result = rate_hz.map(|hz| device.set_sample_rate(hz));
                 let mut m = metrics(state);
+                let (name, lower_name) = if m.caps.sample_rate_is_span {
+                    ("Span", "span")
+                } else {
+                    ("Sample rate", "sample rate")
+                };
                 match (rate_hz, result) {
                     // The rate recorded is the one the device came back with,
                     // not the one that was typed: a driver is free to round onto
@@ -129,21 +139,21 @@ pub(super) fn sample_rate(
                         m.ui.input_mode = InputMode::Normal;
                         m.ui.input_buf.clear();
                         m.push_log(if set.rate_hz == hz {
-                            format!("Sample rate set to {:.3} MHz", hz / 1e6)
+                            format!("{name} set to {:.3} MHz", hz / 1e6)
                         } else {
                             format!(
-                                "Sample rate {:.3} MHz is not on this radio's grid; running at \
+                                "{name} {:.3} MHz is not on this device's grid; running at \
                                  {:.3} MHz",
                                 hz / 1e6,
                                 set.rate_hz / 1e6
                             )
                         });
                     }
-                    (Some(_), Some(Err(e))) => m.push_log(format!("Sample rate error: {}", e)),
+                    (Some(_), Some(Err(e))) => m.push_log(format!("{name} error: {e}")),
                     _ => {
                         let bad = m.ui.input_buf.clone();
                         m.push_log(format!(
-                            "Invalid sample rate: '{}' (valid: {:.1}–{:.1} MHz)",
+                            "Invalid {lower_name}: '{}' (valid: {:.1}–{:.1} MHz)",
                             bad,
                             lo_hz / 1e6,
                             hi_hz / 1e6

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,8 +44,8 @@ pub struct Cli {
     #[arg(long, value_name = "FILE")]
     pub config: Option<PathBuf>,
 
-    /// Pick the backend, optionally with SoapySDR device args (soapy=driver=airspy)
-    #[arg(long, value_name = "hackrf|rtlsdr|soapy[=args]")]
+    /// Pick the backend, optionally with a tinySA path or SoapySDR device args
+    #[arg(long, value_name = "hackrf|rtlsdr|tinysa[=PATH]|soapy[=args]")]
     pub device: Option<String>,
 
     /// Center frequency in Hz, e.g. 433920000 (overrides config)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,8 +44,11 @@ pub struct Cli {
     #[arg(long, value_name = "FILE")]
     pub config: Option<PathBuf>,
 
-    /// Pick the backend, optionally with a tinySA path or SoapySDR device args
-    #[arg(long, value_name = "hackrf|rtlsdr|tinysa[=PATH]|soapy[=args]")]
+    /// Pick the backend, optionally with a tinySA path/input or SoapySDR device args
+    #[arg(
+        long,
+        value_name = "hackrf|rtlsdr|tinysa[=PATH[?input=low|high]]|soapy[=args]"
+    )]
     pub device: Option<String>,
 
     /// Center frequency in Hz, e.g. 433920000 (overrides config)

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -93,7 +93,7 @@ pub struct DeviceListing {
     pub args: Option<String>,
     /// Character-device path for serial backends.
     pub path: Option<PathBuf>,
-    /// Physical input selected for a basic tinySA.
+    /// Explicit physical input override for a basic tinySA.
     pub tiny_sa_input: Option<tinysa::BasicInput>,
 }
 

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -93,6 +93,8 @@ pub struct DeviceListing {
     pub args: Option<String>,
     /// Character-device path for serial backends.
     pub path: Option<PathBuf>,
+    /// Physical input selected for a basic tinySA.
+    pub tiny_sa_input: Option<tinysa::BasicInput>,
 }
 
 /// Normalise a serial so two backends' spellings of the same radio compare
@@ -135,6 +137,11 @@ pub fn parse_device_arg(spec: &str) -> anyhow::Result<(DeviceKind, Option<String
              'soapy'; tinysa and soapy accept '=selector')"
         ),
     };
+    if kind == DeviceKind::TinySa {
+        if let Some(selector) = filter.as_deref() {
+            tinysa::parse_selector(selector)?;
+        }
+    }
     Ok((kind, filter))
 }
 
@@ -169,19 +176,9 @@ pub fn list_all_devices(
     out.extend(hackrf::list());
     out.extend(rtlsdr::list());
     let tinysa = if want == Some(DeviceKind::TinySa) {
-        match soapy_filter.filter(|value| !value.is_empty()) {
-            Some(path) => vec![DeviceListing {
-                kind: DeviceKind::TinySa,
-                index: 0,
-                label: format!("tinySA · {path}"),
-                serial: None,
-                args: None,
-                path: Some(PathBuf::from(path)),
-            }],
-            None => tinysa::list(),
-        }
+        tinysa::list(soapy_filter.filter(|value| !value.is_empty()))
     } else {
-        tinysa::list()
+        tinysa::list(None)
     };
     out.extend(tinysa);
     // A radio the native backend also found is normally dropped. Not when the
@@ -263,7 +260,10 @@ pub fn open_device(listing: &DeviceListing) -> anyhow::Result<Arc<dyn SdrDevice>
             let Some(path) = listing.path.as_deref() else {
                 anyhow::bail!("a tinySA listing with no serial port cannot be opened");
             };
-            Ok(Arc::new(tinysa::TinySaDevice::open(path)?))
+            Ok(Arc::new(tinysa::TinySaDevice::open(
+                path,
+                listing.tiny_sa_input.unwrap_or_default(),
+            )?))
         }
     }
 }
@@ -285,6 +285,7 @@ mod tests {
             serial: serial.map(str::to_string),
             args: args.map(str::to_string),
             path: None,
+            tiny_sa_input: None,
         }
     }
 
@@ -464,6 +465,14 @@ mod tests {
             (DeviceKind::Soapy, Some("driver=airspy".to_string())),
             "only the first = separates the name from the arguments"
         );
+        assert_eq!(
+            parse_device_arg("tinysa=/dev/ttyACM2?input=high").unwrap(),
+            (
+                DeviceKind::TinySa,
+                Some("/dev/ttyACM2?input=high".to_string())
+            )
+        );
+        assert!(parse_device_arg("tinysa=/dev/ttyACM2?input=other").is_err());
         assert!(parse_device_arg("airspy").is_err(), "not a backend name");
         assert!(parse_device_arg("").is_err(), "nor is nothing");
     }

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -12,10 +12,11 @@
 //! Everything in this file is about identity and offering. Opening a device is
 //! the backend's job; [`open_device`] only dispatches to it.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::native::{hackrf, rtlsdr};
-use super::{soapy, sysfs, DeviceCapabilities, SdrDevice};
+use super::{soapy, sysfs, tinysa, DeviceCapabilities, SdrDevice};
 
 /// Which backend a [`DeviceListing`] / open request targets.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -23,6 +24,7 @@ pub enum DeviceKind {
     HackRf,
     RtlSdr,
     Soapy,
+    TinySa,
 }
 
 /// What observer mode needs in order to describe a device it cannot open.
@@ -64,7 +66,7 @@ impl DeviceKind {
                 scan: sysfs::find_rtlsdr,
                 caps: rtlsdr::observer_caps,
             }),
-            DeviceKind::Soapy => None,
+            DeviceKind::Soapy | DeviceKind::TinySa => None,
         }
     }
 }
@@ -89,6 +91,8 @@ pub struct DeviceListing {
     /// a race. The two native backends genuinely are index addressed, so they
     /// carry nothing here.
     pub args: Option<String>,
+    /// Character-device path for serial backends.
+    pub path: Option<PathBuf>,
 }
 
 /// Normalise a serial so two backends' spellings of the same radio compare
@@ -125,9 +129,10 @@ pub fn parse_device_arg(spec: &str) -> anyhow::Result<(DeviceKind, Option<String
         "hackrf" => DeviceKind::HackRf,
         "rtlsdr" | "rtl-sdr" | "rtl" => DeviceKind::RtlSdr,
         "soapy" | "soapysdr" => DeviceKind::Soapy,
+        "tinysa" | "tiny-sa" => DeviceKind::TinySa,
         other => anyhow::bail!(
-            "Unknown --device '{other}' (use 'hackrf', 'rtlsdr', or \
-             'soapy', optionally as 'soapy=driver=airspy')"
+            "Unknown --device '{other}' (use 'hackrf', 'rtlsdr', 'tinysa', or \
+             'soapy'; tinysa and soapy accept '=selector')"
         ),
     };
     Ok((kind, filter))
@@ -163,6 +168,22 @@ pub fn list_all_devices(
     let mut out = Vec::new();
     out.extend(hackrf::list());
     out.extend(rtlsdr::list());
+    let tinysa = if want == Some(DeviceKind::TinySa) {
+        match soapy_filter.filter(|value| !value.is_empty()) {
+            Some(path) => vec![DeviceListing {
+                kind: DeviceKind::TinySa,
+                index: 0,
+                label: format!("tinySA · {path}"),
+                serial: None,
+                args: None,
+                path: Some(PathBuf::from(path)),
+            }],
+            None => tinysa::list(),
+        }
+    } else {
+        tinysa::list()
+    };
+    out.extend(tinysa);
     // A radio the native backend also found is normally dropped. Not when the
     // user asked for SoapySDR by name: then the Soapy path is the thing they
     // wanted, and hiding it would leave `--device soapy` finding nothing at all
@@ -238,6 +259,12 @@ pub fn open_device(listing: &DeviceListing) -> anyhow::Result<Arc<dyn SdrDevice>
             };
             Ok(Arc::new(soapy::device::SoapyDevice::open(args)?))
         }
+        DeviceKind::TinySa => {
+            let Some(path) = listing.path.as_deref() else {
+                anyhow::bail!("a tinySA listing with no serial port cannot be opened");
+            };
+            Ok(Arc::new(tinysa::TinySaDevice::open(path)?))
+        }
     }
 }
 
@@ -257,6 +284,7 @@ mod tests {
             label: label.to_string(),
             serial: serial.map(str::to_string),
             args: args.map(str::to_string),
+            path: None,
         }
     }
 
@@ -449,6 +477,9 @@ mod tests {
         for s in ["soapy", "soapysdr", "SoapySDR"] {
             assert_eq!(parse_device_arg(s).unwrap().0, DeviceKind::Soapy, "{s}");
         }
+        for s in ["tinysa", "tiny-sa", "TinySA"] {
+            assert_eq!(parse_device_arg(s).unwrap().0, DeviceKind::TinySa, "{s}");
+        }
     }
 
     /// `--device soapy=` is a backend with an empty filter, and an empty filter
@@ -479,6 +510,7 @@ mod tests {
             DeviceKind::Soapy.observer_profile().is_none(),
             "there is no sysfs profile for whatever SoapySDR was talking to"
         );
+        assert!(DeviceKind::TinySa.observer_profile().is_none());
     }
 
     /// The failure the deleted assertion existed to prevent: a user staring at

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -3,12 +3,9 @@
 
 //! The hardware layer, and the map of it.
 //!
-//! Three backends, in two groups. [`native`] holds the radios sdrtop drives
-//! itself and has physically tested; [`soapy`] holds everything reachable
-//! through libSoapySDR, under the replacement rule described there. Neither
-//! group knows the other exists. [`discovery`] is the only module that sees
-//! both, because deciding what to offer when they find the same radio is a
-//! question neither can answer alone.
+//! [`native`] holds the radios sdrtop drives itself. [`soapy`] holds everything
+//! reachable through libSoapySDR. [`tinysa`] holds swept spectrum analyzers.
+//! [`discovery`] is the only module that sees all three groups.
 //!
 //! The rest is shared and backend-neutral: [`traits`] is the vocabulary,
 //! [`process`] the per-sample decode all three feed, [`gain`] the placement
@@ -26,6 +23,7 @@ pub mod native;
 pub mod process;
 pub mod soapy;
 pub mod sysfs;
+pub mod tinysa;
 mod traits;
 
 pub use discovery::{list_all_devices, open_device, DeviceKind, DeviceListing};

--- a/src/hardware/native/hackrf/mod.rs
+++ b/src/hardware/native/hackrf/mod.rs
@@ -295,6 +295,7 @@ pub fn list() -> Vec<DeviceListing> {
                     args: None,
                     serial: Some(serial.clone()),
                     path: None,
+                    tiny_sa_input: None,
                 });
             }
         }

--- a/src/hardware/native/hackrf/mod.rs
+++ b/src/hardware/native/hackrf/mod.rs
@@ -294,6 +294,7 @@ pub fn list() -> Vec<DeviceListing> {
                     label: format!("HackRF One · {}", serial),
                     args: None,
                     serial: Some(serial.clone()),
+                    path: None,
                 });
             }
         }
@@ -337,6 +338,7 @@ pub fn caps() -> DeviceCapabilities {
         level_max_db: 0.0,
         trace_stale_ms: crate::hardware::IQ_TRACE_STALE_MS,
         acquisition: crate::hardware::AcquisitionKind::IqSamples,
+        sample_rate_is_span: false,
         freq_min_hz: 1_000_000,
         freq_max_hz: 6_000_000_000,
         sample_rate_min_hz: 2_000_000.0,

--- a/src/hardware/native/rtlsdr/mod.rs
+++ b/src/hardware/native/rtlsdr/mod.rs
@@ -307,6 +307,7 @@ pub fn list() -> Vec<DeviceListing> {
             args: None,
             serial: device_serial(i),
             path: None,
+            tiny_sa_input: None,
         });
     }
     out

--- a/src/hardware/native/rtlsdr/mod.rs
+++ b/src/hardware/native/rtlsdr/mod.rs
@@ -306,6 +306,7 @@ pub fn list() -> Vec<DeviceListing> {
             label: format!("RTL-SDR · {} · {}", name, shown),
             args: None,
             serial: device_serial(i),
+            path: None,
         });
     }
     out
@@ -369,6 +370,7 @@ fn rtl_caps(tuner: c_int, gains_tenths: &[i32]) -> DeviceCapabilities {
         level_max_db: 0.0,
         trace_stale_ms: crate::hardware::IQ_TRACE_STALE_MS,
         acquisition: crate::hardware::AcquisitionKind::IqSamples,
+        sample_rate_is_span: false,
         freq_min_hz,
         freq_max_hz,
         // RTL-SDR's usable upper band is 900_001..=3_200_000 Hz (the lower

--- a/src/hardware/soapy/caps.rs
+++ b/src/hardware/soapy/caps.rs
@@ -168,6 +168,7 @@ pub fn capabilities(a: &DriverAnswers) -> Result<Built, Unsupported> {
         level_max_db: 0.0,
         trace_stale_ms: crate::hardware::IQ_TRACE_STALE_MS,
         acquisition: crate::hardware::AcquisitionKind::IqSamples,
+        sample_rate_is_span: false,
         freq_min_hz: freq_min.max(0.0) as u64,
         freq_max_hz: freq_max.max(0.0) as u64,
         sample_rate_min_hz: rate_min,

--- a/src/hardware/soapy/device.rs
+++ b/src/hardware/soapy/device.rs
@@ -320,6 +320,7 @@ pub fn list() -> Vec<DeviceListing> {
             label: args::label(&kwargs, i),
             serial: args::get(&kwargs, "serial").map(str::to_string),
             args: Some(args::open_markup(&kwargs, i)),
+            path: None,
         })
         .collect()
 }

--- a/src/hardware/soapy/device.rs
+++ b/src/hardware/soapy/device.rs
@@ -321,6 +321,7 @@ pub fn list() -> Vec<DeviceListing> {
             serial: args::get(&kwargs, "serial").map(str::to_string),
             args: Some(args::open_markup(&kwargs, i)),
             path: None,
+            tiny_sa_input: None,
         })
         .collect()
 }

--- a/src/hardware/tinysa/discovery.rs
+++ b/src/hardware/tinysa/discovery.rs
@@ -45,6 +45,7 @@ fn list_at(tty_root: &Path, dev_root: &Path) -> Vec<DeviceListing> {
             serial: None,
             args: None,
             path: Some(path),
+            tiny_sa_input: None,
         })
         .collect()
 }

--- a/src/hardware/tinysa/discovery.rs
+++ b/src/hardware/tinysa/discovery.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::hardware::{DeviceKind, DeviceListing};
+
+pub(super) fn list() -> Vec<DeviceListing> {
+    list_at(Path::new("/sys/class/tty"), Path::new("/dev"))
+}
+
+fn list_at(tty_root: &Path, dev_root: &Path) -> Vec<DeviceListing> {
+    let Ok(entries) = fs::read_dir(tty_root) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("ttyACM") {
+            continue;
+        }
+        let Ok(mut ancestor) = fs::canonicalize(entry.path()) else {
+            continue;
+        };
+        loop {
+            if let Some(product) = matching_product(&ancestor) {
+                found.push((dev_root.join(name.as_ref()), product));
+                break;
+            }
+            if !ancestor.pop() {
+                break;
+            }
+        }
+    }
+    found.sort_by(|left, right| left.0.cmp(&right.0));
+    found
+        .into_iter()
+        .enumerate()
+        .map(|(index, (path, product))| DeviceListing {
+            kind: DeviceKind::TinySa,
+            index,
+            label: format!("{product} · {}", path.display()),
+            serial: None,
+            args: None,
+            path: Some(path),
+        })
+        .collect()
+}
+
+fn matching_product(path: &Path) -> Option<String> {
+    let vendor = read(path.join("idVendor"))?;
+    let product_id = read(path.join("idProduct"))?;
+    if !vendor.eq_ignore_ascii_case("0483") || !product_id.eq_ignore_ascii_case("5740") {
+        return None;
+    }
+    let manufacturer = read(path.join("manufacturer")).unwrap_or_default();
+    let product = read(path.join("product")).unwrap_or_default();
+    let known_manufacturer = manufacturer.eq_ignore_ascii_case("tinysa.org");
+    let known_product =
+        product.eq_ignore_ascii_case("tinysa") || product.eq_ignore_ascii_case("tinysa4");
+    if !known_manufacturer && !known_product {
+        return None;
+    }
+    Some(if product.is_empty() {
+        "tinySA".to_string()
+    } else {
+        product
+    })
+}
+
+fn read(path: PathBuf) -> Option<String> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|value| value.trim().to_string())
+}

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -459,20 +459,19 @@ impl Worker {
     }
 
     fn select_path(&mut self, path: RfPath) -> anyhow::Result<()> {
+        if self.identity.model.is_ultra() {
+            return Ok(());
+        }
         if self.active_path == Some(path) {
             return Ok(());
         }
-        let command = match (self.identity.model.is_ultra(), path) {
-            (false, RfPath::Lower) => "mode low input",
-            (false, RfPath::Upper) => "mode high input",
-            (true, RfPath::Lower) => "ultra off",
-            (true, RfPath::Upper) => "ultra on",
+        let command = match path {
+            RfPath::Lower => "mode low input",
+            RfPath::Upper => "mode high input",
         };
         send_text_command(&mut *self.port, command)?;
-        if !self.identity.model.is_ultra() {
-            send_text_command(&mut *self.port, "abort on")?;
-            apply_scan_settings(&mut *self.port, self.identity.model)?;
-        }
+        send_text_command(&mut *self.port, "abort on")?;
+        apply_scan_settings(&mut *self.port, self.identity.model)?;
         self.active_path = Some(path);
         Ok(())
     }
@@ -914,6 +913,14 @@ fn normalize_span(hz: f64, maximum_hz: u64, points: u32) -> anyhow::Result<u64> 
 }
 
 fn scan_segments(model: Model, start_hz: u64, stop_hz: u64, points: u32) -> Vec<Segment> {
+    if model.is_ultra() {
+        return vec![Segment {
+            start_hz,
+            stop_hz,
+            points,
+            path: RfPath::Lower,
+        }];
+    }
     let boundary = model.path_boundary_hz();
     if start_hz < boundary && boundary < stop_hz && points >= 2 {
         let total_span = stop_hz - start_hz;
@@ -953,7 +960,11 @@ fn startup_settings(model: Model) -> (ScanSettings, Vec<&'static str>) {
     } else {
         SpurMode::On
     };
-    let mut commands = vec!["rbw auto", "attenuate auto"];
+    let mut commands = Vec::new();
+    if model.is_ultra() {
+        commands.extend(["ultra on", "ultra auto"]);
+    }
+    commands.extend(["rbw auto", "attenuate auto"]);
     if model.is_ultra() {
         commands.extend(["lna off", "lna2 auto", "agc auto", "spur auto"]);
     } else {
@@ -1121,7 +1132,7 @@ mod tests {
     }
 
     #[test]
-    fn crossing_scans_split_at_the_model_path_boundary() {
+    fn basic_crossing_scans_split_at_the_model_path_boundary() {
         assert_eq!(
             scan_segments(Model::Basic, 300_000_000, 400_000_000, 290),
             vec![
@@ -1139,25 +1150,30 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn ultra_scans_leave_path_selection_to_the_firmware() {
         assert_eq!(
-            scan_segments(Model::Zs405, 700_000_000, 900_000_000, 450)[0].stop_hz,
-            800_000_000
+            scan_segments(Model::Zs405, 700_000_000, 900_000_000, 450),
+            vec![Segment {
+                start_hz: 700_000_000,
+                stop_hz: 900_000_000,
+                points: 450,
+                path: RfPath::Lower,
+            }]
         );
         assert_eq!(
-            scan_segments(Model::Zs407, 800_000_000, 1_000_000_000, 450)[0].stop_hz,
-            900_000_000
+            scan_segments(Model::Zs407, 100_000, 7_300_000_000, 450).len(),
+            1
         );
     }
 
     #[test]
-    fn unsplit_scans_select_the_expected_path() {
+    fn basic_unsplit_scans_select_the_expected_path() {
         assert_eq!(
             scan_segments(Model::Basic, 100_000, 200_000_000, 64)[0].path,
             RfPath::Lower
-        );
-        assert_eq!(
-            scan_segments(Model::UltraUnknown, 1_000_000_000, 2_000_000_000, 64)[0].path,
-            RfPath::Upper
         );
     }
 
@@ -1169,6 +1185,8 @@ mod tests {
         assert_eq!(
             commands,
             [
+                "ultra on",
+                "ultra auto",
                 "rbw auto",
                 "attenuate auto",
                 "lna off",

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -287,8 +287,6 @@ impl Worker {
                     effective_center_hz,
                     effective_span_hz,
                 }) => {
-                    self.center_hz = effective_center_hz;
-                    self.span_hz = effective_span_hz;
                     if let Some(context) = &self.rx_context {
                         let published = context
                             .power_tx
@@ -369,20 +367,18 @@ impl Worker {
                 let _ = reply.send(Ok(()));
             }
             Command::SetSpan(hz, reply) => {
-                let result = if !hz.is_finite() || hz <= 0.0 {
-                    Err(anyhow!("tinySA span must be a positive finite value"))
-                } else {
-                    let maximum = self.identity.model.maximum_hz() - MIN_FREQUENCY_HZ;
-                    self.span_hz = (hz.round() as u64).clamp(1, maximum);
-                    Ok(RateSet::new(
+                let maximum = self.identity.model.maximum_hz() - MIN_FREQUENCY_HZ;
+                let result = normalize_span(hz, maximum, self.settings.points).map(|span_hz| {
+                    self.span_hz = span_hz;
+                    RateSet::new(
                         hz,
                         Some(self.span_hz as f64),
                         self.settings
                             .rbw_khz
                             .map(|khz| (khz * 1_000.0).round() as u32)
                             .unwrap_or(0),
-                    ))
-                };
+                    )
+                });
                 let _ = reply.send(result);
             }
             Command::NoOp(reply) => {
@@ -416,6 +412,11 @@ impl Worker {
             self.identity.model.maximum_hz(),
         );
         let points = self.settings.points;
+        self.center_hz = window_center(start_hz, stop_hz);
+        self.span_hz = stop_hz - start_hz;
+        if self.span_hz < points as u64 {
+            bail!("tinySA scan span is too narrow for {points} points");
+        }
         let mut frequencies_hz = Vec::with_capacity(points as usize);
         let mut levels_dbm = Vec::with_capacity(points as usize);
         for segment in scan_segments(self.identity.model, start_hz, stop_hz, points) {
@@ -443,11 +444,14 @@ impl Worker {
                 interrupted => return Ok(interrupted),
             }
         }
+        if frequencies_hz.windows(2).any(|pair| pair[1] <= pair[0]) {
+            bail!("tinySA scan returned duplicate or descending frequencies");
+        }
         Ok(ScanResult::Complete {
-            frequencies_hz: uniform_display_frequencies(&frequencies_hz)?,
+            frequencies_hz,
             levels_dbm,
-            effective_center_hz: start_hz + (stop_hz - start_hz) / 2,
-            effective_span_hz: stop_hz - start_hz,
+            effective_center_hz: self.center_hz,
+            effective_span_hz: self.span_hz,
         })
     }
 
@@ -676,7 +680,7 @@ fn scan_segment(
             segment.points,
         ),
         levels_dbm,
-        effective_center_hz: segment.start_hz + (segment.stop_hz - segment.start_hz) / 2,
+        effective_center_hz: window_center(segment.start_hz, segment.stop_hz),
         effective_span_hz: segment.stop_hz - segment.start_hz,
     })
 }
@@ -806,7 +810,7 @@ fn capabilities(model: Model) -> DeviceCapabilities {
         trace_stale_ms: 5_000,
         freq_min_hz: MIN_FREQUENCY_HZ,
         freq_max_hz: model.maximum_hz(),
-        sample_rate_min_hz: 1.0,
+        sample_rate_min_hz: DEFAULT_POINTS as f64,
         sample_rate_max_hz: (model.maximum_hz() - MIN_FREQUENCY_HZ) as f64,
         default_frequency_hz: DEFAULT_FREQUENCY_HZ,
         default_sample_rate_hz: DEFAULT_SPAN_HZ as f64,
@@ -838,27 +842,15 @@ fn centered_window(center_hz: u64, span_hz: u64, minimum_hz: u64, maximum_hz: u6
     (start_hz, stop_hz)
 }
 
-fn uniform_display_frequencies(measured_hz: &[u64]) -> anyhow::Result<Vec<u64>> {
-    let first = *measured_hz
-        .first()
-        .context("tinySA scan returned no frequencies")?;
-    let last = *measured_hz
-        .last()
-        .context("tinySA scan returned no frequencies")?;
-    let intervals = measured_hz.len().saturating_sub(1) as u64;
-    if intervals == 0 {
-        bail!("tinySA scan returned only one frequency");
+fn window_center(start_hz: u64, stop_hz: u64) -> u64 {
+    start_hz + (stop_hz - start_hz) / 2
+}
+
+fn normalize_span(hz: f64, maximum_hz: u64, points: u32) -> anyhow::Result<u64> {
+    if !hz.is_finite() || hz <= 0.0 {
+        bail!("tinySA span must be a positive finite value");
     }
-    let step = last.saturating_sub(first) / intervals;
-    if step == 0 {
-        bail!(
-            "tinySA scan span is too narrow for {} points",
-            measured_hz.len()
-        );
-    }
-    Ok((0..measured_hz.len())
-        .map(|index| first + step * index as u64)
-        .collect())
+    Ok((hz.round() as u64).clamp(points as u64, maximum_hz))
 }
 
 fn scan_segments(model: Model, start_hz: u64, stop_hz: u64, points: u32) -> Vec<Segment> {
@@ -1022,27 +1014,34 @@ mod tests {
     }
 
     #[test]
-    fn float_rounded_firmware_frequencies_get_a_uniform_display_grid() {
+    fn float_rounded_firmware_frequencies_keep_the_measured_edges() {
         let measured = protocol::scan_frequencies(100_000_000, 200_000_000, 450);
         assert!(measured
             .windows(2)
             .any(|pair| pair[1] - pair[0] != measured[1] - measured[0]));
-        let display = uniform_display_frequencies(&measured).unwrap();
-        let step = display[1] - display[0];
-        assert!(display.windows(2).all(|pair| pair[1] - pair[0] == step));
-        assert_eq!(display[0], measured[0]);
-        assert!(display.last().unwrap().abs_diff(*measured.last().unwrap()) < 450);
+        let first = measured[0];
+        let last = *measured.last().unwrap();
+        assert_eq!(
+            crate::signal::power::trace_window(&measured),
+            Some((window_center(first, last), (last - first) as f64))
+        );
     }
 
     #[test]
-    fn a_span_too_narrow_for_the_point_count_is_rejected() {
-        assert!(uniform_display_frequencies(&[100_000, 100_000, 100_000]).is_err());
+    fn a_span_too_narrow_for_the_point_count_is_clamped() {
+        assert_eq!(
+            normalize_span(1.0, 959_900_000, DEFAULT_POINTS).unwrap(),
+            DEFAULT_POINTS as u64
+        );
+        let frequencies =
+            protocol::scan_frequencies(100_000, 100_000 + DEFAULT_POINTS as u64, DEFAULT_POINTS);
+        assert!(frequencies.windows(2).all(|pair| pair[1] > pair[0]));
     }
 
     #[test]
     fn an_edge_shift_becomes_the_next_scan_center() {
         let (start, stop) = centered_window(100_000, 10_000_000, 100_000, 960_000_000);
-        let effective_center = start + (stop - start) / 2;
+        let effective_center = window_center(start, stop);
         assert_eq!(effective_center, 5_100_000);
         assert_eq!(
             centered_window(effective_center, 1_000_000, 100_000, 960_000_000),

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -4,7 +4,7 @@
 mod discovery;
 mod protocol;
 
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -232,6 +232,12 @@ enum ByteEvent {
     Command(Command),
 }
 
+#[derive(Clone, Copy)]
+enum ScanDrain {
+    Records(u32),
+    FrameClosed,
+}
+
 fn worker_entry(
     mut port: Box<dyn SerialPort>,
     command_rx: Receiver<Command>,
@@ -314,22 +320,19 @@ impl Worker {
                 }
                 Ok(ScanResult::Interrupted(command, abort_result)) => {
                     if let Err(error) = abort_result {
-                        let shutting_down = matches!(&command, Command::Shutdown(_));
                         let message = error.to_string();
                         self.stop_acquisition(&message);
                         reject_command(command, anyhow!(message));
-                        if shutting_down {
-                            return;
-                        }
-                        continue;
+                        return;
                     }
                     if !self.handle_command(command) || !self.drain_commands() {
                         return;
                     }
                 }
                 Err(error) => {
-                    let _ = abort_active_scan(&mut *self.port);
+                    best_effort_abort(&mut *self.port);
                     self.stop_acquisition(&error.to_string());
+                    return;
                 }
             }
         }
@@ -618,16 +621,11 @@ fn scan_segment(
     expected.extend_from_slice(b"\r\n{");
     let mut frame = Vec::with_capacity(2 + segment.points as usize * 3);
     for (index, expected_byte) in expected.into_iter().enumerate() {
-        match next_scan_byte(port, command_rx, inactivity_timeout)? {
-            ByteEvent::Byte(byte) if byte == expected_byte => {}
-            ByteEvent::Byte(byte) => {
-                bail!(
-                    "tinySA scan prelude byte {index} was 0x{byte:02x}, expected 0x{expected_byte:02x}"
-                )
-            }
-            ByteEvent::Command(command) => {
-                return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
-            }
+        let byte = next_port_byte(port, inactivity_timeout)?;
+        if byte != expected_byte {
+            bail!(
+                "tinySA scan prelude byte {index} was 0x{byte:02x}, expected 0x{expected_byte:02x}"
+            );
         }
     }
     frame.push(b'{');
@@ -635,7 +633,14 @@ fn scan_segment(
         let tag = match next_scan_byte(port, command_rx, inactivity_timeout)? {
             ByteEvent::Byte(byte) => byte,
             ByteEvent::Command(command) => {
-                return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
+                return Ok(ScanResult::Interrupted(
+                    command,
+                    abort_active_scan(
+                        port,
+                        ScanDrain::Records(segment.points - index),
+                        inactivity_timeout,
+                    ),
+                ))
             }
         };
         if tag == b'}' {
@@ -649,28 +654,32 @@ fn scan_segment(
         }
         frame.push(tag);
         for _ in 0..2 {
-            match next_scan_byte(port, command_rx, inactivity_timeout)? {
-                ByteEvent::Byte(byte) => frame.push(byte),
-                ByteEvent::Command(command) => {
-                    return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
-                }
-            }
+            frame.push(next_port_byte(port, inactivity_timeout)?);
         }
     }
     let close = match next_scan_byte(port, command_rx, inactivity_timeout)? {
         ByteEvent::Byte(byte) => byte,
         ByteEvent::Command(command) => {
-            return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
+            return Ok(ScanResult::Interrupted(
+                command,
+                abort_active_scan(port, ScanDrain::Records(0), inactivity_timeout),
+            ))
         }
     };
     frame.push(close);
     let levels_dbm = protocol::parse_scan_frame(&frame, segment.points, zero_dbm)?;
     for expected_byte in PROMPT {
-        match next_port_byte(port)? {
-            byte if byte == *expected_byte => {}
-            byte => bail!(
+        match next_scan_byte(port, command_rx, inactivity_timeout)? {
+            ByteEvent::Byte(byte) if byte == *expected_byte => {}
+            ByteEvent::Byte(byte) => bail!(
                 "tinySA emitted text after a scan frame: 0x{byte:02x} before the shell prompt"
             ),
+            ByteEvent::Command(command) => {
+                return Ok(ScanResult::Interrupted(
+                    command,
+                    abort_active_scan(port, ScanDrain::FrameClosed, inactivity_timeout),
+                ))
+            }
         }
     }
     Ok(ScanResult::Complete {
@@ -724,7 +733,7 @@ fn poll_scan_command(command_rx: &Receiver<Command>) -> anyhow::Result<Option<Co
     }
 }
 
-fn next_port_byte(port: &mut dyn SerialPort) -> anyhow::Result<u8> {
+fn next_port_byte(port: &mut dyn SerialPort, inactivity_timeout: Duration) -> anyhow::Result<u8> {
     let last_byte = Instant::now();
     loop {
         let mut byte = [0u8; 1];
@@ -733,7 +742,7 @@ fn next_port_byte(port: &mut dyn SerialPort) -> anyhow::Result<u8> {
             Ok(0) => bail!("tinySA disconnected during a scan"),
             Ok(_) => unreachable!(),
             Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
-                if last_byte.elapsed() >= RESPONSE_TIMEOUT {
+                if last_byte.elapsed() >= inactivity_timeout {
                     bail!("tinySA scan timed out");
                 }
             }
@@ -743,40 +752,91 @@ fn next_port_byte(port: &mut dyn SerialPort) -> anyhow::Result<u8> {
     }
 }
 
-fn abort_active_scan(port: &mut dyn SerialPort) -> anyhow::Result<()> {
+fn abort_active_scan<P>(
+    port: &mut P,
+    progress: ScanDrain,
+    inactivity_timeout: Duration,
+) -> anyhow::Result<()>
+where
+    P: Read + Write + ?Sized,
+{
+    const ABORT_REPLY: &[u8] = b"abort\r\nch> ";
+
     port.write_all(b"abort\r")
         .context("failed to send tinySA scan abort")?;
     port.flush().context("failed to flush tinySA scan abort")?;
-    let started = Instant::now();
+    let mut records = match progress {
+        ScanDrain::Records(records) => Some(records),
+        ScanDrain::FrameClosed => None,
+    };
+    let mut abort_reply_at = 0;
+    let mut bytes_read = 0usize;
     let mut last_byte = Instant::now();
-    let mut response = Vec::new();
+
+    while records.is_some() || abort_reply_at < ABORT_REPLY.len() {
+        let byte = read_abort_byte(port, inactivity_timeout, &mut last_byte, &mut bytes_read)?;
+        if let Some(remaining) = records {
+            match byte {
+                b'x' if remaining > 0 => {
+                    read_abort_byte(port, inactivity_timeout, &mut last_byte, &mut bytes_read)?;
+                    read_abort_byte(port, inactivity_timeout, &mut last_byte, &mut bytes_read)?;
+                    records = Some(remaining - 1);
+                }
+                b'}' => records = None,
+                b'a' => {
+                    for expected in &ABORT_REPLY[1..] {
+                        let byte = read_abort_byte(
+                            port,
+                            inactivity_timeout,
+                            &mut last_byte,
+                            &mut bytes_read,
+                        )?;
+                        if byte != *expected {
+                            bail!("tinySA abort acknowledgement was malformed");
+                        }
+                    }
+                    abort_reply_at = ABORT_REPLY.len();
+                }
+                _ => bail!("tinySA aborted scan frame was malformed"),
+            }
+        } else if byte == ABORT_REPLY[abort_reply_at] {
+            abort_reply_at += 1;
+        } else {
+            abort_reply_at = usize::from(byte == ABORT_REPLY[0]);
+        }
+    }
+    Ok(())
+}
+
+fn read_abort_byte<P>(
+    port: &mut P,
+    inactivity_timeout: Duration,
+    last_byte: &mut Instant,
+    bytes_read: &mut usize,
+) -> anyhow::Result<u8>
+where
+    P: Read + ?Sized,
+{
     loop {
-        let mut buffer = [0u8; 64];
-        match port.read(&mut buffer) {
-            Ok(count) if count > 0 => {
-                response.extend_from_slice(&buffer[..count]);
-                last_byte = Instant::now();
-                if response.len() > MAX_RESPONSE_BYTES {
+        let mut byte = [0u8; 1];
+        match port.read(&mut byte) {
+            Ok(1) => {
+                *last_byte = Instant::now();
+                *bytes_read += 1;
+                if *bytes_read > MAX_RESPONSE_BYTES {
                     bail!("tinySA abort drain exceeded {MAX_RESPONSE_BYTES} bytes");
                 }
+                return Ok(byte[0]);
             }
-            Ok(_) => bail!("tinySA disconnected while aborting a scan"),
+            Ok(0) => bail!("tinySA disconnected while aborting a scan"),
+            Ok(_) => unreachable!(),
             Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
-                if last_byte.elapsed() >= DRAIN_QUIET {
-                    if !response
-                        .windows(PROMPT.len())
-                        .any(|window| window == PROMPT)
-                    {
-                        bail!("tinySA abort did not return a shell prompt");
-                    }
-                    return Ok(());
+                if last_byte.elapsed() >= inactivity_timeout {
+                    bail!("timed out draining the tinySA aborted scan");
                 }
             }
             Err(error) if error.kind() == ErrorKind::Interrupted => {}
             Err(error) => return Err(error).context("failed to drain tinySA aborted scan"),
-        }
-        if started.elapsed() >= RESPONSE_TIMEOUT {
-            bail!("timed out draining the tinySA aborted scan");
         }
     }
 }
@@ -938,7 +998,127 @@ fn scan_inactivity_timeout(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::io;
+
     use super::*;
+
+    enum ReadStep {
+        Bytes(VecDeque<u8>),
+        Delay(Duration),
+        FrameClose,
+    }
+
+    struct ScriptedPeer {
+        reads: VecDeque<ReadStep>,
+        writes: Vec<u8>,
+        frame_closed: bool,
+    }
+
+    impl ScriptedPeer {
+        fn new(steps: impl IntoIterator<Item = ReadStep>) -> Self {
+            Self {
+                reads: steps.into_iter().collect(),
+                writes: Vec::new(),
+                frame_closed: false,
+            }
+        }
+    }
+
+    impl Read for ScriptedPeer {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            loop {
+                match self.reads.front_mut() {
+                    Some(ReadStep::Bytes(bytes)) => {
+                        let Some(byte) = bytes.pop_front() else {
+                            self.reads.pop_front();
+                            continue;
+                        };
+                        buffer[0] = byte;
+                        return Ok(1);
+                    }
+                    Some(ReadStep::Delay(duration)) => {
+                        let duration = *duration;
+                        self.reads.pop_front();
+                        std::thread::sleep(duration);
+                        return Err(io::Error::new(ErrorKind::TimedOut, "scripted delay"));
+                    }
+                    Some(ReadStep::FrameClose) => {
+                        self.reads.pop_front();
+                        self.frame_closed = true;
+                        buffer[0] = b'}';
+                        return Ok(1);
+                    }
+                    None => return Err(io::Error::new(ErrorKind::TimedOut, "script exhausted")),
+                }
+            }
+        }
+    }
+
+    impl Write for ScriptedPeer {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            if buffer == b"next\r" {
+                assert!(
+                    self.frame_closed,
+                    "next request preceded the old frame close"
+                );
+            }
+            self.writes.extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn bytes(value: &[u8]) -> ReadStep {
+        ReadStep::Bytes(value.iter().copied().collect())
+    }
+
+    #[test]
+    fn cancellation_waits_for_the_delayed_frame_close_before_the_next_request() {
+        let mut peer = ScriptedPeer::new([
+            bytes(b"x}xxch"),
+            bytes(b"abort\r\nch> "),
+            ReadStep::Delay(Duration::from_millis(225)),
+            ReadStep::FrameClose,
+        ]);
+        let started = Instant::now();
+
+        abort_active_scan(&mut peer, ScanDrain::Records(2), Duration::from_secs(1)).unwrap();
+        peer.write_all(b"next\r").unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(200));
+        assert_eq!(peer.writes, b"abort\rnext\r");
+    }
+
+    #[test]
+    fn cancellation_after_the_frame_waits_only_for_the_abort_reply() {
+        let mut peer = ScriptedPeer::new([
+            bytes(PROMPT),
+            ReadStep::Delay(Duration::from_millis(225)),
+            bytes(b"abort\r\nch> "),
+        ]);
+        let started = Instant::now();
+
+        abort_active_scan(&mut peer, ScanDrain::FrameClosed, Duration::from_secs(1)).unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(200));
+        assert_eq!(peer.writes, b"abort\r");
+    }
+
+    #[test]
+    fn cancellation_times_out_when_the_active_frame_never_closes() {
+        let mut peer = ScriptedPeer::new([bytes(b"abort\r\nch> ")]);
+
+        assert!(
+            abort_active_scan(&mut peer, ScanDrain::Records(1), Duration::from_millis(10),)
+                .unwrap_err()
+                .to_string()
+                .contains("timed out")
+        );
+    }
 
     #[test]
     fn crossing_scans_split_at_the_model_path_boundary() {

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -1277,6 +1277,7 @@ mod tests {
     #[test]
     fn display_grid_rejects_duplicate_firmware_frequencies() {
         assert!(display_frequencies(&[100_000, 100_000, 100_001]).is_err());
+        assert!(display_frequencies(&[100_002, 100_001, 100_000]).is_err());
     }
 
     #[test]

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -287,6 +287,8 @@ impl Worker {
                     effective_center_hz,
                     effective_span_hz,
                 }) => {
+                    self.center_hz = effective_center_hz;
+                    self.span_hz = effective_span_hz;
                     if let Some(context) = &self.rx_context {
                         let published = context
                             .power_tx
@@ -442,7 +444,7 @@ impl Worker {
             }
         }
         Ok(ScanResult::Complete {
-            frequencies_hz,
+            frequencies_hz: uniform_display_frequencies(&frequencies_hz)?,
             levels_dbm,
             effective_center_hz: start_hz + (stop_hz - start_hz) / 2,
             effective_span_hz: stop_hz - start_hz,
@@ -828,11 +830,35 @@ fn centered_window(center_hz: u64, span_hz: u64, minimum_hz: u64, maximum_hz: u6
         start_hz = minimum_hz;
         stop_hz = minimum_hz + span_hz;
     }
+
     if stop_hz > maximum_hz {
         stop_hz = maximum_hz;
         start_hz = maximum_hz - span_hz;
     }
     (start_hz, stop_hz)
+}
+
+fn uniform_display_frequencies(measured_hz: &[u64]) -> anyhow::Result<Vec<u64>> {
+    let first = *measured_hz
+        .first()
+        .context("tinySA scan returned no frequencies")?;
+    let last = *measured_hz
+        .last()
+        .context("tinySA scan returned no frequencies")?;
+    let intervals = measured_hz.len().saturating_sub(1) as u64;
+    if intervals == 0 {
+        bail!("tinySA scan returned only one frequency");
+    }
+    let step = last.saturating_sub(first) / intervals;
+    if step == 0 {
+        bail!(
+            "tinySA scan span is too narrow for {} points",
+            measured_hz.len()
+        );
+    }
+    Ok((0..measured_hz.len())
+        .map(|index| first + step * index as u64)
+        .collect())
 }
 
 fn scan_segments(model: Model, start_hz: u64, stop_hz: u64, points: u32) -> Vec<Segment> {
@@ -992,6 +1018,35 @@ mod tests {
         assert_eq!(
             centered_window(960_000_000, 10_000_000, 100_000, 960_000_000),
             (950_000_000, 960_000_000)
+        );
+    }
+
+    #[test]
+    fn float_rounded_firmware_frequencies_get_a_uniform_display_grid() {
+        let measured = protocol::scan_frequencies(100_000_000, 200_000_000, 450);
+        assert!(measured
+            .windows(2)
+            .any(|pair| pair[1] - pair[0] != measured[1] - measured[0]));
+        let display = uniform_display_frequencies(&measured).unwrap();
+        let step = display[1] - display[0];
+        assert!(display.windows(2).all(|pair| pair[1] - pair[0] == step));
+        assert_eq!(display[0], measured[0]);
+        assert!(display.last().unwrap().abs_diff(*measured.last().unwrap()) < 450);
+    }
+
+    #[test]
+    fn a_span_too_narrow_for_the_point_count_is_rejected() {
+        assert!(uniform_display_frequencies(&[100_000, 100_000, 100_000]).is_err());
+    }
+
+    #[test]
+    fn an_edge_shift_becomes_the_next_scan_center() {
+        let (start, stop) = centered_window(100_000, 10_000_000, 100_000, 960_000_000);
+        let effective_center = start + (stop - start) / 2;
+        assert_eq!(effective_center, 5_100_000);
+        assert_eq!(
+            centered_window(effective_center, 1_000_000, 100_000, 960_000_000),
+            (4_600_000, 5_600_000)
         );
     }
 

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -1,0 +1,1073 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+mod discovery;
+mod protocol;
+
+use std::io::ErrorKind;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context};
+use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
+use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
+
+use crate::hardware::{
+    AcquisitionKind, DeliveryModel, DeviceCapabilities, DeviceInfo, DeviceListing, GainModel,
+    LevelUnit, PowerTrace, RxContext, SampleFormat, SampleGeometry, SdrDevice, SoftwareStack,
+};
+
+use super::traits::RateSet;
+use protocol::{Identity, Model, PROMPT};
+
+const MIN_FREQUENCY_HZ: u64 = 100_000;
+const DEFAULT_FREQUENCY_HZ: u64 = 100_000_000;
+const DEFAULT_SPAN_HZ: u64 = 10_000_000;
+const DEFAULT_POINTS: u32 = 450;
+const READ_TIMEOUT: Duration = Duration::from_millis(50);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+const DRAIN_QUIET: Duration = Duration::from_millis(200);
+const MAX_RESPONSE_BYTES: usize = 128 * 1024;
+
+type UnitReply = Sender<anyhow::Result<()>>;
+
+#[derive(Clone, Copy)]
+struct ScanSettings {
+    points: u32,
+    rbw_khz: Option<f64>,
+    spur: SpurMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpurMode {
+    On,
+    Auto,
+}
+
+pub fn list() -> Vec<DeviceListing> {
+    discovery::list()
+}
+
+pub struct TinySaDevice {
+    caps: DeviceCapabilities,
+    info: DeviceInfo,
+    notes: Vec<String>,
+    command_tx: Sender<Command>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl TinySaDevice {
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        let port = serialport::new(path.to_string_lossy(), 115_200)
+            .data_bits(DataBits::Eight)
+            .stop_bits(StopBits::One)
+            .parity(Parity::None)
+            .flow_control(FlowControl::None)
+            .timeout(READ_TIMEOUT)
+            .open()
+            .with_context(|| format!("failed to open tinySA at {}", path.display()))?;
+        let (command_tx, command_rx) = crossbeam_channel::unbounded();
+        let (init_tx, init_rx) = bounded(1);
+        let worker = thread::Builder::new()
+            .name("tinysa-serial".to_string())
+            .spawn(move || worker_entry(port, command_rx, init_tx))
+            .context("failed to start tinySA serial worker")?;
+        let initialized = match init_rx.recv() {
+            Ok(Ok(initialized)) => initialized,
+            Ok(Err(error)) => {
+                let _ = worker.join();
+                return Err(error);
+            }
+            Err(_) => {
+                let _ = worker.join();
+                bail!("tinySA serial worker stopped during initialization");
+            }
+        };
+        let caps = capabilities(initialized.identity.model);
+        let notes = initialized
+            .identity
+            .hardware
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let info = DeviceInfo {
+            board_name: initialized.identity.board.clone(),
+            serial: path.display().to_string(),
+            stack: Some(SoftwareStack {
+                label: "tinysa fw ",
+                value: Arc::from(initialized.identity.firmware.as_str()),
+            }),
+            ..DeviceInfo::default()
+        };
+        Ok(Self {
+            caps,
+            info,
+            notes,
+            command_tx,
+            worker: Mutex::new(Some(worker)),
+        })
+    }
+
+    fn request<T>(
+        &self,
+        make_command: impl FnOnce(Sender<anyhow::Result<T>>) -> Command,
+    ) -> anyhow::Result<T> {
+        let (reply_tx, reply_rx) = bounded(1);
+        self.command_tx
+            .send(make_command(reply_tx))
+            .map_err(|_| anyhow!("tinySA serial worker is not running"))?;
+        reply_rx
+            .recv()
+            .map_err(|_| anyhow!("tinySA serial worker stopped without replying"))?
+    }
+}
+
+impl SdrDevice for TinySaDevice {
+    fn capabilities(&self) -> &DeviceCapabilities {
+        &self.caps
+    }
+
+    fn info(&self) -> DeviceInfo {
+        self.info.clone()
+    }
+
+    fn start_rx(&self, ctx: Arc<RxContext>) -> anyhow::Result<()> {
+        self.request(|reply| Command::Start(ctx, reply))
+    }
+
+    fn stop_rx(&self) -> anyhow::Result<()> {
+        self.request(Command::Stop)
+    }
+
+    fn is_streaming(&self) -> bool {
+        self.request(Command::IsStreaming).unwrap_or(false)
+    }
+
+    fn set_frequency(&self, hz: u64) -> anyhow::Result<()> {
+        self.request(|reply| Command::SetFrequency(hz, reply))
+    }
+
+    fn set_sample_rate(&self, hz: f64) -> anyhow::Result<RateSet> {
+        self.request(|reply| Command::SetSpan(hz, reply))
+    }
+
+    fn set_lna_gain(&self, _db: u32) -> anyhow::Result<()> {
+        self.request(Command::NoOp)
+    }
+
+    fn open_notes(&self) -> &[String] {
+        &self.notes
+    }
+}
+
+impl Drop for TinySaDevice {
+    fn drop(&mut self) {
+        let (reply_tx, reply_rx) = bounded(1);
+        let _ = self.command_tx.send(Command::Shutdown(reply_tx));
+        let _ = reply_rx.recv_timeout(Duration::from_secs(2));
+        if let Some(worker) = self
+            .worker
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take()
+        {
+            let _ = worker.join();
+        }
+    }
+}
+
+enum Command {
+    Start(Arc<RxContext>, UnitReply),
+    Stop(UnitReply),
+    IsStreaming(Sender<anyhow::Result<bool>>),
+    SetFrequency(u64, UnitReply),
+    SetSpan(f64, Sender<anyhow::Result<RateSet>>),
+    NoOp(UnitReply),
+    Shutdown(UnitReply),
+}
+
+struct Initialized {
+    identity: Identity,
+}
+
+struct Worker {
+    port: Box<dyn SerialPort>,
+    command_rx: Receiver<Command>,
+    identity: Identity,
+    settings: ScanSettings,
+    center_hz: u64,
+    span_hz: u64,
+    rx_context: Option<Arc<RxContext>>,
+    active_path: Option<RfPath>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RfPath {
+    Lower,
+    Upper,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Segment {
+    start_hz: u64,
+    stop_hz: u64,
+    points: u32,
+    path: RfPath,
+}
+
+enum ScanResult {
+    Complete {
+        frequencies_hz: Vec<u64>,
+        levels_dbm: Vec<f32>,
+        effective_center_hz: u64,
+        effective_span_hz: u64,
+    },
+    Interrupted(Command, anyhow::Result<()>),
+}
+
+enum ByteEvent {
+    Byte(u8),
+    Command(Command),
+}
+
+fn worker_entry(
+    mut port: Box<dyn SerialPort>,
+    command_rx: Receiver<Command>,
+    init_tx: Sender<anyhow::Result<Initialized>>,
+) {
+    let (identity, settings) = match initialize(&mut *port) {
+        Ok(value) => value,
+        Err(error) => {
+            let _ = init_tx.send(Err(error));
+            return;
+        }
+    };
+    if init_tx
+        .send(Ok(Initialized {
+            identity: identity.clone(),
+        }))
+        .is_err()
+    {
+        return;
+    }
+    Worker {
+        port,
+        command_rx,
+        identity,
+        settings,
+        center_hz: DEFAULT_FREQUENCY_HZ,
+        span_hz: DEFAULT_SPAN_HZ,
+        rx_context: None,
+        active_path: None,
+    }
+    .run();
+}
+
+impl Worker {
+    fn run(mut self) {
+        loop {
+            if self.rx_context.is_none() {
+                match self.command_rx.recv() {
+                    Ok(command) => {
+                        if self.handle_command(command) {
+                            continue;
+                        }
+                        return;
+                    }
+                    Err(_) => return,
+                }
+            }
+
+            match self.scan_once() {
+                Ok(ScanResult::Complete {
+                    frequencies_hz,
+                    levels_dbm,
+                    effective_center_hz,
+                    effective_span_hz,
+                }) => {
+                    if let Some(context) = &self.rx_context {
+                        let published = context
+                            .power_tx
+                            .try_send(PowerTrace {
+                                frequencies_hz,
+                                levels_dbm,
+                                rbw_hz: self
+                                    .settings
+                                    .rbw_khz
+                                    .map(|khz| (khz * 1_000.0).round() as u32),
+                            })
+                            .is_ok();
+                        if published {
+                            let mut metrics = context
+                                .metrics
+                                .lock()
+                                .unwrap_or_else(|error| error.into_inner());
+                            metrics.radio.frequency = effective_center_hz;
+                            metrics.radio.config_sample_rate = effective_span_hz as f64;
+                        }
+                    }
+                    if !self.drain_commands() {
+                        return;
+                    }
+                }
+                Ok(ScanResult::Interrupted(command, abort_result)) => {
+                    if let Err(error) = abort_result {
+                        let shutting_down = matches!(&command, Command::Shutdown(_));
+                        let message = error.to_string();
+                        self.stop_acquisition(&message);
+                        reject_command(command, anyhow!(message));
+                        if shutting_down {
+                            return;
+                        }
+                        continue;
+                    }
+                    if !self.handle_command(command) || !self.drain_commands() {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    let _ = abort_active_scan(&mut *self.port);
+                    self.stop_acquisition(&error.to_string());
+                }
+            }
+        }
+    }
+
+    fn drain_commands(&mut self) -> bool {
+        while let Ok(command) = self.command_rx.try_recv() {
+            if !self.handle_command(command) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn handle_command(&mut self, command: Command) -> bool {
+        match command {
+            Command::Start(context, reply) => {
+                let result = if self.rx_context.is_some() {
+                    Err(anyhow!("tinySA acquisition is already running"))
+                } else {
+                    self.rx_context = Some(context);
+                    Ok(())
+                };
+                let _ = reply.send(result);
+            }
+            Command::Stop(reply) => {
+                self.rx_context = None;
+                let _ = reply.send(Ok(()));
+            }
+            Command::IsStreaming(reply) => {
+                let _ = reply.send(Ok(self.rx_context.is_some()));
+            }
+            Command::SetFrequency(hz, reply) => {
+                self.center_hz = hz.clamp(MIN_FREQUENCY_HZ, self.identity.model.maximum_hz());
+                let _ = reply.send(Ok(()));
+            }
+            Command::SetSpan(hz, reply) => {
+                let result = if !hz.is_finite() || hz <= 0.0 {
+                    Err(anyhow!("tinySA span must be a positive finite value"))
+                } else {
+                    let maximum = self.identity.model.maximum_hz() - MIN_FREQUENCY_HZ;
+                    self.span_hz = (hz.round() as u64).clamp(1, maximum);
+                    Ok(RateSet::new(
+                        hz,
+                        Some(self.span_hz as f64),
+                        self.settings
+                            .rbw_khz
+                            .map(|khz| (khz * 1_000.0).round() as u32)
+                            .unwrap_or(0),
+                    ))
+                };
+                let _ = reply.send(result);
+            }
+            Command::NoOp(reply) => {
+                let _ = reply.send(Ok(()));
+            }
+            Command::Shutdown(reply) => {
+                self.rx_context = None;
+                let _ = reply.send(Ok(()));
+                return false;
+            }
+        }
+        true
+    }
+
+    fn stop_acquisition(&mut self, message: &str) {
+        if let Some(context) = self.rx_context.take() {
+            let mut metrics = context
+                .metrics
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            metrics.radio.hw_streaming = false;
+            metrics.push_log(format!("tinySA scan error: {message}"));
+        }
+    }
+
+    fn scan_once(&mut self) -> anyhow::Result<ScanResult> {
+        let (start_hz, stop_hz) = centered_window(
+            self.center_hz,
+            self.span_hz,
+            MIN_FREQUENCY_HZ,
+            self.identity.model.maximum_hz(),
+        );
+        let points = self.settings.points;
+        let mut frequencies_hz = Vec::with_capacity(points as usize);
+        let mut levels_dbm = Vec::with_capacity(points as usize);
+        for segment in scan_segments(self.identity.model, start_hz, stop_hz, points) {
+            if let Some(command) = poll_scan_command(&self.command_rx)? {
+                return Ok(ScanResult::Interrupted(command, Ok(())));
+            }
+            self.select_path(segment.path)?;
+            let inactivity_timeout =
+                scan_inactivity_timeout(segment, self.identity.model, self.settings)?;
+            match scan_segment(
+                &mut *self.port,
+                &self.command_rx,
+                segment,
+                self.identity.zero_dbm,
+                inactivity_timeout,
+            )? {
+                ScanResult::Complete {
+                    frequencies_hz: segment_frequencies,
+                    levels_dbm: segment_levels,
+                    ..
+                } => {
+                    frequencies_hz.extend(segment_frequencies);
+                    levels_dbm.extend(segment_levels);
+                }
+                interrupted => return Ok(interrupted),
+            }
+        }
+        Ok(ScanResult::Complete {
+            frequencies_hz,
+            levels_dbm,
+            effective_center_hz: start_hz + (stop_hz - start_hz) / 2,
+            effective_span_hz: stop_hz - start_hz,
+        })
+    }
+
+    fn select_path(&mut self, path: RfPath) -> anyhow::Result<()> {
+        if self.active_path == Some(path) {
+            return Ok(());
+        }
+        let command = match (self.identity.model.is_ultra(), path) {
+            (false, RfPath::Lower) => "mode low input",
+            (false, RfPath::Upper) => "mode high input",
+            (true, RfPath::Lower) => "ultra off",
+            (true, RfPath::Upper) => "ultra on",
+        };
+        send_text_command(&mut *self.port, command)?;
+        if !self.identity.model.is_ultra() {
+            send_text_command(&mut *self.port, "abort on")?;
+            apply_scan_settings(&mut *self.port, self.identity.model)?;
+        }
+        self.active_path = Some(path);
+        Ok(())
+    }
+}
+
+fn initialize(port: &mut dyn SerialPort) -> anyhow::Result<(Identity, ScanSettings)> {
+    best_effort_abort(port);
+    drain_startup(port)?;
+    let mut last_error = None;
+    let mut version = None;
+    for _ in 0..3 {
+        match send_text_command(port, "version") {
+            Ok(response)
+                if String::from_utf8_lossy(&response)
+                    .to_ascii_lowercase()
+                    .contains("tinysa") =>
+            {
+                version = Some(response);
+                break;
+            }
+            Ok(_) => last_error = Some(anyhow!("serial device did not identify as a tinySA")),
+            Err(error) => last_error = Some(error),
+        }
+        let _ = drain_startup(port);
+    }
+    let version = version
+        .ok_or_else(|| last_error.unwrap_or_else(|| anyhow!("tinySA version probe failed")))?;
+    send_text_command(port, "output off")?;
+    let info = send_text_command(port, "info")?;
+    let help = send_text_command(port, "help")?;
+    let zero = send_text_command(port, "zero")?;
+    let identity = protocol::parse_identity(&version, &info, &help, &zero)?;
+    send_text_command(port, "abort on")?;
+    send_text_command(port, input_mode_command(identity.model))?;
+    let (settings, _) = startup_settings(identity.model);
+    apply_scan_settings(port, identity.model)?;
+    Ok((identity, settings))
+}
+
+fn apply_scan_settings(port: &mut dyn SerialPort, model: Model) -> anyhow::Result<()> {
+    for command in startup_settings(model).1 {
+        send_text_command(port, command)?;
+    }
+    Ok(())
+}
+
+fn best_effort_abort(port: &mut dyn SerialPort) {
+    let _ = port.write_all(b"abort\r");
+    let _ = port.flush();
+}
+
+fn input_mode_command(model: Model) -> &'static str {
+    if model.is_ultra() {
+        "mode input"
+    } else {
+        "mode low input"
+    }
+}
+
+fn send_text_command(port: &mut dyn SerialPort, command: &str) -> anyhow::Result<Vec<u8>> {
+    port.write_all(command.as_bytes())
+        .with_context(|| format!("failed to write tinySA {command} command"))?;
+    port.write_all(b"\r")
+        .with_context(|| format!("failed to terminate tinySA {command} command"))?;
+    port.flush()
+        .with_context(|| format!("failed to flush tinySA {command} command"))?;
+    let frame = read_until_prompt(port, RESPONSE_TIMEOUT)?;
+    protocol::parse_text_frame(&frame, command)
+}
+
+fn read_until_prompt(
+    port: &mut dyn SerialPort,
+    inactivity_timeout: Duration,
+) -> anyhow::Result<Vec<u8>> {
+    let mut response = Vec::new();
+    let mut last_byte = Instant::now();
+    loop {
+        let mut byte = [0u8; 1];
+        match port.read(&mut byte) {
+            Ok(1) => {
+                response.push(byte[0]);
+                last_byte = Instant::now();
+                if response.ends_with(PROMPT) {
+                    return Ok(response);
+                }
+                if response.len() > MAX_RESPONSE_BYTES {
+                    bail!("tinySA response exceeded {MAX_RESPONSE_BYTES} bytes");
+                }
+            }
+            Ok(0) => bail!("tinySA disconnected while returning a response"),
+            Ok(_) => unreachable!(),
+            Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+                if last_byte.elapsed() >= inactivity_timeout {
+                    bail!("timed out waiting for the tinySA shell prompt");
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to read tinySA response"),
+        }
+    }
+}
+
+fn drain_startup(port: &mut dyn SerialPort) -> anyhow::Result<()> {
+    let started = Instant::now();
+    let mut last_byte = Instant::now();
+    let mut buffer = [0u8; 256];
+    loop {
+        match port.read(&mut buffer) {
+            Ok(count) if count > 0 => last_byte = Instant::now(),
+            Ok(_) => return Ok(()),
+            Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+                if last_byte.elapsed() >= DRAIN_QUIET {
+                    return Ok(());
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to drain tinySA startup output"),
+        }
+        if started.elapsed() >= RESPONSE_TIMEOUT {
+            bail!("tinySA startup output did not become idle");
+        }
+    }
+}
+
+fn scan_segment(
+    port: &mut dyn SerialPort,
+    command_rx: &Receiver<Command>,
+    segment: Segment,
+    zero_dbm: i32,
+    inactivity_timeout: Duration,
+) -> anyhow::Result<ScanResult> {
+    let command = format!(
+        "scanraw {} {} {} 1",
+        segment.start_hz, segment.stop_hz, segment.points
+    );
+    if let Some(command) = poll_scan_command(command_rx)? {
+        return Ok(ScanResult::Interrupted(command, Ok(())));
+    }
+    port.write_all(command.as_bytes())
+        .context("failed to write tinySA scan command")?;
+    port.write_all(b"\r")
+        .context("failed to terminate tinySA scan command")?;
+    port.flush()
+        .context("failed to flush tinySA scan command")?;
+    let mut expected = command.into_bytes();
+    expected.extend_from_slice(b"\r\n{");
+    let mut frame = Vec::with_capacity(2 + segment.points as usize * 3);
+    for (index, expected_byte) in expected.into_iter().enumerate() {
+        match next_scan_byte(port, command_rx, inactivity_timeout)? {
+            ByteEvent::Byte(byte) if byte == expected_byte => {}
+            ByteEvent::Byte(byte) => {
+                bail!(
+                    "tinySA scan prelude byte {index} was 0x{byte:02x}, expected 0x{expected_byte:02x}"
+                )
+            }
+            ByteEvent::Command(command) => {
+                return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
+            }
+        }
+    }
+    frame.push(b'{');
+    for index in 0..segment.points {
+        let tag = match next_scan_byte(port, command_rx, inactivity_timeout)? {
+            ByteEvent::Byte(byte) => byte,
+            ByteEvent::Command(command) => {
+                return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
+            }
+        };
+        if tag == b'}' {
+            bail!(
+                "tinySA scan closed after {index} of {} records",
+                segment.points
+            );
+        }
+        if tag != b'x' {
+            bail!("tinySA scan record {index} has malformed tag 0x{tag:02x}");
+        }
+        frame.push(tag);
+        for _ in 0..2 {
+            match next_scan_byte(port, command_rx, inactivity_timeout)? {
+                ByteEvent::Byte(byte) => frame.push(byte),
+                ByteEvent::Command(command) => {
+                    return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
+                }
+            }
+        }
+    }
+    let close = match next_scan_byte(port, command_rx, inactivity_timeout)? {
+        ByteEvent::Byte(byte) => byte,
+        ByteEvent::Command(command) => {
+            return Ok(ScanResult::Interrupted(command, abort_active_scan(port)))
+        }
+    };
+    frame.push(close);
+    let levels_dbm = protocol::parse_scan_frame(&frame, segment.points, zero_dbm)?;
+    for expected_byte in PROMPT {
+        match next_port_byte(port)? {
+            byte if byte == *expected_byte => {}
+            byte => bail!(
+                "tinySA emitted text after a scan frame: 0x{byte:02x} before the shell prompt"
+            ),
+        }
+    }
+    Ok(ScanResult::Complete {
+        frequencies_hz: protocol::scan_frequencies(
+            segment.start_hz,
+            segment.stop_hz,
+            segment.points,
+        ),
+        levels_dbm,
+        effective_center_hz: segment.start_hz + (segment.stop_hz - segment.start_hz) / 2,
+        effective_span_hz: segment.stop_hz - segment.start_hz,
+    })
+}
+
+fn next_scan_byte(
+    port: &mut dyn SerialPort,
+    command_rx: &Receiver<Command>,
+    inactivity_timeout: Duration,
+) -> anyhow::Result<ByteEvent> {
+    let last_byte = Instant::now();
+    loop {
+        if let Some(command) = poll_scan_command(command_rx)? {
+            return Ok(ByteEvent::Command(command));
+        }
+        let mut byte = [0u8; 1];
+        match port.read(&mut byte) {
+            Ok(1) => return Ok(ByteEvent::Byte(byte[0])),
+            Ok(0) => bail!("tinySA disconnected during a scan"),
+            Ok(_) => unreachable!(),
+            Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+                if last_byte.elapsed() >= inactivity_timeout {
+                    bail!("tinySA scan timed out");
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to read tinySA scan"),
+        }
+    }
+}
+
+fn poll_scan_command(command_rx: &Receiver<Command>) -> anyhow::Result<Option<Command>> {
+    loop {
+        match command_rx.try_recv() {
+            Ok(Command::IsStreaming(reply)) => {
+                let _ = reply.send(Ok(true));
+            }
+            Ok(command) => return Ok(Some(command)),
+            Err(TryRecvError::Disconnected) => bail!("tinySA command channel disconnected"),
+            Err(TryRecvError::Empty) => return Ok(None),
+        }
+    }
+}
+
+fn next_port_byte(port: &mut dyn SerialPort) -> anyhow::Result<u8> {
+    let last_byte = Instant::now();
+    loop {
+        let mut byte = [0u8; 1];
+        match port.read(&mut byte) {
+            Ok(1) => return Ok(byte[0]),
+            Ok(0) => bail!("tinySA disconnected during a scan"),
+            Ok(_) => unreachable!(),
+            Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+                if last_byte.elapsed() >= RESPONSE_TIMEOUT {
+                    bail!("tinySA scan timed out");
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to read tinySA scan"),
+        }
+    }
+}
+
+fn abort_active_scan(port: &mut dyn SerialPort) -> anyhow::Result<()> {
+    port.write_all(b"abort\r")
+        .context("failed to send tinySA scan abort")?;
+    port.flush().context("failed to flush tinySA scan abort")?;
+    let started = Instant::now();
+    let mut last_byte = Instant::now();
+    let mut response = Vec::new();
+    loop {
+        let mut buffer = [0u8; 64];
+        match port.read(&mut buffer) {
+            Ok(count) if count > 0 => {
+                response.extend_from_slice(&buffer[..count]);
+                last_byte = Instant::now();
+                if response.len() > MAX_RESPONSE_BYTES {
+                    bail!("tinySA abort drain exceeded {MAX_RESPONSE_BYTES} bytes");
+                }
+            }
+            Ok(_) => bail!("tinySA disconnected while aborting a scan"),
+            Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+                if last_byte.elapsed() >= DRAIN_QUIET {
+                    if !response
+                        .windows(PROMPT.len())
+                        .any(|window| window == PROMPT)
+                    {
+                        bail!("tinySA abort did not return a shell prompt");
+                    }
+                    return Ok(());
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to drain tinySA aborted scan"),
+        }
+        if started.elapsed() >= RESPONSE_TIMEOUT {
+            bail!("timed out draining the tinySA aborted scan");
+        }
+    }
+}
+
+fn reject_command(command: Command, error: anyhow::Error) {
+    let message = error.to_string();
+    match command {
+        Command::Start(_, reply)
+        | Command::Stop(reply)
+        | Command::SetFrequency(_, reply)
+        | Command::NoOp(reply)
+        | Command::Shutdown(reply) => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        Command::IsStreaming(reply) => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+        Command::SetSpan(_, reply) => {
+            let _ = reply.send(Err(anyhow!(message)));
+        }
+    }
+}
+
+fn capabilities(model: Model) -> DeviceCapabilities {
+    DeviceCapabilities {
+        acquisition: AcquisitionKind::PowerTrace,
+        sample_rate_is_span: true,
+        level_unit: LevelUnit::Dbm,
+        level_min_db: -120.0,
+        level_max_db: 20.0,
+        trace_stale_ms: 5_000,
+        freq_min_hz: MIN_FREQUENCY_HZ,
+        freq_max_hz: model.maximum_hz(),
+        sample_rate_min_hz: 1.0,
+        sample_rate_max_hz: (model.maximum_hz() - MIN_FREQUENCY_HZ) as f64,
+        default_frequency_hz: DEFAULT_FREQUENCY_HZ,
+        default_sample_rate_hz: DEFAULT_SPAN_HZ as f64,
+        sample_geometry: SampleGeometry {
+            format: SampleFormat::Int8,
+            full_scale: 1.0,
+        },
+        gain: GainModel::new(Vec::new(), "RF", "RF").with_gauge_fallback(0),
+        samples_per_transfer: 0,
+        has_bb_filter: true,
+        friis_applicable: false,
+        delivery: DeliveryModel::Pull,
+    }
+}
+
+fn centered_window(center_hz: u64, span_hz: u64, minimum_hz: u64, maximum_hz: u64) -> (u64, u64) {
+    let span_hz = span_hz.min(maximum_hz - minimum_hz);
+    let mut start_hz = center_hz.saturating_sub(span_hz / 2);
+    let mut stop_hz = start_hz.saturating_add(span_hz);
+    if start_hz < minimum_hz {
+        start_hz = minimum_hz;
+        stop_hz = minimum_hz + span_hz;
+    }
+    if stop_hz > maximum_hz {
+        stop_hz = maximum_hz;
+        start_hz = maximum_hz - span_hz;
+    }
+    (start_hz, stop_hz)
+}
+
+fn scan_segments(model: Model, start_hz: u64, stop_hz: u64, points: u32) -> Vec<Segment> {
+    let boundary = model.path_boundary_hz();
+    if start_hz < boundary && boundary < stop_hz && points >= 2 {
+        let total_span = stop_hz - start_hz;
+        let lower_span = boundary - start_hz;
+        let lower_points = ((points as u64 * lower_span + total_span / 2) / total_span)
+            .clamp(1, points as u64 - 1) as u32;
+        return vec![
+            Segment {
+                start_hz,
+                stop_hz: boundary,
+                points: lower_points,
+                path: RfPath::Lower,
+            },
+            Segment {
+                start_hz: boundary,
+                stop_hz,
+                points: points - lower_points,
+                path: RfPath::Upper,
+            },
+        ];
+    }
+    vec![Segment {
+        start_hz,
+        stop_hz,
+        points,
+        path: if start_hz < boundary {
+            RfPath::Lower
+        } else {
+            RfPath::Upper
+        },
+    }]
+}
+
+fn startup_settings(model: Model) -> (ScanSettings, Vec<&'static str>) {
+    let spur = if model.is_ultra() {
+        SpurMode::Auto
+    } else {
+        SpurMode::On
+    };
+    let mut commands = vec!["rbw auto", "attenuate auto"];
+    if model.is_ultra() {
+        commands.extend(["lna off", "lna2 auto", "agc auto", "spur auto"]);
+    } else {
+        commands.push("spur on");
+    }
+    (
+        ScanSettings {
+            points: DEFAULT_POINTS,
+            rbw_khz: None,
+            spur,
+        },
+        commands,
+    )
+}
+
+fn scan_inactivity_timeout(
+    segment: Segment,
+    model: Model,
+    settings: ScanSettings,
+) -> anyhow::Result<Duration> {
+    let span_hz = segment.stop_hz.saturating_sub(segment.start_hz) as f64;
+    let (minimum_rbw, maximum_rbw) = if model.is_ultra() {
+        (0.2, 850.0)
+    } else {
+        (3.0, 600.0)
+    };
+    let rbw_khz = settings
+        .rbw_khz
+        .unwrap_or_else(|| (span_hz * 7e-6).clamp(minimum_rbw, maximum_rbw));
+    let points = segment.points.max(1) as f64;
+    let mut total_seconds = (span_hz / 20_000.0) / rbw_khz.powi(2) + points / 500.0;
+    if (settings.spur == SpurMode::On && segment.stop_hz > 800_000_000)
+        || settings.spur == SpurMode::Auto
+    {
+        total_seconds *= 2.0;
+    }
+    let block_seconds = total_seconds * 20.0 / points + 1.0;
+    Ok(Duration::from_secs_f64(
+        block_seconds.max(RESPONSE_TIMEOUT.as_secs_f64()),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crossing_scans_split_at_the_model_path_boundary() {
+        assert_eq!(
+            scan_segments(Model::Basic, 300_000_000, 400_000_000, 290),
+            vec![
+                Segment {
+                    start_hz: 300_000_000,
+                    stop_hz: 350_000_000,
+                    points: 145,
+                    path: RfPath::Lower,
+                },
+                Segment {
+                    start_hz: 350_000_000,
+                    stop_hz: 400_000_000,
+                    points: 145,
+                    path: RfPath::Upper,
+                },
+            ]
+        );
+        assert_eq!(
+            scan_segments(Model::Zs405, 700_000_000, 900_000_000, 450)[0].stop_hz,
+            800_000_000
+        );
+        assert_eq!(
+            scan_segments(Model::Zs407, 800_000_000, 1_000_000_000, 450)[0].stop_hz,
+            900_000_000
+        );
+    }
+
+    #[test]
+    fn unsplit_scans_select_the_expected_path() {
+        assert_eq!(
+            scan_segments(Model::Basic, 100_000, 200_000_000, 64)[0].path,
+            RfPath::Lower
+        );
+        assert_eq!(
+            scan_segments(Model::UltraUnknown, 1_000_000_000, 2_000_000_000, 64)[0].path,
+            RfPath::Upper
+        );
+    }
+
+    #[test]
+    fn startup_uses_safe_automatic_controls() {
+        let (ultra, commands) = startup_settings(Model::Zs407);
+        assert_eq!(ultra.points, DEFAULT_POINTS);
+        assert_eq!(ultra.rbw_khz, None);
+        assert_eq!(
+            commands,
+            [
+                "rbw auto",
+                "attenuate auto",
+                "lna off",
+                "lna2 auto",
+                "agc auto",
+                "spur auto",
+            ]
+        );
+        let (basic, commands) = startup_settings(Model::Basic);
+        assert_eq!(basic.spur, SpurMode::On);
+        assert_eq!(commands, ["rbw auto", "attenuate auto", "spur on"]);
+    }
+
+    #[test]
+    fn centered_windows_keep_the_requested_span_inside_the_model_range() {
+        let low_edge = centered_window(100_000, 10_000_000, 100_000, 960_000_000);
+        assert_eq!(low_edge, (100_000, 10_100_000));
+        assert_eq!(low_edge.0 + (low_edge.1 - low_edge.0) / 2, 5_100_000);
+        assert_eq!(
+            centered_window(960_000_000, 10_000_000, 100_000, 960_000_000),
+            (950_000_000, 960_000_000)
+        );
+    }
+
+    #[test]
+    fn unknown_ultra_uses_the_conservative_zs405_range() {
+        assert_eq!(Model::UltraUnknown.maximum_hz(), 6_000_000_000);
+        assert_eq!(Model::UltraUnknown.path_boundary_hz(), 800_000_000);
+    }
+
+    #[test]
+    fn startup_forces_every_model_into_input_mode() {
+        assert_eq!(input_mode_command(Model::Basic), "mode low input");
+        for model in [
+            Model::Zs405,
+            Model::Zs406,
+            Model::Zs407,
+            Model::UltraUnknown,
+        ] {
+            assert_eq!(input_mode_command(model), "mode input");
+        }
+    }
+
+    #[test]
+    fn narrow_rbw_expands_the_scan_deadline() {
+        let settings = ScanSettings {
+            points: DEFAULT_POINTS,
+            rbw_khz: Some(0.2),
+            spur: SpurMode::Auto,
+        };
+        let segment = Segment {
+            start_hz: 400_000_000,
+            stop_hz: 500_000_000,
+            points: 450,
+            path: RfPath::Lower,
+        };
+        let timeout = scan_inactivity_timeout(segment, Model::Zs405, settings).unwrap();
+        assert!(timeout > Duration::from_secs(120), "{timeout:?}");
+    }
+
+    #[cfg(test)]
+    mod hardware_tests {
+        use super::*;
+
+        #[test]
+        #[ignore = "requires SDRTOP_TINYSA_TEST to name a connected serial port"]
+        fn connected_device_streams_spectrum_frames() {
+            let path = std::env::var("SDRTOP_TINYSA_TEST").expect("SDRTOP_TINYSA_TEST is not set");
+            let device = TinySaDevice::open(Path::new(&path)).unwrap();
+            assert!(device
+                .info()
+                .board_name
+                .to_ascii_lowercase()
+                .contains("tinysa"));
+
+            let state = Arc::new(Mutex::new(crate::state::SdrMetrics::fixture()));
+            let (sample_tx, _) = crossbeam_channel::bounded(1);
+            let (demod_tx, _) = crossbeam_channel::bounded(1);
+            let (net_tx, _) = crossbeam_channel::bounded(1);
+            let (power_tx, power_rx) = crossbeam_channel::bounded(4);
+            let context = Arc::new(RxContext {
+                metrics: Arc::clone(&state),
+                sample_tx,
+                fft_feed: crate::hardware::FeedHealth::default(),
+                demod_tx,
+                net_tx,
+                net_feed: crate::hardware::FeedHealth::default(),
+                power_tx,
+                geometry: device.capabilities().sample_geometry,
+            });
+
+            device.start_rx(context).unwrap();
+            let spectrum = power_rx.recv_timeout(Duration::from_secs(15)).unwrap();
+            assert_eq!(spectrum.frequencies_hz.len(), spectrum.levels_dbm.len());
+            assert!(!spectrum.frequencies_hz.is_empty());
+            device.stop_rx().unwrap();
+            assert!(!device.is_streaming());
+        }
+    }
+}

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -5,7 +5,7 @@ mod discovery;
 mod protocol;
 
 use std::io::{ErrorKind, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -30,8 +30,49 @@ const READ_TIMEOUT: Duration = Duration::from_millis(50);
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 const DRAIN_QUIET: Duration = Duration::from_millis(200);
 const MAX_RESPONSE_BYTES: usize = 128 * 1024;
+const BASIC_LOW_MAX_HZ: u64 = 350_000_000;
+const BASIC_HIGH_MIN_HZ: u64 = 240_000_000;
+const BASIC_HIGH_MAX_HZ: u64 = 959_000_000;
 
 type UnitReply = Sender<anyhow::Result<()>>;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BasicInput {
+    #[default]
+    Low,
+    High,
+}
+
+impl BasicInput {
+    fn parse(value: &str) -> anyhow::Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "low" => Ok(Self::Low),
+            "high" => Ok(Self::High),
+            _ => bail!("tinySA input must be 'low' or 'high'"),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Low => "LOW",
+            Self::High => "HIGH",
+        }
+    }
+
+    fn mode_command(self) -> &'static str {
+        match self {
+            Self::Low => "mode low input",
+            Self::High => "mode high input",
+        }
+    }
+
+    fn range(self) -> (u64, u64) {
+        match self {
+            Self::Low => (MIN_FREQUENCY_HZ, BASIC_LOW_MAX_HZ),
+            Self::High => (BASIC_HIGH_MIN_HZ, BASIC_HIGH_MAX_HZ),
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 struct ScanSettings {
@@ -46,8 +87,52 @@ enum SpurMode {
     Auto,
 }
 
-pub fn list() -> Vec<DeviceListing> {
-    discovery::list()
+pub fn list(selector: Option<&str>) -> Vec<DeviceListing> {
+    let show_input = selector.is_some_and(|value| value.contains("?input="));
+    let (path, input) = match selector {
+        Some(selector) => match parse_selector(selector) {
+            Ok(selection) => selection,
+            Err(_) => return Vec::new(),
+        },
+        None => (None, BasicInput::Low),
+    };
+    if let Some(path) = path {
+        let input_label = if show_input {
+            format!(" · {} input", input.label())
+        } else {
+            String::new()
+        };
+        return vec![DeviceListing {
+            kind: crate::hardware::DeviceKind::TinySa,
+            index: 0,
+            label: format!("tinySA · {}{input_label}", path.display()),
+            serial: None,
+            args: None,
+            path: Some(path),
+            tiny_sa_input: Some(input),
+        }];
+    }
+    let mut devices = discovery::list();
+    for device in &mut devices {
+        device.tiny_sa_input = Some(input);
+        if show_input {
+            device
+                .label
+                .push_str(&format!(" · {} input", input.label()));
+        }
+    }
+    devices
+}
+
+pub fn parse_selector(selector: &str) -> anyhow::Result<(Option<PathBuf>, BasicInput)> {
+    let (path, input) = match selector.rsplit_once("?input=") {
+        Some((path, input)) => (path, BasicInput::parse(input)?),
+        None => (selector, BasicInput::Low),
+    };
+    if path.contains('?') {
+        bail!("tinySA selector only supports '?input=low' or '?input=high'");
+    }
+    Ok(((!path.is_empty()).then(|| PathBuf::from(path)), input))
 }
 
 pub struct TinySaDevice {
@@ -59,7 +144,7 @@ pub struct TinySaDevice {
 }
 
 impl TinySaDevice {
-    pub fn open(path: &Path) -> anyhow::Result<Self> {
+    pub fn open(path: &Path, basic_input: BasicInput) -> anyhow::Result<Self> {
         let port = serialport::new(path.to_string_lossy(), 115_200)
             .data_bits(DataBits::Eight)
             .stop_bits(StopBits::One)
@@ -72,7 +157,7 @@ impl TinySaDevice {
         let (init_tx, init_rx) = bounded(1);
         let worker = thread::Builder::new()
             .name("tinysa-serial".to_string())
-            .spawn(move || worker_entry(port, command_rx, init_tx))
+            .spawn(move || worker_entry(port, command_rx, init_tx, basic_input))
             .context("failed to start tinySA serial worker")?;
         let initialized = match init_rx.recv() {
             Ok(Ok(initialized)) => initialized,
@@ -85,7 +170,7 @@ impl TinySaDevice {
                 bail!("tinySA serial worker stopped during initialization");
             }
         };
-        let caps = capabilities(initialized.identity.model);
+        let caps = capabilities(initialized.identity.model, basic_input);
         let notes = initialized
             .identity
             .hardware
@@ -197,16 +282,10 @@ struct Worker {
     command_rx: Receiver<Command>,
     identity: Identity,
     settings: ScanSettings,
+    basic_input: BasicInput,
     center_hz: u64,
     span_hz: u64,
     rx_context: Option<Arc<RxContext>>,
-    active_path: Option<RfPath>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum RfPath {
-    Lower,
-    Upper,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -214,7 +293,6 @@ struct Segment {
     start_hz: u64,
     stop_hz: u64,
     points: u32,
-    path: RfPath,
 }
 
 enum ScanResult {
@@ -242,8 +320,9 @@ fn worker_entry(
     mut port: Box<dyn SerialPort>,
     command_rx: Receiver<Command>,
     init_tx: Sender<anyhow::Result<Initialized>>,
+    basic_input: BasicInput,
 ) {
-    let (identity, settings) = match initialize(&mut *port) {
+    let (identity, settings) = match initialize(&mut *port, basic_input) {
         Ok(value) => value,
         Err(error) => {
             let _ = init_tx.send(Err(error));
@@ -258,15 +337,16 @@ fn worker_entry(
     {
         return;
     }
+    let center_hz = default_frequency(identity.model, basic_input);
     Worker {
         port,
         command_rx,
         identity,
         settings,
-        center_hz: DEFAULT_FREQUENCY_HZ,
+        center_hz,
         span_hz: DEFAULT_SPAN_HZ,
+        basic_input,
         rx_context: None,
-        active_path: None,
     }
     .run();
 }
@@ -366,11 +446,13 @@ impl Worker {
                 let _ = reply.send(Ok(self.rx_context.is_some()));
             }
             Command::SetFrequency(hz, reply) => {
-                self.center_hz = hz.clamp(MIN_FREQUENCY_HZ, self.identity.model.maximum_hz());
+                let (minimum, maximum) = frequency_range(self.identity.model, self.basic_input);
+                self.center_hz = hz.clamp(minimum, maximum);
                 let _ = reply.send(Ok(()));
             }
             Command::SetSpan(hz, reply) => {
-                let maximum = self.identity.model.maximum_hz() - MIN_FREQUENCY_HZ;
+                let (minimum, maximum) = frequency_range(self.identity.model, self.basic_input);
+                let maximum = maximum - minimum;
                 let result = normalize_span(hz, maximum, self.settings.points).map(|span_hz| {
                     self.span_hz = span_hz;
                     RateSet::new(
@@ -408,12 +490,9 @@ impl Worker {
     }
 
     fn scan_once(&mut self) -> anyhow::Result<ScanResult> {
-        let (start_hz, stop_hz) = centered_window(
-            self.center_hz,
-            self.span_hz,
-            MIN_FREQUENCY_HZ,
-            self.identity.model.maximum_hz(),
-        );
+        let (minimum_hz, maximum_hz) = frequency_range(self.identity.model, self.basic_input);
+        let (start_hz, stop_hz) =
+            centered_window(self.center_hz, self.span_hz, minimum_hz, maximum_hz);
         let points = self.settings.points;
         self.center_hz = window_center(start_hz, stop_hz);
         self.span_hz = stop_hz - start_hz;
@@ -422,34 +501,31 @@ impl Worker {
         }
         let mut frequencies_hz = Vec::with_capacity(points as usize);
         let mut levels_dbm = Vec::with_capacity(points as usize);
-        for segment in scan_segments(self.identity.model, start_hz, stop_hz, points) {
-            if let Some(command) = poll_scan_command(&self.command_rx)? {
-                return Ok(ScanResult::Interrupted(command, Ok(())));
+        let segment = Segment {
+            start_hz,
+            stop_hz,
+            points,
+        };
+        let inactivity_timeout =
+            scan_inactivity_timeout(segment, self.identity.model, self.settings)?;
+        match scan_segment(
+            &mut *self.port,
+            &self.command_rx,
+            segment,
+            self.identity.zero_dbm,
+            inactivity_timeout,
+        )? {
+            ScanResult::Complete {
+                frequencies_hz: segment_frequencies,
+                levels_dbm: segment_levels,
+                ..
+            } => {
+                frequencies_hz.extend(segment_frequencies);
+                levels_dbm.extend(segment_levels);
             }
-            self.select_path(segment.path)?;
-            let inactivity_timeout =
-                scan_inactivity_timeout(segment, self.identity.model, self.settings)?;
-            match scan_segment(
-                &mut *self.port,
-                &self.command_rx,
-                segment,
-                self.identity.zero_dbm,
-                inactivity_timeout,
-            )? {
-                ScanResult::Complete {
-                    frequencies_hz: segment_frequencies,
-                    levels_dbm: segment_levels,
-                    ..
-                } => {
-                    frequencies_hz.extend(segment_frequencies);
-                    levels_dbm.extend(segment_levels);
-                }
-                interrupted => return Ok(interrupted),
-            }
+            interrupted => return Ok(interrupted),
         }
-        if frequencies_hz.windows(2).any(|pair| pair[1] <= pair[0]) {
-            bail!("tinySA scan returned duplicate or descending frequencies");
-        }
+        let frequencies_hz = display_frequencies(&frequencies_hz)?;
         Ok(ScanResult::Complete {
             frequencies_hz,
             levels_dbm,
@@ -457,27 +533,12 @@ impl Worker {
             effective_span_hz: self.span_hz,
         })
     }
-
-    fn select_path(&mut self, path: RfPath) -> anyhow::Result<()> {
-        if self.identity.model.is_ultra() {
-            return Ok(());
-        }
-        if self.active_path == Some(path) {
-            return Ok(());
-        }
-        let command = match path {
-            RfPath::Lower => "mode low input",
-            RfPath::Upper => "mode high input",
-        };
-        send_text_command(&mut *self.port, command)?;
-        send_text_command(&mut *self.port, "abort on")?;
-        apply_scan_settings(&mut *self.port, self.identity.model)?;
-        self.active_path = Some(path);
-        Ok(())
-    }
 }
 
-fn initialize(port: &mut dyn SerialPort) -> anyhow::Result<(Identity, ScanSettings)> {
+fn initialize(
+    port: &mut dyn SerialPort,
+    basic_input: BasicInput,
+) -> anyhow::Result<(Identity, ScanSettings)> {
     best_effort_abort(port);
     drain_startup(port)?;
     let mut last_error = None;
@@ -504,8 +565,11 @@ fn initialize(port: &mut dyn SerialPort) -> anyhow::Result<(Identity, ScanSettin
     let help = send_text_command(port, "help")?;
     let zero = send_text_command(port, "zero")?;
     let identity = protocol::parse_identity(&version, &info, &help, &zero)?;
+    if identity.model.is_ultra() && basic_input == BasicInput::High {
+        bail!("tinySA HIGH input selection applies only to the basic model");
+    }
     send_text_command(port, "abort on")?;
-    send_text_command(port, input_mode_command(identity.model))?;
+    send_text_command(port, input_mode_command(identity.model, basic_input))?;
     let (settings, _) = startup_settings(identity.model);
     apply_scan_settings(port, identity.model)?;
     Ok((identity, settings))
@@ -523,11 +587,11 @@ fn best_effort_abort(port: &mut dyn SerialPort) {
     let _ = port.flush();
 }
 
-fn input_mode_command(model: Model) -> &'static str {
+fn input_mode_command(model: Model, basic_input: BasicInput) -> &'static str {
     if model.is_ultra() {
         "mode input"
     } else {
-        "mode low input"
+        basic_input.mode_command()
     }
 }
 
@@ -859,7 +923,8 @@ fn reject_command(command: Command, error: anyhow::Error) {
     }
 }
 
-fn capabilities(model: Model) -> DeviceCapabilities {
+fn capabilities(model: Model, basic_input: BasicInput) -> DeviceCapabilities {
+    let (minimum_hz, maximum_hz) = frequency_range(model, basic_input);
     DeviceCapabilities {
         acquisition: AcquisitionKind::PowerTrace,
         sample_rate_is_span: true,
@@ -867,11 +932,11 @@ fn capabilities(model: Model) -> DeviceCapabilities {
         level_min_db: -120.0,
         level_max_db: 20.0,
         trace_stale_ms: 5_000,
-        freq_min_hz: MIN_FREQUENCY_HZ,
-        freq_max_hz: model.maximum_hz(),
+        freq_min_hz: minimum_hz,
+        freq_max_hz: maximum_hz,
         sample_rate_min_hz: DEFAULT_POINTS as f64,
-        sample_rate_max_hz: (model.maximum_hz() - MIN_FREQUENCY_HZ) as f64,
-        default_frequency_hz: DEFAULT_FREQUENCY_HZ,
+        sample_rate_max_hz: (maximum_hz - minimum_hz) as f64,
+        default_frequency_hz: default_frequency(model, basic_input),
         default_sample_rate_hz: DEFAULT_SPAN_HZ as f64,
         sample_geometry: SampleGeometry {
             format: SampleFormat::Int8,
@@ -883,6 +948,19 @@ fn capabilities(model: Model) -> DeviceCapabilities {
         friis_applicable: false,
         delivery: DeliveryModel::Pull,
     }
+}
+
+fn frequency_range(model: Model, basic_input: BasicInput) -> (u64, u64) {
+    if model.is_ultra() {
+        (MIN_FREQUENCY_HZ, model.maximum_hz())
+    } else {
+        basic_input.range()
+    }
+}
+
+fn default_frequency(model: Model, basic_input: BasicInput) -> u64 {
+    let (minimum_hz, maximum_hz) = frequency_range(model, basic_input);
+    DEFAULT_FREQUENCY_HZ.clamp(minimum_hz, maximum_hz)
 }
 
 fn centered_window(center_hz: u64, span_hz: u64, minimum_hz: u64, maximum_hz: u64) -> (u64, u64) {
@@ -912,46 +990,30 @@ fn normalize_span(hz: f64, maximum_hz: u64, points: u32) -> anyhow::Result<u64> 
     Ok((hz.round() as u64).clamp(points as u64, maximum_hz))
 }
 
-fn scan_segments(model: Model, start_hz: u64, stop_hz: u64, points: u32) -> Vec<Segment> {
-    if model.is_ultra() {
-        return vec![Segment {
-            start_hz,
-            stop_hz,
-            points,
-            path: RfPath::Lower,
-        }];
+fn display_frequencies(measured_hz: &[u64]) -> anyhow::Result<Vec<u64>> {
+    let first = *measured_hz
+        .first()
+        .context("tinySA scan returned no frequencies")?;
+    let last = *measured_hz
+        .last()
+        .context("tinySA scan returned no frequencies")?;
+    if measured_hz.windows(2).any(|pair| pair[1] <= pair[0]) {
+        bail!("tinySA scan returned duplicate or descending frequencies");
     }
-    let boundary = model.path_boundary_hz();
-    if start_hz < boundary && boundary < stop_hz && points >= 2 {
-        let total_span = stop_hz - start_hz;
-        let lower_span = boundary - start_hz;
-        let lower_points = ((points as u64 * lower_span + total_span / 2) / total_span)
-            .clamp(1, points as u64 - 1) as u32;
-        return vec![
-            Segment {
-                start_hz,
-                stop_hz: boundary,
-                points: lower_points,
-                path: RfPath::Lower,
-            },
-            Segment {
-                start_hz: boundary,
-                stop_hz,
-                points: points - lower_points,
-                path: RfPath::Upper,
-            },
-        ];
+    let intervals = measured_hz.len().saturating_sub(1) as u64;
+    let span = last - first;
+    if intervals == 0 || span < intervals {
+        bail!(
+            "tinySA scan span is too narrow for {} points",
+            measured_hz.len()
+        );
     }
-    vec![Segment {
-        start_hz,
-        stop_hz,
-        points,
-        path: if start_hz < boundary {
-            RfPath::Lower
-        } else {
-            RfPath::Upper
-        },
-    }]
+    Ok((0..measured_hz.len())
+        .map(|index| {
+            let offset = (span as u128 * index as u128 + intervals as u128 / 2) / intervals as u128;
+            first + offset as u64
+        })
+        .collect())
 }
 
 fn startup_settings(model: Model) -> (ScanSettings, Vec<&'static str>) {
@@ -1132,48 +1194,18 @@ mod tests {
     }
 
     #[test]
-    fn basic_crossing_scans_split_at_the_model_path_boundary() {
+    fn basic_inputs_expose_only_their_physical_connector_range() {
         assert_eq!(
-            scan_segments(Model::Basic, 300_000_000, 400_000_000, 290),
-            vec![
-                Segment {
-                    start_hz: 300_000_000,
-                    stop_hz: 350_000_000,
-                    points: 145,
-                    path: RfPath::Lower,
-                },
-                Segment {
-                    start_hz: 350_000_000,
-                    stop_hz: 400_000_000,
-                    points: 145,
-                    path: RfPath::Upper,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn ultra_scans_leave_path_selection_to_the_firmware() {
-        assert_eq!(
-            scan_segments(Model::Zs405, 700_000_000, 900_000_000, 450),
-            vec![Segment {
-                start_hz: 700_000_000,
-                stop_hz: 900_000_000,
-                points: 450,
-                path: RfPath::Lower,
-            }]
+            frequency_range(Model::Basic, BasicInput::Low),
+            (100_000, 350_000_000)
         );
         assert_eq!(
-            scan_segments(Model::Zs407, 100_000, 7_300_000_000, 450).len(),
-            1
+            frequency_range(Model::Basic, BasicInput::High),
+            (240_000_000, 959_000_000)
         );
-    }
-
-    #[test]
-    fn basic_unsplit_scans_select_the_expected_path() {
         assert_eq!(
-            scan_segments(Model::Basic, 100_000, 200_000_000, 64)[0].path,
-            RfPath::Lower
+            default_frequency(Model::Basic, BasicInput::High),
+            240_000_000
         );
     }
 
@@ -1212,20 +1244,6 @@ mod tests {
     }
 
     #[test]
-    fn float_rounded_firmware_frequencies_keep_the_measured_edges() {
-        let measured = protocol::scan_frequencies(100_000_000, 200_000_000, 450);
-        assert!(measured
-            .windows(2)
-            .any(|pair| pair[1] - pair[0] != measured[1] - measured[0]));
-        let first = measured[0];
-        let last = *measured.last().unwrap();
-        assert_eq!(
-            crate::signal::power::trace_window(&measured),
-            Some((window_center(first, last), (last - first) as f64))
-        );
-    }
-
-    #[test]
     fn a_span_too_narrow_for_the_point_count_is_clamped() {
         assert_eq!(
             normalize_span(1.0, 959_900_000, DEFAULT_POINTS).unwrap(),
@@ -1234,6 +1252,31 @@ mod tests {
         let frequencies =
             protocol::scan_frequencies(100_000, 100_000 + DEFAULT_POINTS as u64, DEFAULT_POINTS);
         assert!(frequencies.windows(2).all(|pair| pair[1] > pair[0]));
+    }
+
+    #[test]
+    fn firmware_frequencies_use_an_endpoint_preserving_display_grid() {
+        let measured = protocol::scan_frequencies(100_000_000, 200_000_000, 450);
+        assert!(
+            measured.windows(2).map(|pair| pair[1] - pair[0]).min()
+                != measured.windows(2).map(|pair| pair[1] - pair[0]).max()
+        );
+        let displayed = display_frequencies(&measured).unwrap();
+        assert_eq!(displayed.first(), measured.first());
+        assert_eq!(displayed.last(), measured.last());
+        let span = displayed.last().unwrap() - displayed.first().unwrap();
+        let intervals = displayed.len() as u64 - 1;
+        let lower_step = span / intervals;
+        let upper_step = span.div_ceil(intervals);
+        assert!(displayed.windows(2).all(|pair| {
+            let step = pair[1] - pair[0];
+            step == lower_step || step == upper_step
+        }));
+    }
+
+    #[test]
+    fn display_grid_rejects_duplicate_firmware_frequencies() {
+        assert!(display_frequencies(&[100_000, 100_000, 100_001]).is_err());
     }
 
     #[test]
@@ -1250,20 +1293,54 @@ mod tests {
     #[test]
     fn unknown_ultra_uses_the_conservative_zs405_range() {
         assert_eq!(Model::UltraUnknown.maximum_hz(), 6_000_000_000);
-        assert_eq!(Model::UltraUnknown.path_boundary_hz(), 800_000_000);
     }
 
     #[test]
     fn startup_forces_every_model_into_input_mode() {
-        assert_eq!(input_mode_command(Model::Basic), "mode low input");
+        assert_eq!(
+            input_mode_command(Model::Basic, BasicInput::Low),
+            "mode low input"
+        );
+        assert_eq!(
+            input_mode_command(Model::Basic, BasicInput::High),
+            "mode high input"
+        );
         for model in [
             Model::Zs405,
             Model::Zs406,
             Model::Zs407,
             Model::UltraUnknown,
         ] {
-            assert_eq!(input_mode_command(model), "mode input");
+            assert_eq!(input_mode_command(model, BasicInput::High), "mode input");
         }
+    }
+
+    #[test]
+    fn selector_keeps_the_path_and_basic_input_separate() {
+        assert_eq!(
+            parse_selector("/dev/ttyACM2").unwrap(),
+            (Some(PathBuf::from("/dev/ttyACM2")), BasicInput::Low)
+        );
+        assert_eq!(
+            parse_selector("/dev/ttyACM2?input=high").unwrap(),
+            (Some(PathBuf::from("/dev/ttyACM2")), BasicInput::High)
+        );
+        assert_eq!(
+            parse_selector("?input=high").unwrap(),
+            (None, BasicInput::High)
+        );
+        assert!(parse_selector("/dev/ttyACM2?input=other").is_err());
+    }
+
+    #[test]
+    fn basic_capabilities_match_the_selected_input() {
+        let low = capabilities(Model::Basic, BasicInput::Low);
+        assert_eq!((low.freq_min_hz, low.freq_max_hz), (100_000, 350_000_000));
+        let high = capabilities(Model::Basic, BasicInput::High);
+        assert_eq!(
+            (high.freq_min_hz, high.freq_max_hz),
+            (240_000_000, 959_000_000)
+        );
     }
 
     #[test]
@@ -1277,7 +1354,6 @@ mod tests {
             start_hz: 400_000_000,
             stop_hz: 500_000_000,
             points: 450,
-            path: RfPath::Lower,
         };
         let timeout = scan_inactivity_timeout(segment, Model::Zs405, settings).unwrap();
         assert!(timeout > Duration::from_secs(120), "{timeout:?}");
@@ -1291,7 +1367,7 @@ mod tests {
         #[ignore = "requires SDRTOP_TINYSA_TEST to name a connected serial port"]
         fn connected_device_streams_spectrum_frames() {
             let path = std::env::var("SDRTOP_TINYSA_TEST").expect("SDRTOP_TINYSA_TEST is not set");
-            let device = TinySaDevice::open(Path::new(&path)).unwrap();
+            let device = TinySaDevice::open(Path::new(&path), BasicInput::Low).unwrap();
             assert!(device
                 .info()
                 .board_name

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -88,20 +88,20 @@ enum SpurMode {
 }
 
 pub fn list(selector: Option<&str>) -> Vec<DeviceListing> {
-    let show_input = selector.is_some_and(|value| value.contains("?input="));
     let (path, input) = match selector {
         Some(selector) => match parse_selector(selector) {
             Ok(selection) => selection,
-            Err(_) => return Vec::new(),
+            Err(error) => {
+                eprintln!("tinySA: invalid device selector: {error}");
+                return Vec::new();
+            }
         },
-        None => (None, BasicInput::Low),
+        None => (None, None),
     };
     if let Some(path) = path {
-        let input_label = if show_input {
-            format!(" · {} input", input.label())
-        } else {
-            String::new()
-        };
+        let input_label = input
+            .map(|input| format!(" · {} input", input.label()))
+            .unwrap_or_default();
         return vec![DeviceListing {
             kind: crate::hardware::DeviceKind::TinySa,
             index: 0,
@@ -109,13 +109,13 @@ pub fn list(selector: Option<&str>) -> Vec<DeviceListing> {
             serial: None,
             args: None,
             path: Some(path),
-            tiny_sa_input: Some(input),
+            tiny_sa_input: input,
         }];
     }
     let mut devices = discovery::list();
     for device in &mut devices {
-        device.tiny_sa_input = Some(input);
-        if show_input {
+        device.tiny_sa_input = input;
+        if let Some(input) = input {
             device
                 .label
                 .push_str(&format!(" · {} input", input.label()));
@@ -124,10 +124,10 @@ pub fn list(selector: Option<&str>) -> Vec<DeviceListing> {
     devices
 }
 
-pub fn parse_selector(selector: &str) -> anyhow::Result<(Option<PathBuf>, BasicInput)> {
+pub fn parse_selector(selector: &str) -> anyhow::Result<(Option<PathBuf>, Option<BasicInput>)> {
     let (path, input) = match selector.rsplit_once("?input=") {
-        Some((path, input)) => (path, BasicInput::parse(input)?),
-        None => (selector, BasicInput::Low),
+        Some((path, input)) => (path, Some(BasicInput::parse(input)?)),
+        None => (selector, None),
     };
     if path.contains('?') {
         bail!("tinySA selector only supports '?input=low' or '?input=high'");
@@ -1320,17 +1320,28 @@ mod tests {
     fn selector_keeps_the_path_and_basic_input_separate() {
         assert_eq!(
             parse_selector("/dev/ttyACM2").unwrap(),
-            (Some(PathBuf::from("/dev/ttyACM2")), BasicInput::Low)
+            (Some(PathBuf::from("/dev/ttyACM2")), None)
         );
         assert_eq!(
             parse_selector("/dev/ttyACM2?input=high").unwrap(),
-            (Some(PathBuf::from("/dev/ttyACM2")), BasicInput::High)
+            (Some(PathBuf::from("/dev/ttyACM2")), Some(BasicInput::High))
         );
         assert_eq!(
             parse_selector("?input=high").unwrap(),
-            (None, BasicInput::High)
+            (None, Some(BasicInput::High))
         );
         assert!(parse_selector("/dev/ttyACM2?input=other").is_err());
+    }
+
+    #[test]
+    fn only_an_explicit_selector_overrides_the_basic_input() {
+        let bare = list(Some("/dev/ttyACM2"));
+        assert_eq!(bare.len(), 1);
+        assert_eq!(bare[0].tiny_sa_input, None);
+
+        let high = list(Some("/dev/ttyACM2?input=high"));
+        assert_eq!(high.len(), 1);
+        assert_eq!(high[0].tiny_sa_input, Some(BasicInput::High));
     }
 
     #[test]

--- a/src/hardware/tinysa/protocol.rs
+++ b/src/hardware/tinysa/protocol.rs
@@ -27,14 +27,6 @@ impl Model {
         }
     }
 
-    pub(super) fn path_boundary_hz(self) -> u64 {
-        match self {
-            Self::Basic => 350_000_000,
-            Self::Zs405 | Self::UltraUnknown => 800_000_000,
-            Self::Zs406 | Self::Zs407 => 900_000_000,
-        }
-    }
-
     pub(super) fn name(self) -> &'static str {
         match self {
             Self::Basic => "tinySA",

--- a/src/hardware/tinysa/protocol.rs
+++ b/src/hardware/tinysa/protocol.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+use anyhow::{bail, Context};
+
+pub(super) const PROMPT: &[u8] = b"ch> ";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Model {
+    Basic,
+    Zs405,
+    Zs406,
+    Zs407,
+    UltraUnknown,
+}
+
+impl Model {
+    pub(super) fn is_ultra(self) -> bool {
+        self != Self::Basic
+    }
+
+    pub(super) fn maximum_hz(self) -> u64 {
+        match self {
+            Self::Basic => 960_000_000,
+            Self::Zs405 | Self::Zs406 | Self::UltraUnknown => 6_000_000_000,
+            Self::Zs407 => 7_300_000_000,
+        }
+    }
+
+    pub(super) fn path_boundary_hz(self) -> u64 {
+        match self {
+            Self::Basic => 350_000_000,
+            Self::Zs405 | Self::UltraUnknown => 800_000_000,
+            Self::Zs406 | Self::Zs407 => 900_000_000,
+        }
+    }
+
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Self::Basic => "tinySA",
+            Self::Zs405 => "tinySA Ultra ZS405",
+            Self::Zs406 => "tinySA Ultra ZS406",
+            Self::Zs407 => "tinySA Ultra ZS407",
+            Self::UltraUnknown => "tinySA Ultra",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Identity {
+    pub(super) firmware: String,
+    pub(super) hardware: Option<String>,
+    pub(super) board: String,
+    pub(super) zero_dbm: i32,
+    pub(super) model: Model,
+}
+
+pub(super) fn parse_text_frame(frame: &[u8], command: &str) -> anyhow::Result<Vec<u8>> {
+    if !frame.ends_with(PROMPT) {
+        bail!("tinySA response did not end at the shell prompt");
+    }
+    let without_prompt = &frame[..frame.len() - PROMPT.len()];
+    let mut echo = command.as_bytes().to_vec();
+    echo.extend_from_slice(b"\r\n");
+    if !without_prompt.starts_with(&echo) {
+        bail!("tinySA response did not echo the command");
+    }
+    let body = &without_prompt[echo.len()..];
+    let token = command.split_ascii_whitespace().next().unwrap_or(command);
+    let unknown = format!("{token}?");
+    if String::from_utf8_lossy(body)
+        .lines()
+        .any(|line| line.trim() == unknown)
+    {
+        bail!("tinySA does not support the {token} command");
+    }
+    Ok(body.to_vec())
+}
+
+pub(super) fn parse_identity(
+    version: &[u8],
+    info: &[u8],
+    help: &[u8],
+    zero: &[u8],
+) -> anyhow::Result<Identity> {
+    let version = std::str::from_utf8(version).context("tinySA version response was not text")?;
+    let info = std::str::from_utf8(info).context("tinySA info response was not text")?;
+    std::str::from_utf8(help).context("tinySA help response was not text")?;
+    let firmware = first_line(version)
+        .filter(|line| line.to_ascii_lowercase().contains("tinysa"))
+        .context("serial device did not identify itself as a tinySA")?
+        .to_string();
+    let combined = format!("{version}\n{info}");
+    let upper = combined.to_ascii_uppercase();
+    let ultra = upper.contains("TINYSA4") || upper.contains("TINYSA ULTRA");
+    let model = if !ultra {
+        Model::Basic
+    } else if upper.contains("ZS405") || upper.contains("V0.4.5.1.1") || upper.contains("V0.4.5.1")
+    {
+        Model::Zs405
+    } else if upper.contains("ZS406") || upper.contains("V0.4.6") {
+        Model::Zs406
+    } else if upper.contains("ZS407") || upper.contains("V0.5.4") || upper.contains("MAX2871") {
+        Model::Zs407
+    } else {
+        Model::UltraUnknown
+    };
+    let hardware = version
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("HW Version:"))
+        .map(str::to_string);
+    let board = first_line(info).unwrap_or_else(|| model.name()).to_string();
+    Ok(Identity {
+        firmware,
+        hardware,
+        board,
+        zero_dbm: parse_zero(zero)?,
+        model,
+    })
+}
+
+fn first_line(value: &str) -> Option<&str> {
+    value.lines().map(str::trim).find(|line| !line.is_empty())
+}
+
+pub(super) fn parse_zero(response: &[u8]) -> anyhow::Result<i32> {
+    let response = std::str::from_utf8(response).context("tinySA zero response was not text")?;
+    response
+        .lines()
+        .map(str::trim)
+        .find_map(|line| {
+            let number = line
+                .strip_suffix("dBm")
+                .or_else(|| line.strip_suffix("DBM"))?
+                .trim();
+            number.parse::<i32>().ok()
+        })
+        .context("tinySA zero response did not contain a dBm value")
+}
+
+pub(super) fn parse_scan_frame(
+    frame: &[u8],
+    points: u32,
+    zero_dbm: i32,
+) -> anyhow::Result<Vec<f32>> {
+    let expected = 1usize
+        .checked_add(points as usize * 3)
+        .and_then(|size| size.checked_add(1))
+        .context("tinySA scan point count is too large")?;
+    if frame.first() != Some(&b'{') {
+        bail!("tinySA scan frame is missing its opening tag");
+    }
+    let mut levels = Vec::with_capacity(points as usize);
+    let mut offset = 1;
+    for index in 0..points {
+        let Some(&tag) = frame.get(offset) else {
+            bail!("tinySA scan ended after {index} of {points} records");
+        };
+        if tag == b'}' {
+            bail!("tinySA scan closed after {index} of {points} records");
+        }
+        if tag != b'x' {
+            bail!("tinySA scan record {index} has malformed tag 0x{tag:02x}");
+        }
+        let Some(bytes) = frame.get(offset + 1..offset + 3) else {
+            bail!("tinySA scan record {index} ended early");
+        };
+        let raw = i16::from_le_bytes([bytes[0], bytes[1]]);
+        levels.push(raw as f32 / 32.0 - zero_dbm as f32);
+        offset += 3;
+    }
+    if frame.get(offset) != Some(&b'}') {
+        bail!("tinySA scan frame is missing its closing tag");
+    }
+    if frame.len() != expected {
+        bail!("tinySA scan frame has trailing data");
+    }
+    Ok(levels)
+}
+
+pub(super) fn scan_frequencies(start_hz: u64, stop_hz: u64, points: u32) -> Vec<u64> {
+    if points == 0 || stop_hz < start_hz {
+        return Vec::new();
+    }
+    let step = ((stop_hz - start_hz) / points as u64) as f32;
+    (0..points)
+        .map(|index| start_hz + (step * index as f32) as u64)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_frames_require_the_echo_and_prompt() {
+        assert_eq!(
+            parse_text_frame(b"version\r\ntinySA_v1.4\r\nch> ", "version").unwrap(),
+            b"tinySA_v1.4\r\n"
+        );
+        assert!(parse_text_frame(b"tinySA_v1.4\r\nch> ", "version").is_err());
+        assert!(parse_text_frame(b"version\r\ntinySA_v1.4\r\n", "version").is_err());
+        assert!(parse_text_frame(b"frobnicate\r\nfrobnicate?\r\nch> ", "frobnicate").is_err());
+    }
+
+    #[test]
+    fn basic_identity_does_not_need_a_hardware_line() {
+        let identity = parse_identity(
+            b"tinySA_v1.4-1-gabc\r\n",
+            b"tinySA v0.3ZS304\r\nVersion: tinySA_v1.4-1-gabc\r\n",
+            b"commands: version info help zero scanraw\r\n",
+            b"zero {level}\r\n128dBm\r\n",
+        )
+        .unwrap();
+        assert_eq!(identity.model, Model::Basic);
+        assert_eq!(identity.hardware, None);
+        assert_eq!(identity.zero_dbm, 128);
+    }
+
+    #[test]
+    fn ultra_models_are_read_from_the_info_response() {
+        for (suffix, expected) in [
+            ("ZS405", Model::Zs405),
+            ("ZS406", Model::Zs406),
+            ("ZS407", Model::Zs407),
+            ("prototype", Model::UltraUnknown),
+        ] {
+            let info = format!("tinySA ULTRA {suffix}\r\n");
+            let identity = parse_identity(
+                b"tinySA4_v1.4\r\nHW Version:future\r\n",
+                info.as_bytes(),
+                b"commands: scanraw\r\n",
+                b"174dBm\r\n",
+            )
+            .unwrap();
+            assert_eq!(identity.model, expected);
+            assert_eq!(identity.hardware.as_deref(), Some("HW Version:future"));
+        }
+    }
+
+    #[test]
+    fn ultra_models_fall_back_to_the_hardware_revision() {
+        for (hardware, expected) in [
+            ("V0.4.5.1.1", Model::Zs405),
+            ("V0.4.6", Model::Zs406),
+            ("V0.5.4 max2871", Model::Zs407),
+        ] {
+            let version = format!("tinySA4_v1.4\r\nHW Version:{hardware}\r\n");
+            let identity = parse_identity(
+                version.as_bytes(),
+                b"tinySA ULTRA\r\n",
+                b"commands: scanraw\r\n",
+                b"174dBm\r\n",
+            )
+            .unwrap();
+            assert_eq!(identity.model, expected, "{hardware}");
+        }
+    }
+
+    #[test]
+    fn zero_parser_accepts_signed_values() {
+        assert_eq!(parse_zero(b"zero {level}\r\n174dBm\r\n").unwrap(), 174);
+        assert_eq!(parse_zero(b"-174dBm\r\n").unwrap(), -174);
+        assert!(parse_zero(b"zero unavailable\r\n").is_err());
+    }
+
+    #[test]
+    fn scan_payload_bytes_are_never_treated_as_tags() {
+        let frame = [b'{', b'x', b'{', 0, b'x', 0, b'}', b'x', b'x', 0, b'}'];
+        let levels = parse_scan_frame(&frame, 3, 0).unwrap();
+        assert_eq!(levels, vec![123.0 / 32.0, 32000.0 / 32.0, 120.0 / 32.0]);
+    }
+
+    #[test]
+    fn negative_raw_levels_keep_their_sign() {
+        let levels = parse_scan_frame(&[b'{', b'x', 0x40, 0xff, b'}'], 1, 174).unwrap();
+        assert_eq!(levels, vec![-180.0]);
+    }
+
+    #[test]
+    fn scan_parser_rejects_bad_tags_and_truncation() {
+        assert!(parse_scan_frame(b"{q\0\0}", 1, 0)
+            .unwrap_err()
+            .to_string()
+            .contains("malformed tag"));
+        assert!(parse_scan_frame(b"{}", 1, 0)
+            .unwrap_err()
+            .to_string()
+            .contains("closed after"));
+        assert!(parse_scan_frame(b"{x\0\0", 1, 0)
+            .unwrap_err()
+            .to_string()
+            .contains("closing tag"));
+        assert!(parse_scan_frame(b"{x\0", 1, 0).is_err());
+        assert!(parse_scan_frame(b"{x\0\0}extra", 1, 0)
+            .unwrap_err()
+            .to_string()
+            .contains("trailing data"));
+    }
+
+    #[test]
+    fn frequency_mapping_matches_scanraw_integer_then_float_math() {
+        assert_eq!(
+            scan_frequencies(100_000_003, 100_001_006, 4),
+            vec![100_000_003, 100_000_253, 100_000_503, 100_000_753]
+        );
+        let large = scan_frequencies(6_000_000_001, 6_000_100_101, 3);
+        let step = ((100_100u64 / 3) as f32) as u64;
+        assert_eq!(
+            large,
+            vec![
+                6_000_000_001,
+                6_000_000_001 + step,
+                6_000_000_001 + 2 * step
+            ]
+        );
+        assert!(scan_frequencies(10, 9, 3).is_empty());
+        assert!(scan_frequencies(10, 20, 0).is_empty());
+    }
+}

--- a/src/hardware/tinysa/protocol.rs
+++ b/src/hardware/tinysa/protocol.rs
@@ -21,7 +21,7 @@ impl Model {
 
     pub(super) fn maximum_hz(self) -> u64 {
         match self {
-            Self::Basic => 960_000_000,
+            Self::Basic => 959_000_000,
             Self::Zs405 | Self::Zs406 | Self::UltraUnknown => 6_000_000_000,
             Self::Zs407 => 7_300_000_000,
         }

--- a/src/hardware/traits.rs
+++ b/src/hardware/traits.rs
@@ -653,6 +653,8 @@ pub enum DeliveryModel {
 #[derive(Clone, Debug)]
 pub struct DeviceCapabilities {
     pub acquisition: AcquisitionKind,
+    /// `set_sample_rate` controls a swept span for this device.
+    pub sample_rate_is_span: bool,
     /// Spectral levels and display bounds use this unit
     pub level_unit: LevelUnit,
     /// The finite display floor must be below `level_max_db`

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<()> {
     let devices = hardware::list_all_devices(want, soapy_filter.as_deref());
     if devices.is_empty() {
         eprintln!(
-            "No SDR device found. Connect a HackRF or RTL-SDR and try again.{}",
+            "No device found. Connect a HackRF, RTL-SDR, or tinySA and try again.{}",
             hardware::discovery::no_device_hint()
         );
         std::process::exit(1);

--- a/src/signal/power.rs
+++ b/src/signal/power.rs
@@ -443,4 +443,13 @@ mod tests {
         assert_eq!(frame.frequency_of_bin(0), Some(100_000.0));
         assert_eq!(frame.frequency_of_bin(3), Some(100_003.0));
     }
+
+    #[test]
+    fn trace_window_accepts_only_bounded_grid_variation() {
+        assert_eq!(
+            trace_window(&[100_000, 200_001, 300_000]),
+            Some((200_000, 200_000.0))
+        );
+        assert_eq!(trace_window(&[100_000, 200_002, 300_000]), None);
+    }
 }

--- a/src/signal/power.rs
+++ b/src/signal/power.rs
@@ -443,13 +443,4 @@ mod tests {
         assert_eq!(frame.frequency_of_bin(0), Some(100_000.0));
         assert_eq!(frame.frequency_of_bin(3), Some(100_003.0));
     }
-
-    #[test]
-    fn trace_window_accepts_only_bounded_grid_variation() {
-        assert_eq!(
-            trace_window(&[100_000, 200_001, 300_000]),
-            Some((200_000, 200_000.0))
-        );
-        assert_eq!(trace_window(&[100_000, 200_002, 300_000]), None);
-    }
 }

--- a/src/ui/menu/keys.rs
+++ b/src/ui/menu/keys.rs
@@ -21,7 +21,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::hardware::GainModel;
+use crate::hardware::{DeviceCapabilities, GainModel};
 use crate::ui::chrome;
 
 /// How a row reads on a single-knob device: RTL-SDR has one stepped tuner gain
@@ -157,7 +157,17 @@ pub const GLOBAL: &[(&str, &[Binding])] = &[
 ///
 /// Separate from drawing so the scroll arithmetic and the row count can be
 /// tested without a terminal.
+#[cfg(test)]
 fn lines(model: &GainModel, iw: usize, theme: &crate::Theme) -> Vec<Line<'static>> {
+    lines_for(model, false, iw, theme)
+}
+
+fn lines_for(
+    model: &GainModel,
+    sample_rate_is_span: bool,
+    iw: usize,
+    theme: &crate::Theme,
+) -> Vec<Line<'static>> {
     let single = model.is_single();
     let key_style = Style::default()
         .fg(theme.border_accent)
@@ -166,11 +176,19 @@ fn lines(model: &GainModel, iw: usize, theme: &crate::Theme) -> Vec<Line<'static
 
     let mut out = Vec::new();
     for (group, bindings) in GLOBAL {
+        if sample_rate_is_span && *group == "Gain" {
+            continue;
+        }
         // Which of this group's keys this device actually has. Collected first
         // so a group that filters down to nothing takes its heading with it: a
         // section title over empty space reads as a rendering bug, not as
         // "your radio has none of these".
-        let shown: Vec<&Binding> = bindings.iter().filter(|b| b.needs.met(model)).collect();
+        let shown: Vec<&Binding> = bindings
+            .iter()
+            .filter(|binding| {
+                binding.needs.met(model) && !(sample_rate_is_span && binding.ch == Some('m'))
+            })
+            .collect();
         if shown.is_empty() {
             continue;
         }
@@ -179,8 +197,9 @@ fn lines(model: &GainModel, iw: usize, theme: &crate::Theme) -> Vec<Line<'static
         }
         out.push(chrome::section(group, "", iw, theme));
         for binding in shown {
-            let what = match (single, &binding.single) {
-                (true, OnSingle::Reword(text)) => *text,
+            let what = match (sample_rate_is_span, binding.ch, single, &binding.single) {
+                (true, Some('s'), _, _) => "type a span",
+                (_, _, true, OnSingle::Reword(text)) => *text,
                 _ => binding.what,
             };
             out.push(Line::from(vec![
@@ -192,11 +211,22 @@ fn lines(model: &GainModel, iw: usize, theme: &crate::Theme) -> Vec<Line<'static
     out
 }
 
-pub fn render(f: &mut Frame, area: Rect, model: &GainModel, scroll: usize, theme: &crate::Theme) {
+pub fn render(
+    f: &mut Frame,
+    area: Rect,
+    caps: &DeviceCapabilities,
+    scroll: usize,
+    theme: &crate::Theme,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
-    let all = lines(model, area.width as usize, theme);
+    let all = lines_for(
+        &caps.gain,
+        caps.sample_rate_is_span,
+        area.width as usize,
+        theme,
+    );
     let visible = area.height as usize;
     let first = scroll.min(all.len().saturating_sub(visible));
     let shown: Vec<Line> = all.into_iter().skip(first).take(visible).collect();
@@ -205,8 +235,14 @@ pub fn render(f: &mut Frame, area: Rect, model: &GainModel, scroll: usize, theme
 
 /// How many rows the reference needs, so the caller can tell whether scrolling
 /// is possible at all.
-pub fn row_count(model: &GainModel) -> usize {
-    lines(model, 40, &crate::Theme::sdr()).len()
+pub fn row_count_for(caps: &DeviceCapabilities) -> usize {
+    lines_for(
+        &caps.gain,
+        caps.sample_rate_is_span,
+        40,
+        &crate::Theme::sdr(),
+    )
+    .len()
 }
 
 #[cfg(test)]
@@ -320,5 +356,24 @@ mod tests {
         let hackrf = lines(&hackrf::gain_model(), 40, &theme).len();
         let rtl = lines(&rtlsdr::gain_model(&[0, 10, 20]), 40, &theme).len();
         assert_eq!(rtl, hackrf - 2, "the two VGA rows should be gone");
+    }
+
+    #[test]
+    fn power_trace_reference_keeps_only_supported_controls() {
+        let theme = crate::Theme::sdr();
+        let lines = lines_for(
+            &GainModel::new(Vec::new(), "RF", "RF").with_gauge_fallback(0),
+            true,
+            80,
+            &theme,
+        );
+        let text = lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("type a span"));
+        assert!(!text.contains("GAIN"));
+        assert!(!text.contains("survey the band"));
     }
 }

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -158,7 +158,7 @@ fn right_pane(
 
     match state.pane {
         MenuPane::Views => entries::render(f, body, &menu.sections[section], cursor, theme),
-        MenuPane::Keys => keys::render(f, body, &m.caps.gain, state.scroll, theme),
+        MenuPane::Keys => keys::render(f, body, &m.caps, state.scroll, theme),
         MenuPane::Options => options::render(f, body, theme),
     }
 }

--- a/src/ui/panels/core/footer.rs
+++ b/src/ui/panels/core/footer.rs
@@ -188,6 +188,30 @@ fn normal_items(
     items
 }
 
+fn normal_items_for(
+    active_preset: &str,
+    scope: &[(Option<u8>, String)],
+    micro_view: MicroView,
+    available_width: u16,
+    gm: &GainModel,
+    sample_rate_is_span: bool,
+) -> Vec<String> {
+    if sample_rate_is_span {
+        let narrow = available_width < NARROW_COLS;
+        return vec![
+            "[Q] Quit".into(),
+            "[Space] RX".into(),
+            "[F] Freq".into(),
+            "[S] Span".into(),
+            "[R] Reset".into(),
+            "[Esc] Menu".into(),
+            "[Tab] Hide".into(),
+            format!("[P] {}", preset_label(active_preset, narrow)),
+        ];
+    }
+    normal_items(active_preset, scope, micro_view, available_width, gm)
+}
+
 /// Break `items` into lines (groups) where no line exceeds `inner_w` display
 /// columns. Returns the items per line, preserving boundaries so the renderer
 /// can style each key/description independently.
@@ -312,12 +336,13 @@ pub fn compute_footer_height(available_width: u16, state: &SdrMetrics) -> u16 {
         count_lines(&focus_items(state), FOCUS_SEP, inner_w)
     } else {
         count_lines(
-            &normal_items(
+            &normal_items_for(
                 &state.ui.active_preset,
                 &state.ui.scope,
                 state.ui.micro_view(),
                 available_width,
                 &state.caps.gain,
+                state.caps.sample_rate_is_span,
             ),
             NORMAL_SEP,
             inner_w,
@@ -388,7 +413,12 @@ impl Panel for FooterPanel {
                     m.ui.input_buf
                 )),
                 InputMode::SampleRateInput => prompt(format!(
-                    " Sample rate ({:.1}–{:.1} MHz): [{}▌]  [Enter] Confirm  [Esc] Cancel",
+                    " {} ({:.1}–{:.1} MHz): [{}▌]  [Enter] Confirm  [Esc] Cancel",
+                    if m.caps.sample_rate_is_span {
+                        "Span"
+                    } else {
+                        "Sample rate"
+                    },
                     m.caps.sample_rate_min_hz / 1e6,
                     m.caps.sample_rate_max_hz / 1e6,
                     m.ui.input_buf
@@ -425,12 +455,13 @@ impl Panel for FooterPanel {
                         }
                         wrapped
                     } else {
-                        let items = normal_items(
+                        let items = normal_items_for(
                             &m.ui.active_preset,
                             &m.ui.scope,
                             m.ui.micro_view(),
                             frame::outer_of(inner).width,
                             &m.caps.gain,
+                            m.caps.sample_rate_is_span,
                         );
                         let groups = wrap_items_grouped(&items, NORMAL_SEP, inner_w);
                         styled_lines(groups, NORMAL_SEP, theme, max_lines)
@@ -625,6 +656,27 @@ mod tests {
         let items = normal_items("main", &[], MicroView::Main, 120, &hackrf::gain_model());
         assert_eq!(items.last().map(String::as_str), Some("[P] main"));
         assert_eq!(items.len(), NORMAL_ITEMS.len() + 1);
+    }
+
+    #[test]
+    fn power_trace_footer_keeps_only_supported_radio_controls() {
+        let items = normal_items_for(
+            "spectrum_waterfall",
+            &[],
+            MicroView::Main,
+            120,
+            &hackrf::gain_model(),
+            true,
+        );
+        let text = items.join(" ");
+        assert!(text.contains("[Space] RX"));
+        assert!(text.contains("[F] Freq"));
+        assert!(text.contains("[S] Span"));
+        assert!(text.contains("[R] Reset"));
+        assert!(!text.contains("Gain"));
+        assert!(!text.contains("LNA"));
+        assert!(!text.contains("VGA"));
+        assert!(!text.contains("AMP"));
     }
 
     #[test]

--- a/src/ui/panels/core/header.rs
+++ b/src/ui/panels/core/header.rs
@@ -577,8 +577,12 @@ fn bottom_band_line(state: &SdrMetrics, theme: &crate::Theme, inner_width: u16) 
     let active = state.radio.hw_streaming && !state.observer.active;
     let gm = &state.caps.gain;
 
-    // Sample rate: right-padded to 4 chars
     let sr_str = format!("{:4.1}", state.radio.config_sample_rate / 1_000_000.0);
+    let (bandwidth_label, bandwidth_unit) = if state.caps.sample_rate_is_span {
+        ("SPAN ", " MHz")
+    } else {
+        ("SR ", " Msps")
+    };
 
     let freq_color = if state.observer.active {
         theme.label
@@ -617,11 +621,17 @@ fn bottom_band_line(state: &SdrMetrics, theme: &crate::Theme, inner_width: u16) 
         Span::raw(" "),
         Span::styled("MHz", Style::default().fg(theme.label)),
         Span::raw("    "),
-        Span::styled("SR ", Style::default().fg(theme.label)),
+        Span::styled(bandwidth_label, Style::default().fg(theme.label)),
         Span::styled(sr_str, Style::default().fg(val_color)),
-        Span::styled(" Msps", Style::default().fg(theme.label)),
+        Span::styled(bandwidth_unit, Style::default().fg(theme.label)),
     ]);
     let left_w: usize = left_spans.iter().map(|s| s.width()).sum();
+
+    if state.caps.sample_rate_is_span {
+        let gap = (inner_width as usize).saturating_sub(left_w);
+        left_spans.push(leader(gap, theme.border_dim));
+        return Line::from(left_spans);
+    }
 
     // right: primary "LNA/TUN "(4) + bar(8) + " "(1) + val(2) + " dB"(3) + "    "(4)  = 22
     //      + second stage "VGA "(4) + bar(8) + " "(1) + val(2) + " dB"(3) + "  "(2)   = 20  (blank on RTL)

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -10,12 +10,11 @@
 |--------|--------|
 | HackRF One | Fully supported: spectrum, waterfall, every diagnostic |
 | RTL-SDR (R820T / R828D / E4000) | Fully supported: the whole spectrum, waterfall and lab stack, with a single tuner gain plus AGC |
+| tinySA / tinySA Ultra / Ultra+ | Spectrum and waterfall in calibrated dBm. ZS405 is verified on hardware |
 | **Anything with a SoapySDR driver** | Supported, **and not yet confirmed on hardware other than a HackRF**. See [below](#soapysdr-the-honest-version) |
 | PortaPack H4M (Mayhem) | Fully supported (HackRF mode) |
 
-The first two are built and tested on real hardware. Support for them was only
-added after physical testing, never guessed from documentation. Datasheets have
-been known to fib; an oscilloscope rarely does.
+HackRF One, RTL-SDR and the tinySA Ultra ZS405 are tested on real hardware.
 
 The third row is a deliberate exception, and it gets its own section rather than
 a footnote, because you deserve to know which kind of "supported" you are
@@ -37,6 +36,25 @@ The UI adapts rather than showing you fields that can't mean anything:
 
 Everything else, including every lab bench, the demodulator and the sweep scanner,
 works the same on both.
+
+## tinySA
+
+sdrtop uses the tinySA USB console for calibrated power traces. The backend
+supports the basic tinySA and the Ultra family. It was verified on a ZS405
+running `tinySA4_v1.4-236-ge5aa115`.
+
+The device supplies swept power readings without IQ samples. sdrtop therefore
+offers only the spectrum and waterfall layouts. RBW, attenuation, gain, AGC and
+spur handling use safe automatic defaults.
+
+```sh
+sdrtop --device tinysa
+sdrtop --device tinysa=/dev/ttyACM2
+```
+
+Automatic discovery recognizes the official USB CDC identity on
+`/dev/ttyACM*`. The explicit form selects a path when several devices are
+present or discovery cannot inspect sysfs.
 
 > **RTL clones vary.** Different tuners, different gain tables, different quirks,
 > and no single person owns them all. If yours behaves oddly, please

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -57,7 +57,8 @@ Automatic discovery recognizes the official USB CDC identity on
 `/dev/ttyACM*`. The explicit form selects a path when several devices are
 present or discovery cannot inspect sysfs. A basic tinySA uses the LOW input by
 default from 100 kHz to 350 MHz. Select `input=high` for the HIGH connector from
-240 MHz to 959 MHz. One session stays on the selected connector.
+240 MHz to 959 MHz. The supported firmware defines 959 MHz as the HIGH input
+limit. One session stays on the selected connector.
 
 > **RTL clones vary.** Different tuners, different gain tables, different quirks,
 > and no single person owns them all. If yours behaves oddly, please

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -50,11 +50,14 @@ spur handling use safe automatic defaults.
 ```sh
 sdrtop --device tinysa
 sdrtop --device tinysa=/dev/ttyACM2
+sdrtop --device 'tinysa=/dev/ttyACM2?input=high'
 ```
 
 Automatic discovery recognizes the official USB CDC identity on
 `/dev/ttyACM*`. The explicit form selects a path when several devices are
-present or discovery cannot inspect sysfs.
+present or discovery cannot inspect sysfs. A basic tinySA uses the LOW input by
+default from 100 kHz to 350 MHz. Select `input=high` for the HIGH connector from
+240 MHz to 959 MHz. One session stays on the selected connector.
 
 > **RTL clones vary.** Different tuners, different gain tables, different quirks,
 > and no single person owns them all. If yours behaves oddly, please


### PR DESCRIPTION
This PR adds the tinySA backend on the power-trace foundation merged in #7.

The foundation supports calibrated power traces but has no analyzer discovery or serial protocol implementation. It cannot communicate with a tinySA on its own.

This PR adds model-aware discovery and a sole-owner serial worker. The worker publishes validated dBm traces for spectrum and waterfall views on existing firmware. #9 extends the backend to native wide sweeps.