### PR TITLE
Add device options framework

### DIFF
--- a/src/app/builder/boot.rs
+++ b/src/app/builder/boot.rs
@@ -409,6 +409,7 @@ pub(super) fn initial_metrics(cfg: &AppConfig, boot: Boot) -> anyhow::Result<Sdr
         demod: crate::state::DemodState::default(),
         net: crate::state::NetState::default(),
         caps,
+        device_options: Vec::new(),
         acc: Accumulators::default(),
     })
 }

--- a/src/app/builder/boot.rs
+++ b/src/app/builder/boot.rs
@@ -409,7 +409,7 @@ pub(super) fn initial_metrics(cfg: &AppConfig, boot: Boot) -> anyhow::Result<Sdr
         demod: crate::state::DemodState::default(),
         net: crate::state::NetState::default(),
         caps,
-        device_options: Vec::new(),
+        device_options: Arc::new(Vec::new()),
         acc: Accumulators::default(),
     })
 }

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -86,7 +86,7 @@ impl App {
         startup_results.push(device.set_amp_enable(cfg.radio.amp_enabled));
         startup_results.push(device.set_tuner_agc(cfg.radio.amp_enabled));
 
-        let (device_options, option_notes) = sanitize_device_options(device.options());
+        let (device_options, option_notes) = hardware::sanitize_device_options(device.options());
         let mut initial =
             initial_metrics(&cfg, Boot::normal(&cfg, Arc::clone(&caps), tuning, &info))?;
         initial.device_options = device_options;
@@ -343,68 +343,5 @@ impl App {
             theme_config: cfg.theme.clone(),
             user_presets: cfg.presets,
         })
-    }
-}
-
-fn sanitize_device_options(
-    options: Vec<hardware::DeviceOption>,
-) -> (Vec<hardware::DeviceOption>, Vec<String>) {
-    let mut valid = Vec::with_capacity(options.len());
-    let mut notes = Vec::new();
-    for mut option in options {
-        let name = if option.label.is_empty() {
-            option.id.as_str()
-        } else {
-            option.label.as_str()
-        };
-        let Some(first) = option.choices.first().cloned() else {
-            notes.push(format!(
-                "Warning: device option '{name}' has no choices. Hiding it."
-            ));
-            continue;
-        };
-        if !option.choices.contains(&option.selected_choice) {
-            notes.push(format!(
-                "Warning: device option '{name}' selected unavailable choice '{}'. Using '{first}'.",
-                option.selected_choice
-            ));
-            option.selected_choice = first;
-        }
-        valid.push(option);
-    }
-    (valid, notes)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn option(choices: &[&str], selected: &str) -> hardware::DeviceOption {
-        hardware::DeviceOption {
-            id: "bandwidth".into(),
-            label: "Bandwidth".into(),
-            choices: choices.iter().map(|choice| (*choice).into()).collect(),
-            selected_choice: selected.into(),
-        }
-    }
-
-    #[test]
-    fn startup_hides_options_without_choices_and_reports_them() {
-        let (options, notes) = sanitize_device_options(vec![option(&[], "")]);
-
-        assert!(options.is_empty());
-        assert_eq!(notes.len(), 1);
-        assert!(notes[0].contains("Bandwidth"));
-        assert!(notes[0].contains("no choices"));
-    }
-
-    #[test]
-    fn startup_replaces_an_unavailable_selected_choice() {
-        let (options, notes) =
-            sanitize_device_options(vec![option(&["Narrow", "Wide"], "Missing")]);
-
-        assert_eq!(options[0].selected_choice, "Narrow");
-        assert_eq!(notes.len(), 1);
-        assert!(notes[0].contains("unavailable choice"));
     }
 }

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -86,10 +86,11 @@ impl App {
         startup_results.push(device.set_amp_enable(cfg.radio.amp_enabled));
         startup_results.push(device.set_tuner_agc(cfg.radio.amp_enabled));
 
-        let (device_options, option_notes) = hardware::sanitize_device_options(device.options());
+        let device_options = device.options();
+        hardware::debug_assert_device_options(&device_options);
         let mut initial =
             initial_metrics(&cfg, Boot::normal(&cfg, Arc::clone(&caps), tuning, &info))?;
-        initial.device_options = device_options;
+        initial.device_options = Arc::new(device_options);
         let state = Arc::new(Mutex::new(initial));
 
         {
@@ -129,9 +130,6 @@ impl App {
             // ones are computed by `resolve_tuning`, which is pure, and surfaced
             // here.
             for note in &boot_notes {
-                m.push_log(note.clone());
-            }
-            for note in &option_notes {
                 m.push_log(note.clone());
             }
             let names = [
@@ -258,7 +256,7 @@ impl App {
     /// `preset_override` is `None` for "whatever the config asks for". Observer
     /// mode passes `Some("observer")` because its layout is the only one that
     /// says anything useful with no stream behind it.
-    fn assemble(
+    pub(super) fn assemble(
         cfg: AppConfig,
         config_path: Option<PathBuf>,
         state: Arc<Mutex<SdrMetrics>>,

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -86,9 +86,10 @@ impl App {
         startup_results.push(device.set_amp_enable(cfg.radio.amp_enabled));
         startup_results.push(device.set_tuner_agc(cfg.radio.amp_enabled));
 
+        let (device_options, option_notes) = sanitize_device_options(device.options());
         let mut initial =
             initial_metrics(&cfg, Boot::normal(&cfg, Arc::clone(&caps), tuning, &info))?;
-        initial.device_options = device.options();
+        initial.device_options = device_options;
         let state = Arc::new(Mutex::new(initial));
 
         {
@@ -128,6 +129,9 @@ impl App {
             // ones are computed by `resolve_tuning`, which is pure, and surfaced
             // here.
             for note in &boot_notes {
+                m.push_log(note.clone());
+            }
+            for note in &option_notes {
                 m.push_log(note.clone());
             }
             let names = [
@@ -206,6 +210,7 @@ impl App {
                 );
             }
         }
+
         tasks::spawn_sweep_task(Arc::clone(&state), Arc::clone(&device));
         tasks::spawn_sys_resource_task(Arc::clone(&state));
 
@@ -338,5 +343,68 @@ impl App {
             theme_config: cfg.theme.clone(),
             user_presets: cfg.presets,
         })
+    }
+}
+
+fn sanitize_device_options(
+    options: Vec<hardware::DeviceOption>,
+) -> (Vec<hardware::DeviceOption>, Vec<String>) {
+    let mut valid = Vec::with_capacity(options.len());
+    let mut notes = Vec::new();
+    for mut option in options {
+        let name = if option.label.is_empty() {
+            option.id.as_str()
+        } else {
+            option.label.as_str()
+        };
+        let Some(first) = option.choices.first().cloned() else {
+            notes.push(format!(
+                "Warning: device option '{name}' has no choices. Hiding it."
+            ));
+            continue;
+        };
+        if !option.choices.contains(&option.selected_choice) {
+            notes.push(format!(
+                "Warning: device option '{name}' selected unavailable choice '{}'. Using '{first}'.",
+                option.selected_choice
+            ));
+            option.selected_choice = first;
+        }
+        valid.push(option);
+    }
+    (valid, notes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn option(choices: &[&str], selected: &str) -> hardware::DeviceOption {
+        hardware::DeviceOption {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choices: choices.iter().map(|choice| (*choice).into()).collect(),
+            selected_choice: selected.into(),
+        }
+    }
+
+    #[test]
+    fn startup_hides_options_without_choices_and_reports_them() {
+        let (options, notes) = sanitize_device_options(vec![option(&[], "")]);
+
+        assert!(options.is_empty());
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("Bandwidth"));
+        assert!(notes[0].contains("no choices"));
+    }
+
+    #[test]
+    fn startup_replaces_an_unavailable_selected_choice() {
+        let (options, notes) =
+            sanitize_device_options(vec![option(&["Narrow", "Wide"], "Missing")]);
+
+        assert_eq!(options[0].selected_choice, "Narrow");
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("unavailable choice"));
     }
 }

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -86,10 +86,10 @@ impl App {
         startup_results.push(device.set_amp_enable(cfg.radio.amp_enabled));
         startup_results.push(device.set_tuner_agc(cfg.radio.amp_enabled));
 
-        let state = Arc::new(Mutex::new(initial_metrics(
-            &cfg,
-            Boot::normal(&cfg, Arc::clone(&caps), tuning, &info),
-        )?));
+        let mut initial =
+            initial_metrics(&cfg, Boot::normal(&cfg, Arc::clone(&caps), tuning, &info))?;
+        initial.device_options = device.options();
+        let state = Arc::new(Mutex::new(initial));
 
         {
             let mut m = state.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -13,7 +13,8 @@
 
 use crossterm::event::{KeyCode, KeyEvent};
 
-use crate::state::{MenuPane, MenuState};
+use crate::event::{DeviceOptionCompletion, DeviceOptionRequest};
+use crate::state::{DeviceOptionUpdate, MenuPane, MenuState, SdrMetrics};
 use crate::ui::menu::{keys, sections};
 
 use super::{global, metrics, InputCtx, KeyAction};
@@ -21,23 +22,32 @@ use super::{global, metrics, InputCtx, KeyAction};
 pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
     // Nothing to steer. Should not happen, since the caller only routes here
     // while the menu is open, but closing is a better answer than a panic.
-    let (state, has_options) = {
+    let (state, has_options, option_pending) = {
         let m = metrics(ctx.state);
-        (m.ui.menu, !m.device_options.is_empty())
+        (
+            m.ui.menu,
+            !m.device_options.is_empty(),
+            matches!(
+                m.ui.device_option_update,
+                DeviceOptionUpdate::Pending { .. }
+            ),
+        )
     };
     let Some(state) = state else {
         return KeyAction::Continue;
     };
 
     match key.code {
+        KeyCode::Esc if option_pending => {}
+        KeyCode::Tab | KeyCode::BackTab if option_pending => {}
         KeyCode::Esc => close(ctx),
         KeyCode::Char('q') => return KeyAction::Quit,
 
         KeyCode::Right if state.pane == MenuPane::Options && has_options => {
-            adjust_option(ctx, state, 1)
+            return request_option_change(ctx, state, 1);
         }
         KeyCode::Left if state.pane == MenuPane::Options && has_options => {
-            adjust_option(ctx, state, -1)
+            return request_option_change(ctx, state, -1);
         }
         KeyCode::Tab | KeyCode::Right => move_row(ctx, state, 1),
         KeyCode::BackTab | KeyCode::Left => move_row(ctx, state, -1),
@@ -72,7 +82,9 @@ pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
                 return open(ctx, &name);
             }
         }
-        KeyCode::Enter if state.pane == MenuPane::Options => adjust_option(ctx, state, 1),
+        KeyCode::Enter if state.pane == MenuPane::Options => {
+            return request_option_change(ctx, state, 1);
+        }
         _ => {}
     }
     KeyAction::Continue
@@ -182,34 +194,21 @@ fn move_down(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
     }
 }
 
-fn adjust_option(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
-    let Some(device) = ctx.device else {
-        return;
+fn request_option_change(ctx: &mut InputCtx<'_>, menu: MenuState, step: isize) -> KeyAction {
+    let mut m = metrics(ctx.state);
+    if matches!(
+        m.ui.device_option_update,
+        DeviceOptionUpdate::Pending { .. }
+    ) {
+        return KeyAction::Continue;
+    }
+    let Some(option) = m.device_options.get(menu.scroll) else {
+        return KeyAction::Continue;
     };
-    apply_option_change(
-        ctx.state,
-        state.scroll,
-        step,
-        |id, choice| device.set_option(id, choice),
-        || device.options(),
-    );
-}
-
-fn apply_option_change(
-    state: &std::sync::Arc<std::sync::Mutex<crate::state::SdrMetrics>>,
-    option_index: usize,
-    step: isize,
-    apply: impl FnOnce(&str, &str) -> anyhow::Result<()>,
-    refresh: impl FnOnce() -> Vec<crate::hardware::DeviceOption>,
-) {
+    if option.choices.is_empty() {
+        return KeyAction::Continue;
+    }
     let requested = {
-        let m = metrics(state);
-        let Some(option) = m.device_options.get(option_index) else {
-            return;
-        };
-        if option.choices.is_empty() {
-            return;
-        }
         let current = option
             .choices
             .iter()
@@ -226,25 +225,68 @@ fn apply_option_change(
         )
     };
 
-    if let Err(error) = apply(&requested.0, &requested.2) {
-        metrics(state).push_log(format!("{} error: {error}", requested.1));
+    let request = DeviceOptionRequest {
+        request_id: m.ui.next_device_option_request,
+        id: requested.0,
+        label: requested.1,
+        choice: requested.2,
+    };
+    m.ui.next_device_option_request = m.ui.next_device_option_request.wrapping_add(1);
+    m.ui.device_option_update = DeviceOptionUpdate::Pending {
+        request_id: request.request_id,
+        id: request.id.clone(),
+        label: request.label.clone(),
+        choice: request.choice.clone(),
+    };
+    KeyAction::ApplyDeviceOption(request)
+}
+
+pub(super) fn complete_device_option(
+    state: &std::sync::Arc<std::sync::Mutex<SdrMetrics>>,
+    completion: DeviceOptionCompletion,
+) {
+    let mut m = metrics(state);
+    let DeviceOptionUpdate::Pending { request_id, .. } = &m.ui.device_option_update else {
+        return;
+    };
+    if *request_id != completion.request.request_id {
         return;
     }
 
-    let (options, notes) = crate::hardware::sanitize_device_options(refresh());
-    let mut m = metrics(state);
-    m.device_options = options;
-    let last_option = m.device_options.len().saturating_sub(1);
-    if let Some(menu) =
-        m.ui.menu
-            .as_mut()
-            .filter(|menu| menu.pane == MenuPane::Options)
-    {
-        menu.scroll = menu.scroll.min(last_option);
-    }
-    m.push_log(format!("{} set to {}", requested.1, requested.2));
-    for note in notes {
-        m.push_log(note);
+    match completion.result {
+        Ok(options) => {
+            let (options, notes) = crate::hardware::sanitize_device_options(options);
+            m.device_options = options;
+            let last_option = m.device_options.len().saturating_sub(1);
+            if let Some(menu) =
+                m.ui.menu
+                    .as_mut()
+                    .filter(|menu| menu.pane == MenuPane::Options)
+            {
+                menu.scroll = menu.scroll.min(last_option);
+            }
+            m.ui.device_option_update = DeviceOptionUpdate::Completed {
+                request_id: completion.request.request_id,
+                id: completion.request.id.clone(),
+                choice: completion.request.choice.clone(),
+            };
+            m.push_log(format!(
+                "{} set to {}",
+                completion.request.label, completion.request.choice
+            ));
+            for note in notes {
+                m.push_log(note);
+            }
+        }
+        Err(message) => {
+            m.ui.device_option_update = DeviceOptionUpdate::Error {
+                request_id: completion.request.request_id,
+                id: completion.request.id,
+                choice: completion.request.choice,
+                message: message.clone(),
+            };
+            m.push_log(format!("{} error: {message}", completion.request.label));
+        }
     }
 }
 
@@ -267,7 +309,6 @@ mod tests {
     use crate::state::SdrMetrics;
     use crate::ui::{self, PanelRegistry};
     use crossterm::event::KeyEvent;
-    use std::cell::Cell;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
@@ -407,9 +448,10 @@ mod tests {
         h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
         let before = h.menu();
 
-        h.key(KeyCode::Right);
+        let action = h.key(KeyCode::Right);
 
         assert_eq!(h.menu(), before);
+        assert!(matches!(action, KeyAction::ApplyDeviceOption(_)));
     }
 
     #[test]
@@ -433,46 +475,31 @@ mod tests {
     }
 
     #[test]
-    fn a_successful_change_refreshes_all_options_without_locking() {
-        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
-        state
-            .lock()
-            .unwrap()
-            .device_options
-            .push(option("bandwidth", "Bandwidth", "Narrow"));
-        let mut call = None;
-        let set_called = Cell::new(false);
-        let options_called = Cell::new(false);
+    fn a_successful_completion_refreshes_all_options() {
+        let mut h = Harness::new();
+        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
+        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+            panic!("value change did not create a request");
+        };
 
-        apply_option_change(
-            &state,
-            0,
-            1,
-            |id, choice| {
-                assert!(
-                    state.try_lock().is_ok(),
-                    "state was locked during set_option"
-                );
-                set_called.set(true);
-                call = Some((id.to_string(), choice.to_string()));
-                Ok(())
-            },
-            || {
-                assert!(set_called.get(), "options refreshed before set_option");
-                assert!(state.try_lock().is_ok(), "state was locked during options");
-                options_called.set(true);
-                vec![
+        complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                request,
+                result: Ok(vec![
                     option("bandwidth", "Bandwidth", "Wide"),
                     described_option("attenuation", "Attenuation", &["0 dB", "10 dB"], "0 dB"),
-                ]
+                ]),
             },
         );
 
-        let m = state.lock().unwrap();
-        assert!(options_called.get());
-        assert_eq!(call, Some(("bandwidth".to_string(), "Wide".to_string())));
+        let m = h.state.lock().unwrap();
         assert_eq!(m.device_options[0].selected_choice, "Wide");
         assert_eq!(m.device_options[1].selected_choice, "0 dB");
+        assert!(matches!(
+            m.ui.device_option_update,
+            DeviceOptionUpdate::Completed { .. }
+        ));
         assert!(m
             .ui
             .log
@@ -481,36 +508,28 @@ mod tests {
     }
 
     #[test]
-    fn a_failed_change_keeps_state_and_surfaces_the_error() {
-        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
-        state
-            .lock()
-            .unwrap()
-            .device_options
-            .push(option("bandwidth", "Bandwidth", "Narrow"));
-        let before = state.lock().unwrap().device_options.clone();
-        let refresh_called = Cell::new(false);
+    fn a_failed_completion_keeps_state_and_surfaces_the_error() {
+        let mut h = Harness::new();
+        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
+        let before = h.state.lock().unwrap().device_options.clone();
+        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+            panic!("value change did not create a request");
+        };
 
-        apply_option_change(
-            &state,
-            0,
-            1,
-            |_, _| {
-                assert!(
-                    state.try_lock().is_ok(),
-                    "state was locked during set_option"
-                );
-                anyhow::bail!("device rejected choice")
-            },
-            || {
-                refresh_called.set(true);
-                Vec::new()
+        complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                request,
+                result: Err("device rejected choice".to_string()),
             },
         );
 
-        let m = state.lock().unwrap();
-        assert!(!refresh_called.get());
+        let m = h.state.lock().unwrap();
         assert_eq!(m.device_options, before);
+        assert!(matches!(
+            m.ui.device_option_update,
+            DeviceOptionUpdate::Error { .. }
+        ));
         assert!(m.ui.log.back().is_some_and(|entry| entry
             .text
             .contains("Bandwidth error: device rejected choice")));
@@ -518,32 +537,79 @@ mod tests {
 
     #[test]
     fn refreshed_options_use_the_startup_sanitization_rules() {
-        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
-        state
-            .lock()
-            .unwrap()
-            .device_options
-            .push(option("bandwidth", "Bandwidth", "Narrow"));
+        let mut h = Harness::new();
+        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
+        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+            panic!("value change did not create a request");
+        };
 
-        apply_option_change(
-            &state,
-            0,
-            1,
-            |_, _| Ok(()),
-            || {
-                vec![
+        complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                request,
+                result: Ok(vec![
                     described_option("empty", "Empty", &[], ""),
                     described_option("bandwidth", "Bandwidth", &["Narrow", "Wide"], "Missing"),
-                ]
+                ]),
             },
         );
 
-        let m = state.lock().unwrap();
+        let m = h.state.lock().unwrap();
         assert_eq!(m.device_options.len(), 1);
         assert_eq!(m.device_options[0].selected_choice, "Narrow");
         let log: Vec<&str> = m.ui.log.iter().map(|entry| entry.text.as_ref()).collect();
         assert!(log.iter().any(|entry| entry.contains("no choices")));
         assert!(log.iter().any(|entry| entry.contains("unavailable choice")));
+    }
+
+    #[test]
+    fn a_pending_change_keeps_navigation_and_quit_responsive() {
+        let mut h = Harness::new();
+        h.show_options(vec![
+            option("bandwidth", "Bandwidth", "Narrow"),
+            option("mode", "Mode", "Wide"),
+        ]);
+
+        assert!(matches!(
+            h.key(KeyCode::Right),
+            KeyAction::ApplyDeviceOption(_)
+        ));
+        assert_eq!(h.key(KeyCode::Left), KeyAction::Continue);
+        h.key(KeyCode::Down);
+        assert_eq!(h.menu().scroll, 1);
+        h.key(KeyCode::Esc);
+        assert!(h.state.lock().unwrap().ui.menu.is_some());
+        h.key(KeyCode::Tab);
+        assert_eq!(h.menu().pane, MenuPane::Options);
+        h.key(KeyCode::BackTab);
+        assert_eq!(h.menu().pane, MenuPane::Options);
+        assert_eq!(h.key(KeyCode::Char('q')), KeyAction::Quit);
+    }
+
+    #[test]
+    fn a_late_completion_cannot_replace_a_newer_pending_request() {
+        let mut h = Harness::new();
+        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
+        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+            panic!("value change did not create a request");
+        };
+        let mut late = request.clone();
+        late.request_id = request.request_id.wrapping_add(1);
+
+        complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                request: late,
+                result: Ok(vec![option("bandwidth", "Bandwidth", "Wide")]),
+            },
+        );
+
+        let m = h.state.lock().unwrap();
+        assert_eq!(m.device_options[0].selected_choice, "Narrow");
+        assert!(matches!(
+            m.ui.device_option_update,
+            DeviceOptionUpdate::Pending { .. }
+        ));
     }
 
     /// A pane is a detour, not a reset: the place you had in the list survives

--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -27,10 +27,7 @@ pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
         (
             m.ui.menu,
             !m.device_options.is_empty(),
-            matches!(
-                m.ui.device_option_update,
-                DeviceOptionUpdate::Pending { .. }
-            ),
+            m.ui.device_option_update.is_pending(),
         )
     };
     let Some(state) = state else {
@@ -196,28 +193,31 @@ fn move_down(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
 
 fn request_option_change(ctx: &mut InputCtx<'_>, menu: MenuState, step: isize) -> KeyAction {
     let mut m = metrics(ctx.state);
-    if matches!(
-        m.ui.device_option_update,
-        DeviceOptionUpdate::Pending { .. }
-    ) {
+    if m.ui.device_option_update.is_pending() {
         return KeyAction::Continue;
     }
     let Some(option) = m.device_options.get(menu.scroll) else {
         return KeyAction::Continue;
     };
-    if option.choices.is_empty() {
+    if option.choices.len() < 2 {
         return KeyAction::Continue;
     }
     let requested = {
-        let current = option
+        let Some(current) = option
             .choices
             .iter()
-            .position(|choice| choice == &option.selected_choice);
-        let selected = match current {
-            Some(index) => wrap(index, step, option.choices.len()),
-            None if step >= 0 => 0,
-            None => option.choices.len() - 1,
+            .position(|choice| choice == &option.selected_choice)
+        else {
+            let label = option.label.clone();
+            m.push_log(format!(
+                "{label} error: selected choice is not advertised by the device"
+            ));
+            return KeyAction::Continue;
         };
+        let selected = wrap(current, step, option.choices.len());
+        if option.choices[selected] == option.selected_choice {
+            return KeyAction::Continue;
+        }
         (
             option.id.clone(),
             option.label.clone(),
@@ -226,17 +226,13 @@ fn request_option_change(ctx: &mut InputCtx<'_>, menu: MenuState, step: isize) -
     };
 
     let request = DeviceOptionRequest {
-        request_id: m.ui.next_device_option_request,
         id: requested.0,
         label: requested.1,
         choice: requested.2,
     };
-    m.ui.next_device_option_request = m.ui.next_device_option_request.wrapping_add(1);
     m.ui.device_option_update = DeviceOptionUpdate::Pending {
-        request_id: request.request_id,
-        id: request.id.clone(),
-        label: request.label.clone(),
-        choice: request.choice.clone(),
+        request: request.clone(),
+        quit_requested: false,
     };
     KeyAction::ApplyDeviceOption(request)
 }
@@ -244,50 +240,56 @@ fn request_option_change(ctx: &mut InputCtx<'_>, menu: MenuState, step: isize) -
 pub(super) fn complete_device_option(
     state: &std::sync::Arc<std::sync::Mutex<SdrMetrics>>,
     completion: DeviceOptionCompletion,
-) {
+) -> bool {
     let mut m = metrics(state);
-    let DeviceOptionUpdate::Pending { request_id, .. } = &m.ui.device_option_update else {
-        return;
+    let DeviceOptionUpdate::Pending {
+        request,
+        quit_requested,
+    } = &m.ui.device_option_update
+    else {
+        return false;
     };
-    if *request_id != completion.request.request_id {
-        return;
-    }
+    let request = request.clone();
+    let quit_requested = *quit_requested;
 
     match completion.result {
         Ok(options) => {
-            let (options, notes) = crate::hardware::sanitize_device_options(options);
-            m.device_options = options;
+            crate::hardware::debug_assert_device_options(&options);
+            let selected_id =
+                m.ui.menu
+                    .filter(|menu| menu.pane == MenuPane::Options)
+                    .and_then(|menu| m.device_options.get(menu.scroll))
+                    .map(|option| option.id.clone());
+            m.device_options = std::sync::Arc::new(options);
             let last_option = m.device_options.len().saturating_sub(1);
+            let preserved_index = selected_id
+                .as_ref()
+                .and_then(|id| m.device_options.iter().position(|option| &option.id == id));
             if let Some(menu) =
                 m.ui.menu
                     .as_mut()
                     .filter(|menu| menu.pane == MenuPane::Options)
             {
-                menu.scroll = menu.scroll.min(last_option);
+                menu.scroll = preserved_index.unwrap_or_else(|| menu.scroll.min(last_option));
             }
-            m.ui.device_option_update = DeviceOptionUpdate::Completed {
-                request_id: completion.request.request_id,
-                id: completion.request.id.clone(),
-                choice: completion.request.choice.clone(),
-            };
-            m.push_log(format!(
-                "{} set to {}",
-                completion.request.label, completion.request.choice
-            ));
-            for note in notes {
-                m.push_log(note);
+            let updated_choice = m
+                .device_options
+                .iter()
+                .find(|option| option.id == request.id)
+                .map(|option| option.selected_choice.clone());
+            m.ui.device_option_update = DeviceOptionUpdate::Idle;
+            if let Some(choice) = updated_choice {
+                m.push_log(format!("{} set to {choice}", request.label));
+            } else {
+                m.push_log(format!("{} updated", request.label));
             }
         }
         Err(message) => {
-            m.ui.device_option_update = DeviceOptionUpdate::Error {
-                request_id: completion.request.request_id,
-                id: completion.request.id,
-                choice: completion.request.choice,
-                message: message.clone(),
-            };
-            m.push_log(format!("{} error: {message}", completion.request.label));
+            m.ui.device_option_update = DeviceOptionUpdate::Failed { id: request.id };
+            m.push_log(format!("{} error: {message}", request.label));
         }
     }
+    quit_requested
 }
 
 /// `i + step` modulo `len`, for a step of -1 or 1. Pure, so the wrap-around at
@@ -354,7 +356,7 @@ mod tests {
 
         fn show_options(&mut self, options: Vec<DeviceOption>) {
             let mut m = self.state.lock().unwrap();
-            m.device_options = options;
+            m.device_options = Arc::new(options);
             m.ui.menu = Some(MenuState {
                 pane: MenuPane::Options,
                 ..MenuState::default()
@@ -478,14 +480,13 @@ mod tests {
     fn a_successful_completion_refreshes_all_options() {
         let mut h = Harness::new();
         h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
-        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+        let KeyAction::ApplyDeviceOption(_) = h.key(KeyCode::Right) else {
             panic!("value change did not create a request");
         };
 
         complete_device_option(
             &h.state,
             DeviceOptionCompletion {
-                request,
                 result: Ok(vec![
                     option("bandwidth", "Bandwidth", "Wide"),
                     described_option("attenuation", "Attenuation", &["0 dB", "10 dB"], "0 dB"),
@@ -498,7 +499,7 @@ mod tests {
         assert_eq!(m.device_options[1].selected_choice, "0 dB");
         assert!(matches!(
             m.ui.device_option_update,
-            DeviceOptionUpdate::Completed { .. }
+            DeviceOptionUpdate::Idle
         ));
         assert!(m
             .ui
@@ -512,14 +513,13 @@ mod tests {
         let mut h = Harness::new();
         h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
         let before = h.state.lock().unwrap().device_options.clone();
-        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+        let KeyAction::ApplyDeviceOption(_) = h.key(KeyCode::Right) else {
             panic!("value change did not create a request");
         };
 
         complete_device_option(
             &h.state,
             DeviceOptionCompletion {
-                request,
                 result: Err("device rejected choice".to_string()),
             },
         );
@@ -528,7 +528,7 @@ mod tests {
         assert_eq!(m.device_options, before);
         assert!(matches!(
             m.ui.device_option_update,
-            DeviceOptionUpdate::Error { .. }
+            DeviceOptionUpdate::Failed { .. }
         ));
         assert!(m.ui.log.back().is_some_and(|entry| entry
             .text
@@ -536,30 +536,55 @@ mod tests {
     }
 
     #[test]
-    fn refreshed_options_use_the_startup_sanitization_rules() {
+    fn a_successful_refresh_logs_the_authoritative_choice() {
         let mut h = Harness::new();
         h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
-        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+        let KeyAction::ApplyDeviceOption(_) = h.key(KeyCode::Right) else {
             panic!("value change did not create a request");
         };
 
         complete_device_option(
             &h.state,
             DeviceOptionCompletion {
-                request,
-                result: Ok(vec![
-                    described_option("empty", "Empty", &[], ""),
-                    described_option("bandwidth", "Bandwidth", &["Narrow", "Wide"], "Missing"),
-                ]),
+                result: Ok(vec![described_option(
+                    "bandwidth",
+                    "Bandwidth",
+                    &["Narrow", "Wide", "Auto"],
+                    "Auto",
+                )]),
             },
         );
 
         let m = h.state.lock().unwrap();
-        assert_eq!(m.device_options.len(), 1);
-        assert_eq!(m.device_options[0].selected_choice, "Narrow");
-        let log: Vec<&str> = m.ui.log.iter().map(|entry| entry.text.as_ref()).collect();
-        assert!(log.iter().any(|entry| entry.contains("no choices")));
-        assert!(log.iter().any(|entry| entry.contains("unavailable choice")));
+        assert_eq!(m.device_options[0].selected_choice, "Auto");
+        assert!(m
+            .ui
+            .log
+            .back()
+            .is_some_and(|entry| entry.text.contains("Bandwidth set to Auto")));
+    }
+
+    #[test]
+    fn a_disappearing_option_gets_a_neutral_success_log() {
+        let mut h = Harness::new();
+        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
+        let KeyAction::ApplyDeviceOption(_) = h.key(KeyCode::Right) else {
+            panic!("value change did not create a request");
+        };
+
+        complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                result: Ok(vec![option("mode", "Mode", "Narrow")]),
+            },
+        );
+
+        let m = h.state.lock().unwrap();
+        assert!(m
+            .ui
+            .log
+            .back()
+            .is_some_and(|entry| entry.text.as_ref() == "Bandwidth updated"));
     }
 
     #[test]
@@ -587,28 +612,50 @@ mod tests {
     }
 
     #[test]
-    fn a_late_completion_cannot_replace_a_newer_pending_request() {
+    fn a_refresh_preserves_the_highlighted_option_by_id() {
         let mut h = Harness::new();
-        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
-        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Right) else {
+        h.show_options(vec![
+            option("bandwidth", "Bandwidth", "Narrow"),
+            option("mode", "Mode", "Narrow"),
+        ]);
+        let KeyAction::ApplyDeviceOption(_) = h.key(KeyCode::Right) else {
             panic!("value change did not create a request");
         };
-        let mut late = request.clone();
-        late.request_id = request.request_id.wrapping_add(1);
+        h.key(KeyCode::Down);
 
         complete_device_option(
             &h.state,
             DeviceOptionCompletion {
-                request: late,
-                result: Ok(vec![option("bandwidth", "Bandwidth", "Wide")]),
+                result: Ok(vec![
+                    option("mode", "Mode", "Narrow"),
+                    option("bandwidth", "Bandwidth", "Wide"),
+                ]),
             },
         );
 
-        let m = h.state.lock().unwrap();
-        assert_eq!(m.device_options[0].selected_choice, "Narrow");
+        assert_eq!(
+            h.menu().scroll,
+            0,
+            "Mode remains highlighted after reordering"
+        );
+    }
+
+    #[test]
+    fn unchanged_and_single_choice_options_do_not_start_writes() {
+        let mut h = Harness::new();
+        h.show_options(vec![described_option("mode", "Mode", &["Only"], "Only")]);
+
+        assert_eq!(h.key(KeyCode::Right), KeyAction::Continue);
+        h.show_options(vec![described_option(
+            "mode",
+            "Mode",
+            &["Same", "Same"],
+            "Same",
+        )]);
+        assert_eq!(h.key(KeyCode::Right), KeyAction::Continue);
         assert!(matches!(
-            m.ui.device_option_update,
-            DeviceOptionUpdate::Pending { .. }
+            h.state.lock().unwrap().ui.device_option_update,
+            DeviceOptionUpdate::Idle
         ));
     }
 

--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -186,9 +186,13 @@ fn adjust_option(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
     let Some(device) = ctx.device else {
         return;
     };
-    apply_option_change(ctx.state, state.scroll, step, |id, choice| {
-        device.set_option(id, choice)
-    });
+    apply_option_change(
+        ctx.state,
+        state.scroll,
+        step,
+        |id, choice| device.set_option(id, choice),
+        || device.options(),
+    );
 }
 
 fn apply_option_change(
@@ -196,6 +200,7 @@ fn apply_option_change(
     option_index: usize,
     step: isize,
     apply: impl FnOnce(&str, &str) -> anyhow::Result<()>,
+    refresh: impl FnOnce() -> Vec<crate::hardware::DeviceOption>,
 ) {
     let requested = {
         let m = metrics(state);
@@ -221,20 +226,25 @@ fn apply_option_change(
         )
     };
 
-    let result = apply(&requested.0, &requested.2);
+    if let Err(error) = apply(&requested.0, &requested.2) {
+        metrics(state).push_log(format!("{} error: {error}", requested.1));
+        return;
+    }
+
+    let (options, notes) = crate::hardware::sanitize_device_options(refresh());
     let mut m = metrics(state);
-    match result {
-        Ok(()) => {
-            if let Some(option) = m
-                .device_options
-                .iter_mut()
-                .find(|option| option.id == requested.0)
-            {
-                option.selected_choice.clone_from(&requested.2);
-            }
-            m.push_log(format!("{} set to {}", requested.1, requested.2));
-        }
-        Err(error) => m.push_log(format!("{} error: {error}", requested.1)),
+    m.device_options = options;
+    let last_option = m.device_options.len().saturating_sub(1);
+    if let Some(menu) =
+        m.ui.menu
+            .as_mut()
+            .filter(|menu| menu.pane == MenuPane::Options)
+    {
+        menu.scroll = menu.scroll.min(last_option);
+    }
+    m.push_log(format!("{} set to {}", requested.1, requested.2));
+    for note in notes {
+        m.push_log(note);
     }
 }
 
@@ -257,6 +267,7 @@ mod tests {
     use crate::state::SdrMetrics;
     use crate::ui::{self, PanelRegistry};
     use crossterm::event::KeyEvent;
+    use std::cell::Cell;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
@@ -311,10 +322,14 @@ mod tests {
     }
 
     fn option(id: &str, label: &str, selected: &str) -> DeviceOption {
+        described_option(id, label, &["Narrow", "Wide"], selected)
+    }
+
+    fn described_option(id: &str, label: &str, choices: &[&str], selected: &str) -> DeviceOption {
         DeviceOption {
             id: id.into(),
             label: label.into(),
-            choices: vec!["Narrow".into(), "Wide".into()],
+            choices: choices.iter().map(|choice| (*choice).into()).collect(),
             selected_choice: selected.into(),
         }
     }
@@ -418,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    fn a_successful_change_updates_state_after_the_device_call() {
+    fn a_successful_change_refreshes_all_options_without_locking() {
         let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
         state
             .lock()
@@ -426,19 +441,38 @@ mod tests {
             .device_options
             .push(option("bandwidth", "Bandwidth", "Narrow"));
         let mut call = None;
+        let set_called = Cell::new(false);
+        let options_called = Cell::new(false);
 
-        apply_option_change(&state, 0, 1, |id, choice| {
-            assert!(
-                state.try_lock().is_ok(),
-                "state was locked during device call"
-            );
-            call = Some((id.to_string(), choice.to_string()));
-            Ok(())
-        });
+        apply_option_change(
+            &state,
+            0,
+            1,
+            |id, choice| {
+                assert!(
+                    state.try_lock().is_ok(),
+                    "state was locked during set_option"
+                );
+                set_called.set(true);
+                call = Some((id.to_string(), choice.to_string()));
+                Ok(())
+            },
+            || {
+                assert!(set_called.get(), "options refreshed before set_option");
+                assert!(state.try_lock().is_ok(), "state was locked during options");
+                options_called.set(true);
+                vec![
+                    option("bandwidth", "Bandwidth", "Wide"),
+                    described_option("attenuation", "Attenuation", &["0 dB", "10 dB"], "0 dB"),
+                ]
+            },
+        );
 
         let m = state.lock().unwrap();
+        assert!(options_called.get());
         assert_eq!(call, Some(("bandwidth".to_string(), "Wide".to_string())));
         assert_eq!(m.device_options[0].selected_choice, "Wide");
+        assert_eq!(m.device_options[1].selected_choice, "0 dB");
         assert!(m
             .ui
             .log
@@ -454,20 +488,62 @@ mod tests {
             .unwrap()
             .device_options
             .push(option("bandwidth", "Bandwidth", "Narrow"));
+        let before = state.lock().unwrap().device_options.clone();
+        let refresh_called = Cell::new(false);
 
-        apply_option_change(&state, 0, 1, |_, _| {
-            assert!(
-                state.try_lock().is_ok(),
-                "state was locked during device call"
-            );
-            anyhow::bail!("device rejected choice")
-        });
+        apply_option_change(
+            &state,
+            0,
+            1,
+            |_, _| {
+                assert!(
+                    state.try_lock().is_ok(),
+                    "state was locked during set_option"
+                );
+                anyhow::bail!("device rejected choice")
+            },
+            || {
+                refresh_called.set(true);
+                Vec::new()
+            },
+        );
 
         let m = state.lock().unwrap();
-        assert_eq!(m.device_options[0].selected_choice, "Narrow");
+        assert!(!refresh_called.get());
+        assert_eq!(m.device_options, before);
         assert!(m.ui.log.back().is_some_and(|entry| entry
             .text
             .contains("Bandwidth error: device rejected choice")));
+    }
+
+    #[test]
+    fn refreshed_options_use_the_startup_sanitization_rules() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        state
+            .lock()
+            .unwrap()
+            .device_options
+            .push(option("bandwidth", "Bandwidth", "Narrow"));
+
+        apply_option_change(
+            &state,
+            0,
+            1,
+            |_, _| Ok(()),
+            || {
+                vec![
+                    described_option("empty", "Empty", &[], ""),
+                    described_option("bandwidth", "Bandwidth", &["Narrow", "Wide"], "Missing"),
+                ]
+            },
+        );
+
+        let m = state.lock().unwrap();
+        assert_eq!(m.device_options.len(), 1);
+        assert_eq!(m.device_options[0].selected_choice, "Narrow");
+        let log: Vec<&str> = m.ui.log.iter().map(|entry| entry.text.as_ref()).collect();
+        assert!(log.iter().any(|entry| entry.contains("no choices")));
+        assert!(log.iter().any(|entry| entry.contains("unavailable choice")));
     }
 
     /// A pane is a detour, not a reset: the place you had in the list survives

--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -21,7 +21,11 @@ use super::{global, metrics, InputCtx, KeyAction};
 pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
     // Nothing to steer. Should not happen, since the caller only routes here
     // while the menu is open, but closing is a better answer than a panic.
-    let Some(state) = metrics(ctx.state).ui.menu else {
+    let (state, has_options) = {
+        let m = metrics(ctx.state);
+        (m.ui.menu, !m.device_options.is_empty())
+    };
+    let Some(state) = state else {
         return KeyAction::Continue;
     };
 
@@ -29,6 +33,12 @@ pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
         KeyCode::Esc => close(ctx),
         KeyCode::Char('q') => return KeyAction::Quit,
 
+        KeyCode::Right if state.pane == MenuPane::Options && has_options => {
+            adjust_option(ctx, state, 1)
+        }
+        KeyCode::Left if state.pane == MenuPane::Options && has_options => {
+            adjust_option(ctx, state, -1)
+        }
         KeyCode::Tab | KeyCode::Right => move_row(ctx, state, 1),
         KeyCode::BackTab | KeyCode::Left => move_row(ctx, state, -1),
         KeyCode::Down => move_down(ctx, state, 1),
@@ -62,6 +72,7 @@ pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
                 return open(ctx, &name);
             }
         }
+        KeyCode::Enter if state.pane == MenuPane::Options => adjust_option(ctx, state, 1),
         _ => {}
     }
     KeyAction::Continue
@@ -158,10 +169,72 @@ fn move_down(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
                 ..state
             });
         }
-        // Nothing to move through yet. When the first setting lands this grows a
-        // cursor of its own; until then the arrows are quiet rather than moving
-        // something the reader cannot see.
-        MenuPane::Options => {}
+        MenuPane::Options => {
+            let count = metrics(ctx.state).device_options.len();
+            if count == 0 {
+                return;
+            }
+            metrics(ctx.state).ui.menu = Some(MenuState {
+                scroll: wrap(state.scroll.min(count - 1), step, count),
+                ..state
+            });
+        }
+    }
+}
+
+fn adjust_option(ctx: &mut InputCtx<'_>, state: MenuState, step: isize) {
+    let Some(device) = ctx.device else {
+        return;
+    };
+    apply_option_change(ctx.state, state.scroll, step, |id, choice| {
+        device.set_option(id, choice)
+    });
+}
+
+fn apply_option_change(
+    state: &std::sync::Arc<std::sync::Mutex<crate::state::SdrMetrics>>,
+    option_index: usize,
+    step: isize,
+    apply: impl FnOnce(&str, &str) -> anyhow::Result<()>,
+) {
+    let requested = {
+        let m = metrics(state);
+        let Some(option) = m.device_options.get(option_index) else {
+            return;
+        };
+        if option.choices.is_empty() {
+            return;
+        }
+        let current = option
+            .choices
+            .iter()
+            .position(|choice| choice == &option.selected_choice);
+        let selected = match current {
+            Some(index) => wrap(index, step, option.choices.len()),
+            None if step >= 0 => 0,
+            None => option.choices.len() - 1,
+        };
+        (
+            option.id.clone(),
+            option.label.clone(),
+            option.choices[selected].clone(),
+        )
+    };
+
+    let result = apply(&requested.0, &requested.2);
+    let mut m = metrics(state);
+    match result {
+        Ok(()) => {
+            if let Some(option) = m
+                .device_options
+                .iter_mut()
+                .find(|option| option.id == requested.0)
+            {
+                option.selected_choice.clone_from(&requested.2);
+            }
+            m.push_log(format!("{} set to {}", requested.1, requested.2));
+        }
+        Err(error) => m.push_log(format!("{} error: {error}", requested.1)),
     }
 }
 
@@ -180,6 +253,7 @@ fn wrap(i: usize, step: isize, len: usize) -> usize {
 mod tests {
     use super::*;
     use crate::config::LayoutConfig;
+    use crate::hardware::DeviceOption;
     use crate::state::SdrMetrics;
     use crate::ui::{self, PanelRegistry};
     use crossterm::event::KeyEvent;
@@ -224,6 +298,24 @@ mod tests {
 
         fn menu(&self) -> MenuState {
             self.state.lock().unwrap().ui.menu.expect("menu is open")
+        }
+
+        fn show_options(&mut self, options: Vec<DeviceOption>) {
+            let mut m = self.state.lock().unwrap();
+            m.device_options = options;
+            m.ui.menu = Some(MenuState {
+                pane: MenuPane::Options,
+                ..MenuState::default()
+            });
+        }
+    }
+
+    fn option(id: &str, label: &str, selected: &str) -> DeviceOption {
+        DeviceOption {
+            id: id.into(),
+            label: label.into(),
+            choices: vec!["Narrow".into(), "Wide".into()],
+            selected_choice: selected.into(),
         }
     }
 
@@ -276,6 +368,106 @@ mod tests {
             "command_rail",
             "no key in Options may load a layout"
         );
+    }
+
+    #[test]
+    fn options_move_up_and_down_through_device_settings() {
+        let mut h = Harness::new();
+        h.show_options(vec![
+            option("bandwidth", "Bandwidth", "Narrow"),
+            option("mode", "Mode", "Wide"),
+        ]);
+
+        h.key(KeyCode::Down);
+        assert_eq!(h.menu().scroll, 1);
+        h.key(KeyCode::Down);
+        assert_eq!(h.menu().scroll, 0);
+        h.key(KeyCode::Up);
+        assert_eq!(h.menu().scroll, 1);
+    }
+
+    #[test]
+    fn horizontal_value_keys_do_not_leave_options_when_values_exist() {
+        let mut h = Harness::new();
+        h.show_options(vec![option("bandwidth", "Bandwidth", "Narrow")]);
+        let before = h.menu();
+
+        h.key(KeyCode::Right);
+
+        assert_eq!(h.menu(), before);
+    }
+
+    #[test]
+    fn horizontal_keys_keep_the_old_navigation_for_empty_devices() {
+        let mut h = Harness::new();
+        h.state.lock().unwrap().ui.menu = Some(MenuState {
+            pane: MenuPane::Options,
+            ..MenuState::default()
+        });
+
+        h.key(KeyCode::Left);
+        assert_eq!(h.menu().pane, MenuPane::Keys);
+
+        h.state.lock().unwrap().ui.menu = Some(MenuState {
+            pane: MenuPane::Options,
+            ..MenuState::default()
+        });
+        h.key(KeyCode::Right);
+        assert_eq!(h.menu().pane, MenuPane::Views);
+        assert_eq!(h.menu().section, 0);
+    }
+
+    #[test]
+    fn a_successful_change_updates_state_after_the_device_call() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        state
+            .lock()
+            .unwrap()
+            .device_options
+            .push(option("bandwidth", "Bandwidth", "Narrow"));
+        let mut call = None;
+
+        apply_option_change(&state, 0, 1, |id, choice| {
+            assert!(
+                state.try_lock().is_ok(),
+                "state was locked during device call"
+            );
+            call = Some((id.to_string(), choice.to_string()));
+            Ok(())
+        });
+
+        let m = state.lock().unwrap();
+        assert_eq!(call, Some(("bandwidth".to_string(), "Wide".to_string())));
+        assert_eq!(m.device_options[0].selected_choice, "Wide");
+        assert!(m
+            .ui
+            .log
+            .back()
+            .is_some_and(|entry| entry.text.contains("Bandwidth set to Wide")));
+    }
+
+    #[test]
+    fn a_failed_change_keeps_state_and_surfaces_the_error() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        state
+            .lock()
+            .unwrap()
+            .device_options
+            .push(option("bandwidth", "Bandwidth", "Narrow"));
+
+        apply_option_change(&state, 0, 1, |_, _| {
+            assert!(
+                state.try_lock().is_ok(),
+                "state was locked during device call"
+            );
+            anyhow::bail!("device rejected choice")
+        });
+
+        let m = state.lock().unwrap();
+        assert_eq!(m.device_options[0].selected_choice, "Narrow");
+        assert!(m.ui.log.back().is_some_and(|entry| entry
+            .text
+            .contains("Bandwidth error: device rejected choice")));
     }
 
     /// A pane is a detour, not a reset: the place you had in the list survives

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -135,8 +135,8 @@ pub fn handle_key(
 pub(super) fn complete_device_option(
     state: &Arc<Mutex<SdrMetrics>>,
     completion: DeviceOptionCompletion,
-) {
-    menu::complete_device_option(state, completion);
+) -> bool {
+    menu::complete_device_option(state, completion)
 }
 
 /// Fold an uppercase letter key onto its lowercase twin, leaving every other key

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -35,16 +35,18 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crossterm::event::{KeyCode, KeyEvent};
 
+use crate::event::{DeviceOptionCompletion, DeviceOptionRequest};
 use crate::hardware;
 use crate::state::{InputMode, SdrMetrics};
 use crate::ui;
 
 /// What the main loop should do next. `PartialEq`/`Debug` so a test can say
 /// which one it expected.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum KeyAction {
     Continue,
     Quit,
+    ApplyDeviceOption(DeviceOptionRequest),
 }
 
 /// Everything a key handler is allowed to touch.
@@ -106,6 +108,7 @@ pub fn handle_key(
                 handle_normal(key, &mut ctx)
             }
         }
+
         InputMode::FrequencyInput => {
             text::frequency(key, state, device);
             KeyAction::Continue
@@ -127,6 +130,13 @@ pub fn handle_key(
             KeyAction::Continue
         }
     }
+}
+
+pub(super) fn complete_device_option(
+    state: &Arc<Mutex<SdrMetrics>>,
+    completion: DeviceOptionCompletion,
+) {
+    menu::complete_device_option(state, completion);
 }
 
 /// Fold an uppercase letter key onto its lowercase twin, leaving every other key

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{backend::Backend, Terminal};
 
 use crate::config::{AppConfig, DisplayConfig, RadioConfig};
@@ -76,7 +77,6 @@ impl App {
     pub fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
         const FRAME_DURATION: Duration = Duration::from_millis(33);
         let mut last_draw = Instant::now();
-        let mut quit_requested = false;
 
         // Repaint from a clean slate: the device selector and any backend chatter
         // during open may have left the alternate screen dirty before we get here.
@@ -86,39 +86,41 @@ impl App {
         loop {
             let needs_redraw = match self.events.recv() {
                 AppEvent::Key(key) => {
-                    if quit_requested {
-                        continue;
-                    }
-                    match input::handle_key(
-                        key,
-                        &self.state,
-                        self.device.as_ref(),
-                        &mut self.engine,
-                        &mut self.show_footer,
-                        &self.focus_keys,
-                    ) {
-                        input::KeyAction::Quit => {
-                            if self.device_option_pending() {
-                                quit_requested = true;
-                                let mut m =
-                                    self.state.lock().unwrap_or_else(|error| error.into_inner());
-                                m.ui.quit_after_device_option = true;
-                            } else {
-                                self.finish_session();
-                                return Ok(());
+                    if self.device_option_pending() && Self::is_option_quit_key(key) {
+                        if self.request_pending_option_quit() {
+                            return Err(self.forced_option_quit_error());
+                        }
+                        true
+                    } else {
+                        match input::handle_key(
+                            key,
+                            &self.state,
+                            self.device.as_ref(),
+                            &mut self.engine,
+                            &mut self.show_footer,
+                            &self.focus_keys,
+                        ) {
+                            input::KeyAction::Quit => {
+                                if self.device_option_pending() {
+                                    if self.request_pending_option_quit() {
+                                        return Err(self.forced_option_quit_error());
+                                    }
+                                } else {
+                                    self.finish_session();
+                                    return Ok(());
+                                }
+                            }
+                            input::KeyAction::Continue => {}
+                            input::KeyAction::ApplyDeviceOption(request) => {
+                                self.start_device_option(request);
                             }
                         }
-                        input::KeyAction::Continue => {}
-                        input::KeyAction::ApplyDeviceOption(request) => {
-                            self.start_device_option(request);
-                        }
+                        last_draw.elapsed() >= FRAME_DURATION
                     }
-                    last_draw.elapsed() >= FRAME_DURATION
                 }
                 AppEvent::Tick => true,
                 AppEvent::DeviceOptionComplete(completion) => {
-                    input::complete_device_option(&self.state, completion);
-                    if quit_requested && !self.device_option_pending() {
+                    if input::complete_device_option(&self.state, completion) {
                         self.finish_session();
                         return Ok(());
                     }
@@ -138,7 +140,6 @@ impl App {
             input::complete_device_option(
                 &self.state,
                 DeviceOptionCompletion {
-                    request,
                     result: Err("device is unavailable".to_string()),
                 },
             );
@@ -146,7 +147,7 @@ impl App {
         };
         let tx = self.events.sender();
         let worker_request = request.clone();
-        Self::spawn_device_option_task(request, tx, move || {
+        Self::spawn_device_option_task(tx, move || {
             Self::execute_device_option(
                 &worker_request,
                 |id, choice| device.set_option(id, choice),
@@ -157,9 +158,35 @@ impl App {
 
     fn device_option_pending(&self) -> bool {
         let m = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        matches!(
-            m.ui.device_option_update,
-            crate::state::DeviceOptionUpdate::Pending { .. }
+        m.ui.device_option_update.is_pending()
+    }
+
+    fn is_option_quit_key(key: KeyEvent) -> bool {
+        matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q'))
+            || matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
+                && key.modifiers.contains(KeyModifiers::CONTROL)
+    }
+
+    fn request_pending_option_quit(&self) -> bool {
+        let mut m = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        let forced = m.ui.device_option_update.request_quit();
+        if !forced {
+            m.push_log(
+                "Waiting for device option update; Q/Ctrl-C again forces quit without saving"
+                    .to_string(),
+            );
+        }
+        forced
+    }
+
+    fn forced_option_quit_error(&self) -> io::Error {
+        // A backend destructor can block. Leak one owner on this process-exit
+        // path so App teardown and worker completion cannot run that destructor.
+        if let Some(device) = self.device.as_ref().cloned() {
+            std::mem::forget(device);
+        }
+        io::Error::other(
+            "Forced quit while a device option update is still running; device state is uncertain and settings were not saved",
         )
     }
 
@@ -246,7 +273,7 @@ impl App {
                 f.render_widget(ratatui::widgets::Clear, area);
                 ui::menu::render(f, area, &m, self.engine.menu(), &menu_state, &frame_theme);
             }
-            if m.ui.quit_after_device_option {
+            if m.ui.device_option_update.quit_requested() {
                 let full = f.size();
                 let area = ratatui::layout::Rect::new(
                     full.x,
@@ -256,8 +283,10 @@ impl App {
                 );
                 f.render_widget(ratatui::widgets::Clear, area);
                 f.render_widget(
-                    ratatui::widgets::Paragraph::new(" Waiting for device before quit")
-                        .style(ratatui::style::Style::default().fg(frame_theme.status_warn)),
+                    ratatui::widgets::Paragraph::new(
+                        " Waiting for device; Q/Ctrl-C again forces quit without saving",
+                    )
+                    .style(ratatui::style::Style::default().fg(frame_theme.status_warn)),
                     area,
                 );
             }
@@ -304,14 +333,12 @@ impl App {
     }
 
     fn spawn_device_option_task(
-        request: DeviceOptionRequest,
         tx: std::sync::mpsc::Sender<AppEvent>,
         apply: impl FnOnce() -> anyhow::Result<Vec<hardware::DeviceOption>> + Send + 'static,
     ) {
         std::thread::spawn(move || {
             let completion = DeviceOptionCompletion {
-                request,
-                result: apply().map_err(|error| error.to_string()),
+                result: apply().map_err(|error| format!("{error:#}")),
             };
             let _ = tx.send(AppEvent::DeviceOptionComplete(completion));
         });
@@ -431,82 +458,234 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hardware::{DeviceCapabilities, DeviceInfo, RateSet};
     use crate::state::DeviceOptionUpdate;
     use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{mpsc, Arc, Mutex};
 
-    /// Quitting must give the tuner back before the config is written.
-    ///
-    /// `save_config` persists `radio.frequency`, and while a sweep is running
-    /// that field holds the position the scan has reached, not anything the user
-    /// tuned. The ordering of the two calls is the whole of the fix, and nothing
-    /// in the type system holds it: both are `&self` methods returning `()`, so
-    /// swapping them or dropping one still compiles and quietly puts the bug
-    /// back. Read as source text for the same reason the dispatch table is.
-    #[test]
-    fn quitting_gives_the_tuner_back_before_saving_the_config() {
-        let body = include_str!("mod.rs")
-            .split_once("fn finish_session(&self) {")
-            .expect("finish_session has been renamed")
-            .1
-            .split_once("\n    fn ")
-            .expect("finish_session no longer ends")
-            .0;
-        let restore = body.find("self.restore_sweep_tuning()").expect(
-            "quitting no longer ends the sweep, so save_config writes out \
-             whichever position the scan was parked on as the tuned frequency",
-        );
-        let save = body
-            .find("self.save_config()")
-            .expect("finish_session no longer saves the config");
-        assert!(
-            restore < save,
-            "restore_sweep_tuning must run before save_config, or the config \
-             still records the scan position"
-        );
+    struct QuitDevice {
+        caps: DeviceCapabilities,
+        tuned_hz: AtomicU64,
+        tune_calls: AtomicUsize,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl QuitDevice {
+        fn new(caps: DeviceCapabilities) -> Self {
+            Self {
+                caps,
+                tuned_hz: AtomicU64::new(0),
+                tune_calls: AtomicUsize::new(0),
+                drops: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl Drop for QuitDevice {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    impl SdrDevice for QuitDevice {
+        fn capabilities(&self) -> &DeviceCapabilities {
+            &self.caps
+        }
+
+        fn info(&self) -> DeviceInfo {
+            DeviceInfo::default()
+        }
+
+        fn start_rx(&self, _ctx: Arc<RxContext>) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop_rx(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn is_streaming(&self) -> bool {
+            false
+        }
+
+        fn set_frequency(&self, hz: u64) -> anyhow::Result<()> {
+            self.tuned_hz.store(hz, Ordering::Relaxed);
+            self.tune_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn set_sample_rate(&self, hz: f64) -> anyhow::Result<RateSet> {
+            Ok(RateSet::new(hz, Some(hz), 0))
+        }
+
+        fn set_lna_gain(&self, _db: u32) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn pending_request() -> DeviceOptionRequest {
+        DeviceOptionRequest {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choice: "Wide".into(),
+        }
+    }
+
+    fn quit_test_app() -> (
+        App,
+        mpsc::Sender<AppEvent>,
+        Arc<QuitDevice>,
+        std::path::PathBuf,
+    ) {
+        static NEXT_PATH: AtomicUsize = AtomicUsize::new(0);
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        {
+            let mut m = state.lock().unwrap();
+            m.radio.frequency = 200_000_000;
+            m.sweep.pre_sweep_hz = Some(100_000_000);
+            m.ui.device_option_update = DeviceOptionUpdate::Pending {
+                request: pending_request(),
+                quit_requested: false,
+            };
+        }
+        let device = Arc::new(QuitDevice::new(state.lock().unwrap().caps.as_ref().clone()));
+        let path = std::env::temp_dir().join(format!(
+            "sdrtop-option-quit-{}-{}.toml",
+            std::process::id(),
+            NEXT_PATH.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mut app = App::assemble(
+            AppConfig::default(),
+            Some(path.clone()),
+            state,
+            Some(device.clone()),
+            None,
+            None,
+        )
+        .unwrap();
+        let (tx, rx) = mpsc::channel();
+        app.events = EventStream::from_channel(tx.clone(), rx);
+        (app, tx, device, path)
     }
 
     #[test]
-    fn quitting_waits_for_a_pending_device_option() {
-        let run = include_str!("mod.rs")
-            .split_once("pub fn run")
-            .expect("App::run has been renamed")
-            .1
-            .split_once("\n    fn start_device_option")
-            .expect("App::run no longer ends before option startup")
-            .0;
-        let quit = run
-            .split_once("KeyAction::Quit => {")
-            .expect("the quit arm has been renamed")
-            .1
-            .split_once("KeyAction::Continue")
-            .expect("the quit arm no longer ends")
-            .0;
-        assert!(quit.contains("self.device_option_pending()"));
-        assert!(quit.contains("quit_requested = true"));
-        assert!(quit.contains("self.finish_session()"));
-        let completed = run
-            .split_once("AppEvent::DeviceOptionComplete(completion) => {")
-            .expect("the option completion arm is missing")
-            .1;
-        assert!(completed.contains("quit_requested && !self.device_option_pending()"));
-        assert!(completed.contains("self.finish_session()"));
+    fn first_quit_waits_for_success_then_restores_before_saving() {
+        let (mut app, tx, device, path) = quit_test_app();
+        tx.send(AppEvent::Key(KeyEvent::from(KeyCode::Char('q'))))
+            .unwrap();
+        tx.send(AppEvent::DeviceOptionComplete(DeviceOptionCompletion {
+            result: Ok(vec![hardware::DeviceOption {
+                id: "bandwidth".into(),
+                label: "Bandwidth".into(),
+                choices: vec!["Narrow".into(), "Wide".into()],
+                selected_choice: "Wide".into(),
+            }]),
+        }))
+        .unwrap();
+        let mut terminal = Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+
+        app.run(&mut terminal).unwrap();
+
+        assert_eq!(device.tune_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(device.tuned_hz.load(Ordering::Relaxed), 100_000_000);
+        assert_eq!(
+            AppConfig::load_or_default(&path).radio.frequency_hz,
+            100_000_000
+        );
+        let m = app.state.lock().unwrap();
+        assert_eq!(m.device_options[0].selected_choice, "Wide");
+        assert!(matches!(
+            m.ui.device_option_update,
+            DeviceOptionUpdate::Idle
+        ));
+        assert!(m
+            .ui
+            .log
+            .back()
+            .is_some_and(|entry| entry.text.contains("Bandwidth set to Wide")));
+        drop(m);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn first_quit_also_waits_for_failure_before_orderly_finish() {
+        let (mut app, tx, device, path) = quit_test_app();
+        tx.send(AppEvent::Key(KeyEvent::from(KeyCode::Char('q'))))
+            .unwrap();
+        tx.send(AppEvent::DeviceOptionComplete(DeviceOptionCompletion {
+            result: Err("device rejected choice".into()),
+        }))
+        .unwrap();
+        let mut terminal = Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+
+        app.run(&mut terminal).unwrap();
+
+        assert_eq!(device.tune_calls.load(Ordering::Relaxed), 1);
+        assert!(path.exists());
+        let m = app.state.lock().unwrap();
+        assert!(matches!(
+            &m.ui.device_option_update,
+            DeviceOptionUpdate::Failed { id } if id == "bandwidth"
+        ));
+        assert!(m.ui.log.back().is_some_and(|entry| entry
+            .text
+            .contains("Bandwidth error: device rejected choice")));
+        drop(m);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn second_quit_or_control_c_escapes_without_restore_or_save() {
+        let escapes = [
+            KeyEvent::from(KeyCode::Char('q')),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        ];
+        for escape in escapes {
+            let (mut app, tx, device, path) = quit_test_app();
+            tx.send(AppEvent::Key(KeyEvent::from(KeyCode::Char('q'))))
+                .unwrap();
+            tx.send(AppEvent::Key(escape)).unwrap();
+            let mut terminal = Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+
+            let error = app.run(&mut terminal).unwrap_err();
+
+            assert!(error.to_string().contains("device state is uncertain"));
+            assert!(error.to_string().contains("settings were not saved"));
+            assert_eq!(device.tune_calls.load(Ordering::Relaxed), 0);
+            assert!(!path.exists());
+            assert!(
+                app.state
+                    .lock()
+                    .unwrap()
+                    .ui
+                    .device_option_update
+                    .is_pending(),
+                "forced exit must not pretend the worker was cancelled"
+            );
+            let drops = Arc::clone(&device.drops);
+            drop(app);
+            drop(device);
+            assert_eq!(
+                drops.load(Ordering::Relaxed),
+                0,
+                "the retained device owner must suppress backend Drop"
+            );
+        }
     }
 
     #[test]
     fn slow_device_option_work_runs_off_the_event_thread() {
         let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
         let request = DeviceOptionRequest {
-            request_id: 7,
             id: "bandwidth".into(),
             label: "Bandwidth".into(),
             choice: "Wide".into(),
         };
         state.lock().unwrap().ui.device_option_update = DeviceOptionUpdate::Pending {
-            request_id: request.request_id,
-            id: request.id.clone(),
-            label: request.label.clone(),
-            choice: request.choice.clone(),
+            request: request.clone(),
+            quit_requested: false,
         };
         let (event_tx, event_rx) = mpsc::channel();
         let (started_tx, started_rx) = mpsc::channel();
@@ -514,7 +693,7 @@ mod tests {
         let worker_state = Arc::clone(&state);
         let worker_request = request.clone();
 
-        App::spawn_device_option_task(request, event_tx, move || {
+        App::spawn_device_option_task(event_tx, move || {
             App::execute_device_option(
                 &worker_request,
                 |_, _| {
@@ -574,7 +753,6 @@ mod tests {
     #[test]
     fn failed_device_option_set_does_not_refresh() {
         let request = DeviceOptionRequest {
-            request_id: 1,
             id: "bandwidth".into(),
             label: "Bandwidth".into(),
             choice: "Wide".into(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use ratatui::{backend::Backend, Terminal};
 
 use crate::config::{AppConfig, DisplayConfig, RadioConfig};
-use crate::event::{AppEvent, EventStream};
+use crate::event::{AppEvent, DeviceOptionCompletion, DeviceOptionRequest, EventStream};
 use crate::hardware::{self, RxContext, SdrDevice};
 use crate::state::SdrMetrics;
 use crate::ui;
@@ -76,6 +76,7 @@ impl App {
     pub fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
         const FRAME_DURATION: Duration = Duration::from_millis(33);
         let mut last_draw = Instant::now();
+        let mut quit_requested = false;
 
         // Repaint from a clean slate: the device selector and any backend chatter
         // during open may have left the alternate screen dirty before we get here.
@@ -85,6 +86,9 @@ impl App {
         loop {
             let needs_redraw = match self.events.recv() {
                 AppEvent::Key(key) => {
+                    if quit_requested {
+                        continue;
+                    }
                     match input::handle_key(
                         key,
                         &self.state,
@@ -94,16 +98,32 @@ impl App {
                         &self.focus_keys,
                     ) {
                         input::KeyAction::Quit => {
-                            self.restore_noise_sweep();
-                            self.restore_sweep_tuning();
-                            self.save_config();
-                            return Ok(());
+                            if self.device_option_pending() {
+                                quit_requested = true;
+                                let mut m =
+                                    self.state.lock().unwrap_or_else(|error| error.into_inner());
+                                m.ui.quit_after_device_option = true;
+                            } else {
+                                self.finish_session();
+                                return Ok(());
+                            }
                         }
                         input::KeyAction::Continue => {}
+                        input::KeyAction::ApplyDeviceOption(request) => {
+                            self.start_device_option(request);
+                        }
                     }
                     last_draw.elapsed() >= FRAME_DURATION
                 }
                 AppEvent::Tick => true,
+                AppEvent::DeviceOptionComplete(completion) => {
+                    input::complete_device_option(&self.state, completion);
+                    if quit_requested && !self.device_option_pending() {
+                        self.finish_session();
+                        return Ok(());
+                    }
+                    true
+                }
             };
 
             if needs_redraw {
@@ -111,6 +131,42 @@ impl App {
                 last_draw = Instant::now();
             }
         }
+    }
+
+    fn start_device_option(&self, request: DeviceOptionRequest) {
+        let Some(device) = self.device.as_ref().cloned() else {
+            input::complete_device_option(
+                &self.state,
+                DeviceOptionCompletion {
+                    request,
+                    result: Err("device is unavailable".to_string()),
+                },
+            );
+            return;
+        };
+        let tx = self.events.sender();
+        let worker_request = request.clone();
+        Self::spawn_device_option_task(request, tx, move || {
+            Self::execute_device_option(
+                &worker_request,
+                |id, choice| device.set_option(id, choice),
+                || device.options(),
+            )
+        });
+    }
+
+    fn device_option_pending(&self) -> bool {
+        let m = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        matches!(
+            m.ui.device_option_update,
+            crate::state::DeviceOptionUpdate::Pending { .. }
+        )
+    }
+
+    fn finish_session(&self) {
+        self.restore_noise_sweep();
+        self.restore_sweep_tuning();
+        self.save_config();
     }
 
     fn draw<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
@@ -190,12 +246,28 @@ impl App {
                 f.render_widget(ratatui::widgets::Clear, area);
                 ui::menu::render(f, area, &m, self.engine.menu(), &menu_state, &frame_theme);
             }
+            if m.ui.quit_after_device_option {
+                let full = f.size();
+                let area = ratatui::layout::Rect::new(
+                    full.x,
+                    full.y + full.height.saturating_sub(1),
+                    full.width,
+                    1,
+                );
+                f.render_widget(ratatui::widgets::Clear, area);
+                f.render_widget(
+                    ratatui::widgets::Paragraph::new(" Waiting for device before quit")
+                        .style(ratatui::style::Style::default().fg(frame_theme.status_warn)),
+                    area,
+                );
+            }
         })?;
         // The deck is behind the menu from the moment it has been drawn once
         // without one in front of it.
         if m.ui.menu.is_none() {
             self.deck_shown = true;
         }
+
         Ok(())
     }
 
@@ -229,6 +301,29 @@ impl App {
         if let Some(g) = m.radio.gains.get_mut(idx) {
             *g = db;
         }
+    }
+
+    fn spawn_device_option_task(
+        request: DeviceOptionRequest,
+        tx: std::sync::mpsc::Sender<AppEvent>,
+        apply: impl FnOnce() -> anyhow::Result<Vec<hardware::DeviceOption>> + Send + 'static,
+    ) {
+        std::thread::spawn(move || {
+            let completion = DeviceOptionCompletion {
+                request,
+                result: apply().map_err(|error| error.to_string()),
+            };
+            let _ = tx.send(AppEvent::DeviceOptionComplete(completion));
+        });
+    }
+
+    fn execute_device_option(
+        request: &DeviceOptionRequest,
+        set: impl FnOnce(&str, &str) -> anyhow::Result<()>,
+        refresh: impl FnOnce() -> Vec<hardware::DeviceOption>,
+    ) -> anyhow::Result<Vec<hardware::DeviceOption>> {
+        set(&request.id, &request.choice)?;
+        Ok(refresh())
     }
 
     /// Put the tuner back before the app goes away.
@@ -335,6 +430,11 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::state::DeviceOptionUpdate;
+    use std::cell::Cell;
+    use std::sync::{mpsc, Arc, Mutex};
+
     /// Quitting must give the tuner back before the config is written.
     ///
     /// `save_config` persists `radio.frequency`, and while a sweep is running
@@ -345,25 +445,153 @@ mod tests {
     /// back. Read as source text for the same reason the dispatch table is.
     #[test]
     fn quitting_gives_the_tuner_back_before_saving_the_config() {
-        let arm = include_str!("mod.rs")
-            .split_once("KeyAction::Quit => {")
-            .expect("the quit arm has been renamed")
+        let body = include_str!("mod.rs")
+            .split_once("fn finish_session(&self) {")
+            .expect("finish_session has been renamed")
             .1
-            .split_once("return Ok(());")
-            .expect("the quit arm no longer returns")
+            .split_once("\n    fn ")
+            .expect("finish_session no longer ends")
             .0;
-        let restore = arm.find("self.restore_sweep_tuning()").expect(
+        let restore = body.find("self.restore_sweep_tuning()").expect(
             "quitting no longer ends the sweep, so save_config writes out \
              whichever position the scan was parked on as the tuned frequency",
         );
-        let save = arm
+        let save = body
             .find("self.save_config()")
-            .expect("the quit arm no longer saves the config");
+            .expect("finish_session no longer saves the config");
         assert!(
             restore < save,
             "restore_sweep_tuning must run before save_config, or the config \
              still records the scan position"
         );
+    }
+
+    #[test]
+    fn quitting_waits_for_a_pending_device_option() {
+        let run = include_str!("mod.rs")
+            .split_once("pub fn run")
+            .expect("App::run has been renamed")
+            .1
+            .split_once("\n    fn start_device_option")
+            .expect("App::run no longer ends before option startup")
+            .0;
+        let quit = run
+            .split_once("KeyAction::Quit => {")
+            .expect("the quit arm has been renamed")
+            .1
+            .split_once("KeyAction::Continue")
+            .expect("the quit arm no longer ends")
+            .0;
+        assert!(quit.contains("self.device_option_pending()"));
+        assert!(quit.contains("quit_requested = true"));
+        assert!(quit.contains("self.finish_session()"));
+        let completed = run
+            .split_once("AppEvent::DeviceOptionComplete(completion) => {")
+            .expect("the option completion arm is missing")
+            .1;
+        assert!(completed.contains("quit_requested && !self.device_option_pending()"));
+        assert!(completed.contains("self.finish_session()"));
+    }
+
+    #[test]
+    fn slow_device_option_work_runs_off_the_event_thread() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        let request = DeviceOptionRequest {
+            request_id: 7,
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choice: "Wide".into(),
+        };
+        state.lock().unwrap().ui.device_option_update = DeviceOptionUpdate::Pending {
+            request_id: request.request_id,
+            id: request.id.clone(),
+            label: request.label.clone(),
+            choice: request.choice.clone(),
+        };
+        let (event_tx, event_rx) = mpsc::channel();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let worker_state = Arc::clone(&state);
+        let worker_request = request.clone();
+
+        App::spawn_device_option_task(request, event_tx, move || {
+            App::execute_device_option(
+                &worker_request,
+                |_, _| {
+                    assert!(
+                        worker_state.try_lock().is_ok(),
+                        "state was locked during set_option"
+                    );
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Ok(())
+                },
+                || {
+                    assert!(
+                        worker_state.try_lock().is_ok(),
+                        "state was locked during options"
+                    );
+                    vec![
+                        hardware::DeviceOption {
+                            id: "bandwidth".into(),
+                            label: "Bandwidth".into(),
+                            choices: vec!["Narrow".into(), "Wide".into()],
+                            selected_choice: "Wide".into(),
+                        },
+                        hardware::DeviceOption {
+                            id: "attenuation".into(),
+                            label: "Attenuation".into(),
+                            choices: vec!["0 dB".into(), "10 dB".into()],
+                            selected_choice: "0 dB".into(),
+                        },
+                    ]
+                },
+            )
+        });
+
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("option worker did not start");
+        assert!(
+            state.try_lock().is_ok(),
+            "event thread cannot read state while the backend waits"
+        );
+        release_tx.send(()).unwrap();
+        let AppEvent::DeviceOptionComplete(completion) = event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("option worker did not complete")
+        else {
+            panic!("worker sent the wrong event");
+        };
+        input::complete_device_option(&state, completion);
+
+        let m = state.lock().unwrap();
+        assert_eq!(m.device_options.len(), 2);
+        assert_eq!(m.device_options[0].selected_choice, "Wide");
+        assert_eq!(m.device_options[1].selected_choice, "0 dB");
+    }
+
+    #[test]
+    fn failed_device_option_set_does_not_refresh() {
+        let request = DeviceOptionRequest {
+            request_id: 1,
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choice: "Wide".into(),
+        };
+        let refreshed = Cell::new(false);
+
+        let result = App::execute_device_option(
+            &request,
+            |_, _| anyhow::bail!("device rejected choice"),
+            || {
+                refreshed.set(true);
+                Vec::new()
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(!refreshed.get());
     }
 
     /// **Every scanner that parks the radio gives the tuner back on quit.**

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,45 +2,68 @@
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
 use crossterm::event::{self, Event, KeyEvent};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::Duration;
+
+use crate::hardware::DeviceOption;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeviceOptionRequest {
+    pub request_id: u64,
+    pub id: String,
+    pub label: String,
+    pub choice: String,
+}
+
+#[derive(Debug)]
+pub struct DeviceOptionCompletion {
+    pub request: DeviceOptionRequest,
+    pub result: Result<Vec<DeviceOption>, String>,
+}
 
 pub enum AppEvent {
     Key(KeyEvent),
     Tick,
+    DeviceOptionComplete(DeviceOptionCompletion),
 }
 
 pub struct EventStream {
+    tx: Sender<AppEvent>,
     rx: Receiver<AppEvent>,
 }
 
 impl EventStream {
     pub fn new(tick_rate: Duration) -> Self {
         let (tx, rx) = mpsc::channel();
+        let event_tx = tx.clone();
         thread::spawn(move || loop {
             if event::poll(tick_rate).unwrap_or(false) {
                 match event::read() {
                     Ok(Event::Key(key)) => {
-                        if tx.send(AppEvent::Key(key)).is_err() {
+                        if event_tx.send(AppEvent::Key(key)).is_err() {
                             break;
                         }
                     }
                     Ok(Event::Resize(..))
                         // Trigger an immediate redraw so preferred_height re-runs with the new width.
-                        if tx.send(AppEvent::Tick).is_err() => {
+                        if event_tx.send(AppEvent::Tick).is_err() => {
                             break;
                         }
                     _ => {}
                 }
-            } else if tx.send(AppEvent::Tick).is_err() {
+            } else if event_tx.send(AppEvent::Tick).is_err() {
                 break;
             }
         });
-        Self { rx }
+        Self { tx, rx }
     }
 
     pub fn recv(&self) -> AppEvent {
         self.rx.recv().unwrap_or(AppEvent::Tick)
+    }
+
+    pub fn sender(&self) -> Sender<AppEvent> {
+        self.tx.clone()
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,7 +10,6 @@ use crate::hardware::DeviceOption;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeviceOptionRequest {
-    pub request_id: u64,
     pub id: String,
     pub label: String,
     pub choice: String,
@@ -18,7 +17,6 @@ pub struct DeviceOptionRequest {
 
 #[derive(Debug)]
 pub struct DeviceOptionCompletion {
-    pub request: DeviceOptionRequest,
     pub result: Result<Vec<DeviceOption>, String>,
 }
 
@@ -65,5 +63,10 @@ impl EventStream {
 
     pub fn sender(&self) -> Sender<AppEvent> {
         self.tx.clone()
+    }
+
+    #[cfg(test)]
+    pub fn from_channel(tx: Sender<AppEvent>, rx: Receiver<AppEvent>) -> Self {
+        Self { tx, rx }
     }
 }

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -30,7 +30,8 @@ pub use discovery::{list_all_devices, open_device, DeviceKind, DeviceListing};
 #[cfg(test)]
 pub(crate) use traits::RateSet;
 pub use traits::{
-    AcquisitionKind, Boost, DeliveryModel, DeviceCapabilities, DeviceInfo, DirectSweepConfig,
-    FeedHealth, GainModel, LevelUnit, PowerTrace, PowerTraceTarget, RxContext, SampleFormat,
-    SampleGeometry, SdrDevice, SoftwareStack, StageSpec, StreamBlock, IQ_TRACE_STALE_MS,
+    AcquisitionKind, Boost, DeliveryModel, DeviceCapabilities, DeviceInfo, DeviceOption,
+    DirectSweepConfig, FeedHealth, GainModel, LevelUnit, PowerTrace, PowerTraceTarget, RxContext,
+    SampleFormat, SampleGeometry, SdrDevice, SoftwareStack, StageSpec, StreamBlock,
+    IQ_TRACE_STALE_MS,
 };

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -35,3 +35,66 @@ pub use traits::{
     SampleFormat, SampleGeometry, SdrDevice, SoftwareStack, StageSpec, StreamBlock,
     IQ_TRACE_STALE_MS,
 };
+
+pub(crate) fn sanitize_device_options(
+    options: Vec<DeviceOption>,
+) -> (Vec<DeviceOption>, Vec<String>) {
+    let mut valid = Vec::with_capacity(options.len());
+    let mut notes = Vec::new();
+    for mut option in options {
+        let name = if option.label.is_empty() {
+            option.id.as_str()
+        } else {
+            option.label.as_str()
+        };
+        let Some(first) = option.choices.first().cloned() else {
+            notes.push(format!(
+                "Warning: device option '{name}' has no choices. Hiding it."
+            ));
+            continue;
+        };
+        if !option.choices.contains(&option.selected_choice) {
+            notes.push(format!(
+                "Warning: device option '{name}' selected unavailable choice '{}'. Using '{first}'.",
+                option.selected_choice
+            ));
+            option.selected_choice = first;
+        }
+        valid.push(option);
+    }
+    (valid, notes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn option(choices: &[&str], selected: &str) -> DeviceOption {
+        DeviceOption {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choices: choices.iter().map(|choice| (*choice).into()).collect(),
+            selected_choice: selected.into(),
+        }
+    }
+
+    #[test]
+    fn options_without_choices_are_hidden_and_reported() {
+        let (options, notes) = sanitize_device_options(vec![option(&[], "")]);
+
+        assert!(options.is_empty());
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("Bandwidth"));
+        assert!(notes[0].contains("no choices"));
+    }
+
+    #[test]
+    fn an_unavailable_selected_choice_uses_the_first_choice() {
+        let (options, notes) =
+            sanitize_device_options(vec![option(&["Narrow", "Wide"], "Missing")]);
+
+        assert_eq!(options[0].selected_choice, "Narrow");
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("unavailable choice"));
+    }
+}

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -36,42 +36,38 @@ pub use traits::{
     IQ_TRACE_STALE_MS,
 };
 
-pub(crate) fn sanitize_device_options(
-    options: Vec<DeviceOption>,
-) -> (Vec<DeviceOption>, Vec<String>) {
-    let mut valid = Vec::with_capacity(options.len());
-    let mut notes = Vec::new();
-    for mut option in options {
-        let name = if option.label.is_empty() {
-            option.id.as_str()
-        } else {
-            option.label.as_str()
-        };
-        let Some(first) = option.choices.first().cloned() else {
-            notes.push(format!(
-                "Warning: device option '{name}' has no choices. Hiding it."
-            ));
-            continue;
-        };
-        if !option.choices.contains(&option.selected_choice) {
-            notes.push(format!(
-                "Warning: device option '{name}' selected unavailable choice '{}'. Using '{first}'.",
-                option.selected_choice
-            ));
-            option.selected_choice = first;
+pub(crate) fn debug_assert_device_options(options: &[DeviceOption]) {
+    #[cfg(debug_assertions)]
+    {
+        let mut ids = std::collections::HashSet::with_capacity(options.len());
+        for option in options {
+            debug_assert!(
+                !option.choices.is_empty(),
+                "device option '{}' must advertise a choice",
+                option.id
+            );
+            debug_assert!(
+                option.choices.contains(&option.selected_choice),
+                "device option '{}' selected an unavailable choice",
+                option.id
+            );
+            debug_assert!(
+                ids.insert(option.id.as_str()),
+                "device option IDs must be unique within a snapshot"
+            );
         }
-        valid.push(option);
     }
-    (valid, notes)
+    #[cfg(not(debug_assertions))]
+    let _ = options;
 }
 
-#[cfg(test)]
+#[cfg(all(test, debug_assertions))]
 mod tests {
     use super::*;
 
-    fn option(choices: &[&str], selected: &str) -> DeviceOption {
+    fn option(id: &str, choices: &[&str], selected: &str) -> DeviceOption {
         DeviceOption {
-            id: "bandwidth".into(),
+            id: id.into(),
             label: "Bandwidth".into(),
             choices: choices.iter().map(|choice| (*choice).into()).collect(),
             selected_choice: selected.into(),
@@ -79,22 +75,23 @@ mod tests {
     }
 
     #[test]
-    fn options_without_choices_are_hidden_and_reported() {
-        let (options, notes) = sanitize_device_options(vec![option(&[], "")]);
-
-        assert!(options.is_empty());
-        assert_eq!(notes.len(), 1);
-        assert!(notes[0].contains("Bandwidth"));
-        assert!(notes[0].contains("no choices"));
+    #[should_panic(expected = "must advertise a choice")]
+    fn option_contract_rejects_an_empty_choice_list() {
+        debug_assert_device_options(&[option("bandwidth", &[], "")]);
     }
 
     #[test]
-    fn an_unavailable_selected_choice_uses_the_first_choice() {
-        let (options, notes) =
-            sanitize_device_options(vec![option(&["Narrow", "Wide"], "Missing")]);
+    #[should_panic(expected = "selected an unavailable choice")]
+    fn option_contract_rejects_an_unavailable_selection() {
+        debug_assert_device_options(&[option("bandwidth", &["Narrow", "Wide"], "Missing")]);
+    }
 
-        assert_eq!(options[0].selected_choice, "Narrow");
-        assert_eq!(notes.len(), 1);
-        assert!(notes[0].contains("unavailable choice"));
+    #[test]
+    #[should_panic(expected = "must be unique")]
+    fn option_contract_rejects_duplicate_ids() {
+        debug_assert_device_options(&[
+            option("bandwidth", &["Narrow"], "Narrow"),
+            option("bandwidth", &["Wide"], "Wide"),
+        ]);
     }
 }

--- a/src/hardware/traits.rs
+++ b/src/hardware/traits.rs
@@ -66,6 +66,10 @@ pub struct DirectSweepConfig {
 }
 
 /// One configurable choice exposed by a device.
+///
+/// Every snapshot must use unique IDs. Each option must advertise at least one
+/// choice. `selected_choice` must be one of those choices. Choice strings are
+/// stable values passed back to [`SdrDevice::set_option`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeviceOption {
     pub id: String,

--- a/src/hardware/traits.rs
+++ b/src/hardware/traits.rs
@@ -65,6 +65,15 @@ pub struct DirectSweepConfig {
     pub generation: u64,
 }
 
+/// One configurable choice exposed by a device.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeviceOption {
+    pub id: String,
+    pub label: String,
+    pub choices: Vec<String>,
+    pub selected_choice: String,
+}
+
 /// How raw USB bytes encode each I/Q component.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SampleFormat {
@@ -962,6 +971,14 @@ pub trait SdrDevice: Send + Sync {
 
     fn set_direct_sweep(&self, _config: Option<DirectSweepConfig>) -> anyhow::Result<()> {
         anyhow::bail!("this backend does not support direct power sweeps")
+    }
+
+    fn options(&self) -> Vec<DeviceOption> {
+        Vec::new()
+    }
+
+    fn set_option(&self, _id: &str, _choice: &str) -> anyhow::Result<()> {
+        anyhow::bail!("this backend has no device options")
     }
 
     /// Set one stage by position, exactly.

--- a/src/state/fixture.rs
+++ b/src/state/fixture.rs
@@ -108,6 +108,7 @@ impl SdrMetrics {
             demod: DemodState::default(),
             net: crate::state::NetState::default(),
             caps,
+            device_options: Vec::new(),
             acc: Accumulators::default(),
         }
     }

--- a/src/state/fixture.rs
+++ b/src/state/fixture.rs
@@ -108,7 +108,7 @@ impl SdrMetrics {
             demod: DemodState::default(),
             net: crate::state::NetState::default(),
             caps,
-            device_options: Vec::new(),
+            device_options: Arc::new(Vec::new()),
             acc: Accumulators::default(),
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -81,7 +81,7 @@ pub struct SdrMetrics {
     /// rendering (gain model, BB filter / Friis applicability, ranges). Shared
     /// (Arc) so the per-frame `SdrMetrics` clone stays cheap.
     pub caps: std::sync::Arc<crate::hardware::DeviceCapabilities>,
-    pub device_options: Vec<crate::hardware::DeviceOption>,
+    pub device_options: std::sync::Arc<Vec<crate::hardware::DeviceOption>>,
     pub(crate) acc: Accumulators,
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -41,8 +41,8 @@ pub use sweep::{SweepConfig, SweepFrame, SweepState, SWEEP_SETTLING_MS};
 pub use system::SystemState;
 pub use timing::{TimingCause, TimingQuality, TimingState, HACKRF_SAMPLES_PER_TRANSFER};
 pub use ui::{
-    active_recall_slot, recall_from_hz, recall_to_hz, InputMode, LogEntry, LogLevel, MenuPane,
-    MenuState, RailMode, UiState, RECALL_SLOTS,
+    active_recall_slot, recall_from_hz, recall_to_hz, DeviceOptionUpdate, InputMode, LogEntry,
+    LogLevel, MenuPane, MenuState, RailMode, UiState, RECALL_SLOTS,
 };
 pub use waterfall::{BinAxis, BinWindow, FftFrame, WaterfallState, WATERFALL_MIN_ROWS};
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -81,6 +81,7 @@ pub struct SdrMetrics {
     /// rendering (gain model, BB filter / Friis applicability, ranges). Shared
     /// (Arc) so the per-frame `SdrMetrics` clone stays cheap.
     pub caps: std::sync::Arc<crate::hardware::DeviceCapabilities>,
+    pub device_options: Vec<crate::hardware::DeviceOption>,
     pub(crate) acc: Accumulators,
 }
 

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -129,6 +129,29 @@ pub struct LogEntry {
     pub text: Arc<str>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum DeviceOptionUpdate {
+    #[default]
+    Ready,
+    Pending {
+        request_id: u64,
+        id: String,
+        label: String,
+        choice: String,
+    },
+    Completed {
+        request_id: u64,
+        id: String,
+        choice: String,
+    },
+    Error {
+        request_id: u64,
+        id: String,
+        choice: String,
+        message: String,
+    },
+}
+
 #[derive(Clone, PartialEq)]
 pub enum InputMode {
     Normal,
@@ -195,6 +218,9 @@ pub struct UiState {
     /// Where the cursor is while the menu is open, `None` when it is closed.
     /// See [`MenuState`].
     pub menu: Option<MenuState>,
+    pub device_option_update: DeviceOptionUpdate,
+    pub next_device_option_request: u64,
+    pub quit_after_device_option: bool,
 }
 
 /// Which pane the menu's right column is showing.
@@ -328,6 +354,9 @@ impl Default for UiState {
             recall_cursor: 0,
             log_overlay: false,
             menu: None,
+            device_option_update: DeviceOptionUpdate::default(),
+            next_device_option_request: 0,
+            quit_after_device_option: false,
         }
     }
 }

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -132,24 +132,39 @@ pub struct LogEntry {
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub enum DeviceOptionUpdate {
     #[default]
-    Ready,
+    Idle,
     Pending {
-        request_id: u64,
-        id: String,
-        label: String,
-        choice: String,
+        request: crate::event::DeviceOptionRequest,
+        quit_requested: bool,
     },
-    Completed {
-        request_id: u64,
+    Failed {
         id: String,
-        choice: String,
     },
-    Error {
-        request_id: u64,
-        id: String,
-        choice: String,
-        message: String,
-    },
+}
+
+impl DeviceOptionUpdate {
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending { .. })
+    }
+
+    pub fn quit_requested(&self) -> bool {
+        matches!(
+            self,
+            Self::Pending {
+                quit_requested: true,
+                ..
+            }
+        )
+    }
+
+    pub fn request_quit(&mut self) -> bool {
+        let Self::Pending { quit_requested, .. } = self else {
+            return false;
+        };
+        let already_requested = *quit_requested;
+        *quit_requested = true;
+        already_requested
+    }
 }
 
 #[derive(Clone, PartialEq)]
@@ -219,8 +234,6 @@ pub struct UiState {
     /// See [`MenuState`].
     pub menu: Option<MenuState>,
     pub device_option_update: DeviceOptionUpdate,
-    pub next_device_option_request: u64,
-    pub quit_after_device_option: bool,
 }
 
 /// Which pane the menu's right column is showing.
@@ -355,8 +368,6 @@ impl Default for UiState {
             log_overlay: false,
             menu: None,
             device_option_update: DeviceOptionUpdate::default(),
-            next_device_option_request: 0,
-            quit_after_device_option: false,
         }
     }
 }

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -206,9 +206,7 @@ pub enum MenuPane {
     /// The key reference. Replaces the `?` overlay, which had drifted out of
     /// step with the dispatch because nothing checked it.
     Keys,
-    /// Settings. Empty so far, and it says so on screen. The variant exists
-    /// ahead of its first row so that adding one is a row rather than a
-    /// reshuffle of the enum, the column and the dispatch together.
+    /// Settings exposed by the active device.
     Options,
 }
 
@@ -228,11 +226,7 @@ pub struct MenuState {
     pub section: usize,
     pub entry: usize,
     pub pane: MenuPane,
-    /// First visible row of the [`MenuPane::Keys`] list.
-    ///
-    /// Its own field rather than reusing `entry`: the reference is taller than a
-    /// 24 row terminal, so it has to scroll, and one field meaning two things
-    /// depending on the pane is how a cursor ends up somewhere nobody expected.
+    /// Scroll position in Keys or selected row in Options.
     pub scroll: usize,
 }
 

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -223,12 +223,15 @@ mod tests {
     /// the menu is not a panel, so it cannot go through
     /// `PanelRegistry::render_panel` and needs its own harness.
     fn draw(w: u16, h: u16, state: &MenuState) -> Vec<String> {
+        draw_with_metrics(w, h, state, &SdrMetrics::fixture())
+    }
+
+    fn draw_with_metrics(w: u16, h: u16, state: &MenuState, metrics: &SdrMetrics) -> Vec<String> {
         let menu = model::build(&LayoutConfig::default_config().presets);
-        let metrics = SdrMetrics::fixture();
         let theme = crate::Theme::sdr();
         let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
         terminal
-            .draw(|f| render(f, f.size(), &metrics, &menu, state, &theme))
+            .draw(|f| render(f, f.size(), metrics, &menu, state, &theme))
             .unwrap();
         let buf = terminal.backend().buffer().clone();
         (0..h)
@@ -399,6 +402,27 @@ mod tests {
         assert!(all.contains("Settings will live here"), "{all}");
         // And the pane replaces the right column only, the same as Keys.
         assert!(all.contains("Command Rail"), "{all}");
+    }
+
+    #[test]
+    fn a_short_folded_options_pane_keeps_the_selected_option_visible() {
+        let state = MenuState {
+            pane: MenuPane::Options,
+            scroll: 5,
+            ..MenuState::default()
+        };
+        let mut metrics = SdrMetrics::fixture();
+        for index in 0..6 {
+            metrics.device_options.push(crate::hardware::DeviceOption {
+                id: format!("option-{index}"),
+                label: format!("Option {index}"),
+                choices: vec!["Off".into(), "On".into()],
+                selected_choice: "On".into(),
+            });
+        }
+
+        let all = draw_with_metrics(40, 10, &state, &metrics).join("\n");
+        assert!(all.contains("Option 5"), "{all}");
     }
 
     /// Small enough that nothing sensible fits. The requirement is only that it

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -216,6 +216,7 @@ mod tests {
     use super::*;
     use crate::config::LayoutConfig;
     use ratatui::{backend::TestBackend, Terminal};
+    use std::sync::Arc;
 
     /// Render the menu at a fixed size and hand back the buffer as lines.
     ///
@@ -413,7 +414,7 @@ mod tests {
         };
         let mut metrics = SdrMetrics::fixture();
         for index in 0..6 {
-            metrics.device_options.push(crate::hardware::DeviceOption {
+            Arc::make_mut(&mut metrics.device_options).push(crate::hardware::DeviceOption {
                 id: format!("option-{index}"),
                 label: format!("Option {index}"),
                 choices: vec!["Off".into(), "On".into()],

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -15,7 +15,7 @@
 //! - [`sections`]: the left column.
 //! - [`entries`]: the right column, a section's layouts.
 //! - [`keys`]: the right column, the key reference.
-//! - [`options`]: the right column, settings. Empty for now, and honest about it.
+//! - [`options`]: the right column, device settings.
 //!
 //! [`render`] is the orchestrator. It resolves the frame, carves the rows and
 //! columns, and calls each part once. **The parts do not call each other.**
@@ -84,7 +84,7 @@ pub fn render(
         .split(inner);
 
     header(f, rows[0], m, theme);
-    footer(f, rows[2], theme);
+    footer(f, rows[2], state.pane, !m.device_options.is_empty(), theme);
 
     // The cursor is cloned into the frame snapshot and arrives here without the
     // engine, so it is clamped rather than trusted. An out of range index would
@@ -159,7 +159,7 @@ fn right_pane(
     match state.pane {
         MenuPane::Views => entries::render(f, body, &menu.sections[section], cursor, theme),
         MenuPane::Keys => keys::render(f, body, &m.caps, state.scroll, theme),
-        MenuPane::Options => options::render(f, body, theme),
+        MenuPane::Options => options::render(f, body, m, state.scroll, theme),
     }
 }
 
@@ -183,19 +183,30 @@ fn header(f: &mut Frame, area: Rect, m: &SdrMetrics, theme: &crate::Theme) {
 }
 
 /// The keys, in the order the design's "Moving around" table lists them.
-fn footer(f: &mut Frame, area: Rect, theme: &crate::Theme) {
+fn footer(f: &mut Frame, area: Rect, pane: MenuPane, has_options: bool, theme: &crate::Theme) {
     let key = Style::default().fg(theme.border_accent);
     let what = Style::default().fg(theme.label);
     let mut spans = Vec::new();
-    for (k, w) in [
-        ("Tab", "section"),
-        ("\u{2191}\u{2193}", "move"),
-        ("1-9", "open"),
-        ("Enter", "open"),
-        ("Esc", "close"),
-    ] {
+    let bindings: &[(&str, &str)] = if pane == MenuPane::Options && has_options {
+        &[
+            ("Tab", "section"),
+            ("\u{2191}\u{2193}", "option"),
+            ("\u{2190}\u{2192}", "value"),
+            ("Enter", "next"),
+            ("Esc", "close"),
+        ]
+    } else {
+        &[
+            ("Tab", "section"),
+            ("\u{2191}\u{2193}", "move"),
+            ("1-9", "open"),
+            ("Enter", "open"),
+            ("Esc", "close"),
+        ]
+    };
+    for (k, w) in bindings {
         spans.push(Span::styled(format!(" {k} "), key));
-        spans.push(Span::styled(w, what));
+        spans.push(Span::styled(*w, what));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);
 }

--- a/src/ui/menu/options.rs
+++ b/src/ui/menu/options.rs
@@ -131,10 +131,10 @@ fn option_line(
     let choice_width = content_width - label_width;
     let label = fit_cell(&option.label, label_width);
     let shown = match update {
-        DeviceOptionUpdate::Pending { id, choice, .. } if id == &option.id => {
-            format!("{} -> {choice}...", option.selected_choice)
+        DeviceOptionUpdate::Pending { request, .. } if request.id == option.id => {
+            format!("{} -> {}...", option.selected_choice, request.choice)
         }
-        DeviceOptionUpdate::Error { id, .. } if id == &option.id => {
+        DeviceOptionUpdate::Failed { id } if id == &option.id => {
             format!("{} (failed)", option.selected_choice)
         }
         _ => option.selected_choice.clone(),
@@ -197,6 +197,7 @@ pub fn render(f: &mut Frame, area: Rect, m: &SdrMetrics, selected: usize, theme:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     /// The pane's whole job right now is to name itself and admit it is empty,
     /// so both halves are worth pinning.
@@ -237,7 +238,7 @@ mod tests {
     #[test]
     fn options_name_their_current_choices() {
         let mut m = SdrMetrics::fixture();
-        m.device_options.push(crate::hardware::DeviceOption {
+        Arc::make_mut(&mut m.device_options).push(crate::hardware::DeviceOption {
             id: "bandwidth".into(),
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
@@ -256,7 +257,7 @@ mod tests {
     fn the_selected_option_stays_in_a_short_viewport() {
         let mut m = SdrMetrics::fixture();
         for index in 0..6 {
-            m.device_options.push(crate::hardware::DeviceOption {
+            Arc::make_mut(&mut m.device_options).push(crate::hardware::DeviceOption {
                 id: format!("option-{index}"),
                 label: format!("Option {index}"),
                 choices: vec!["Off".into(), "On".into()],
@@ -276,7 +277,7 @@ mod tests {
     #[test]
     fn the_selected_option_uses_the_only_available_row() {
         let mut m = SdrMetrics::fixture();
-        m.device_options.push(crate::hardware::DeviceOption {
+        Arc::make_mut(&mut m.device_options).push(crate::hardware::DeviceOption {
             id: "bandwidth".into(),
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
@@ -295,7 +296,7 @@ mod tests {
     #[test]
     fn backend_text_never_exceeds_the_pane_width() {
         let mut m = SdrMetrics::fixture();
-        m.device_options.push(crate::hardware::DeviceOption {
+        Arc::make_mut(&mut m.device_options).push(crate::hardware::DeviceOption {
             id: "long".into(),
             label: "A device-provided label that is much too long".into(),
             choices: vec!["A device-provided choice that is much too long".into()],
@@ -316,17 +317,19 @@ mod tests {
     #[test]
     fn pending_change_keeps_the_accepted_choice_visible() {
         let mut m = SdrMetrics::fixture();
-        m.device_options.push(crate::hardware::DeviceOption {
+        Arc::make_mut(&mut m.device_options).push(crate::hardware::DeviceOption {
             id: "bandwidth".into(),
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
             selected_choice: "Narrow".into(),
         });
         m.ui.device_option_update = DeviceOptionUpdate::Pending {
-            request_id: 1,
-            id: "bandwidth".into(),
-            label: "Bandwidth".into(),
-            choice: "Wide".into(),
+            request: crate::event::DeviceOptionRequest {
+                id: "bandwidth".into(),
+                label: "Bandwidth".into(),
+                choice: "Wide".into(),
+            },
+            quit_requested: false,
         };
 
         let text = lines(&m, 0, 80, 1, &crate::Theme::sdr())
@@ -340,17 +343,14 @@ mod tests {
     #[test]
     fn failed_change_keeps_the_accepted_choice_visible() {
         let mut m = SdrMetrics::fixture();
-        m.device_options.push(crate::hardware::DeviceOption {
+        Arc::make_mut(&mut m.device_options).push(crate::hardware::DeviceOption {
             id: "bandwidth".into(),
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
             selected_choice: "Narrow".into(),
         });
-        m.ui.device_option_update = DeviceOptionUpdate::Error {
-            request_id: 1,
+        m.ui.device_option_update = DeviceOptionUpdate::Failed {
             id: "bandwidth".into(),
-            choice: "Wide".into(),
-            message: "device rejected choice".into(),
         };
 
         let text = lines(&m, 0, 80, 1, &crate::Theme::sdr())

--- a/src/ui/menu/options.rs
+++ b/src/ui/menu/options.rs
@@ -1,21 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
-//! The menu's right column: settings.
-//!
-//! **Empty on purpose.** Nothing sdrtop can be told is told here yet, and the
-//! pane says so rather than showing an enabled-looking list of things that do
-//! not work. It exists now because the alternative was to cut this seam later,
-//! at the same time as writing the first setting, which is how a one row change
-//! turns into a refactor of the pane, the enum, the column and the dispatch all
-//! at once.
-//!
-//! Two lines and a TODO is the whole screen. Anyone who opens it already knows
-//! what an empty Options pane means, so explaining it at length would be talking
-//! past the reader.
-//!
-//! Draws only, like [`super::entries`] and [`super::keys`]. When the first real
-//! row lands it goes in here and nowhere else.
+//! The menu's right column: settings exposed by the active device.
 
 use ratatui::{
     layout::Rect,
@@ -25,7 +11,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::chrome;
+use crate::{state::SdrMetrics, ui::chrome};
 
 /// The heading. Says what the pane is for, in the future tense, because that is
 /// the only true tense for it right now.
@@ -44,7 +30,7 @@ const TODO: &[&str] = &[
 /// Separate from drawing for the same reason `keys::lines` is: the wrapping is
 /// the only thing here that can be wrong, and it can be checked without a
 /// terminal.
-fn lines(iw: usize, theme: &crate::Theme) -> Vec<Line<'static>> {
+fn empty_lines(iw: usize, theme: &crate::Theme) -> Vec<Line<'static>> {
     let mut out = vec![Line::from("")];
     for row in chrome::wrap(HEADING, iw.saturating_sub(4), 3) {
         out.push(Line::from(Span::styled(
@@ -68,11 +54,110 @@ fn lines(iw: usize, theme: &crate::Theme) -> Vec<Line<'static>> {
     out
 }
 
-pub fn render(f: &mut Frame, area: Rect, theme: &crate::Theme) {
+fn lines(
+    m: &SdrMetrics,
+    selected: usize,
+    iw: usize,
+    height: usize,
+    theme: &crate::Theme,
+) -> Vec<Line<'static>> {
+    if m.device_options.is_empty() {
+        return empty_lines(iw, theme);
+    }
+
+    let selected = selected.min(m.device_options.len() - 1);
+    let visible = height.saturating_sub(3);
+    let first = scroll_offset(selected, m.device_options.len(), visible);
+    let mut out = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            fit_text("  Device options", iw),
+            Style::default()
+                .fg(theme.value_hi)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+    for (index, option) in m
+        .device_options
+        .iter()
+        .enumerate()
+        .skip(first)
+        .take(visible)
+    {
+        let active = index == selected;
+        let marker = if active { "\u{25b8} " } else { "  " };
+        let value_style = Style::default()
+            .fg(if active { theme.value_hi } else { theme.value })
+            .add_modifier(if active {
+                Modifier::BOLD
+            } else {
+                Modifier::empty()
+            });
+        if iw < 7 {
+            out.push(Line::from(Span::styled(
+                fit_text(marker, iw),
+                Style::default().fg(theme.border_accent),
+            )));
+            continue;
+        }
+        let content_width = iw - 7;
+        let label_width = content_width.min(18).min(content_width / 2);
+        let choice_width = content_width - label_width;
+        let label = fit_cell(&option.label, label_width);
+        let choice = fit_text(&option.selected_choice, choice_width);
+        out.push(Line::from(vec![
+            Span::styled(marker, Style::default().fg(theme.border_accent)),
+            Span::styled(label, Style::default().fg(theme.label)),
+            Span::raw(" "),
+            Span::styled(format!("\u{25c0} {choice} \u{25b6}"), value_style),
+        ]));
+    }
+    out
+}
+
+fn scroll_offset(cursor: usize, total: usize, visible: usize) -> usize {
+    if visible == 0 || total <= visible {
+        return 0;
+    }
+    cursor
+        .saturating_sub(visible - 1)
+        .min(total.saturating_sub(visible))
+}
+
+fn fit_cell(text: &str, width: usize) -> String {
+    let mut fitted = fit_text(text, width);
+    fitted.push_str(&" ".repeat(width.saturating_sub(text_width(&fitted))));
+    fitted
+}
+
+fn fit_text(text: &str, width: usize) -> String {
+    let mut fitted = String::new();
+    for character in text.chars() {
+        fitted.push(character);
+        if text_width(&fitted) > width {
+            fitted.pop();
+            break;
+        }
+    }
+    fitted
+}
+
+fn text_width(text: &str) -> usize {
+    Line::from(text).width()
+}
+
+pub fn render(f: &mut Frame, area: Rect, m: &SdrMetrics, selected: usize, theme: &crate::Theme) {
     if area.width == 0 || area.height == 0 {
         return;
     }
-    let all = lines(area.width as usize, theme);
+    let all = lines(
+        m,
+        selected,
+        area.width as usize,
+        area.height as usize,
+        theme,
+    );
     let shown: Vec<Line> = all.into_iter().take(area.height as usize).collect();
     f.render_widget(Paragraph::new(shown), area);
 }
@@ -85,7 +170,7 @@ mod tests {
     /// so both halves are worth pinning.
     #[test]
     fn the_empty_state_names_itself_and_admits_it() {
-        let text: String = lines(60, &crate::Theme::sdr())
+        let text: String = lines(&SdrMetrics::fixture(), 0, 60, 20, &crate::Theme::sdr())
             .iter()
             .map(|l| l.to_string())
             .collect::<Vec<_>>()
@@ -100,7 +185,7 @@ mod tests {
     #[test]
     fn every_row_fits_the_pane() {
         for iw in [28, 40, 44, 60, 100] {
-            for line in lines(iw, &crate::Theme::sdr()) {
+            for line in empty_lines(iw, &crate::Theme::sdr()) {
                 assert!(
                     line.width() <= iw,
                     "a {}-wide row does not fit {iw} columns: {line:?}",
@@ -115,5 +200,65 @@ mod tests {
     fn the_copy_uses_no_em_dashes() {
         assert!(!HEADING.contains('\u{2014}'));
         assert!(TODO.iter().all(|t| !t.contains('\u{2014}')));
+    }
+
+    #[test]
+    fn options_name_their_current_choices() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options.push(crate::hardware::DeviceOption {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choices: vec!["Narrow".into(), "Wide".into()],
+            selected_choice: "Wide".into(),
+        });
+        let text = lines(&m, 0, 60, 20, &crate::Theme::sdr())
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Bandwidth"), "{text}");
+        assert!(text.contains("Wide"), "{text}");
+    }
+
+    #[test]
+    fn the_selected_option_stays_in_a_short_viewport() {
+        let mut m = SdrMetrics::fixture();
+        for index in 0..6 {
+            m.device_options.push(crate::hardware::DeviceOption {
+                id: format!("option-{index}"),
+                label: format!("Option {index}"),
+                choices: vec!["Off".into(), "On".into()],
+                selected_choice: "Off".into(),
+            });
+        }
+
+        let text = lines(&m, 5, 60, 5, &crate::Theme::sdr())
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Option 5"), "{text}");
+        assert!(!text.contains("Option 0"), "{text}");
+    }
+
+    #[test]
+    fn backend_text_never_exceeds_the_pane_width() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options.push(crate::hardware::DeviceOption {
+            id: "long".into(),
+            label: "A device-provided label that is much too long".into(),
+            choices: vec!["A device-provided choice that is much too long".into()],
+            selected_choice: "A device-provided choice that is much too long".into(),
+        });
+
+        for width in [1, 4, 7, 8, 12, 20, 28] {
+            for line in lines(&m, 0, width, 6, &crate::Theme::sdr()) {
+                assert!(
+                    line.width() <= width,
+                    "a {}-wide row does not fit {width} columns: {line:?}",
+                    line.width()
+                );
+            }
+        }
     }
 }

--- a/src/ui/menu/options.rs
+++ b/src/ui/menu/options.rs
@@ -11,7 +11,10 @@ use ratatui::{
     Frame,
 };
 
-use crate::{state::SdrMetrics, ui::chrome};
+use crate::{
+    state::{DeviceOptionUpdate, SdrMetrics},
+    ui::chrome,
+};
 
 /// The heading. Says what the pane is for, in the future tense, because that is
 /// the only true tense for it right now.
@@ -76,7 +79,13 @@ fn lines(
         .skip(first)
         .take(visible)
     {
-        out.push(option_line(option, index == selected, iw, theme));
+        out.push(option_line(
+            option,
+            index == selected,
+            &m.ui.device_option_update,
+            iw,
+            theme,
+        ));
     }
     out
 }
@@ -99,6 +108,7 @@ fn option_header(iw: usize, height: usize, theme: &crate::Theme) -> Vec<Line<'st
 fn option_line(
     option: &crate::hardware::DeviceOption,
     active: bool,
+    update: &DeviceOptionUpdate,
     iw: usize,
     theme: &crate::Theme,
 ) -> Line<'static> {
@@ -120,7 +130,16 @@ fn option_line(
     let label_width = content_width.min(18).min(content_width / 2);
     let choice_width = content_width - label_width;
     let label = fit_cell(&option.label, label_width);
-    let choice = fit_text(&option.selected_choice, choice_width);
+    let shown = match update {
+        DeviceOptionUpdate::Pending { id, choice, .. } if id == &option.id => {
+            format!("{} -> {choice}...", option.selected_choice)
+        }
+        DeviceOptionUpdate::Error { id, .. } if id == &option.id => {
+            format!("{} (failed)", option.selected_choice)
+        }
+        _ => option.selected_choice.clone(),
+    };
+    let choice = fit_text(&shown, choice_width);
     Line::from(vec![
         Span::styled(marker, Style::default().fg(theme.border_accent)),
         Span::styled(label, Style::default().fg(theme.label)),
@@ -292,5 +311,54 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn pending_change_keeps_the_accepted_choice_visible() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options.push(crate::hardware::DeviceOption {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choices: vec!["Narrow".into(), "Wide".into()],
+            selected_choice: "Narrow".into(),
+        });
+        m.ui.device_option_update = DeviceOptionUpdate::Pending {
+            request_id: 1,
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choice: "Wide".into(),
+        };
+
+        let text = lines(&m, 0, 80, 1, &crate::Theme::sdr())
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Narrow -> Wide..."), "{text}");
+    }
+
+    #[test]
+    fn failed_change_keeps_the_accepted_choice_visible() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options.push(crate::hardware::DeviceOption {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choices: vec!["Narrow".into(), "Wide".into()],
+            selected_choice: "Narrow".into(),
+        });
+        m.ui.device_option_update = DeviceOptionUpdate::Error {
+            request_id: 1,
+            id: "bandwidth".into(),
+            choice: "Wide".into(),
+            message: "device rejected choice".into(),
+        };
+
+        let text = lines(&m, 0, 80, 1, &crate::Theme::sdr())
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Narrow (failed)"), "{text}");
+        assert!(!text.contains("Wide"), "{text}");
     }
 }

--- a/src/ui/menu/options.rs
+++ b/src/ui/menu/options.rs
@@ -66,18 +66,9 @@ fn lines(
     }
 
     let selected = selected.min(m.device_options.len() - 1);
-    let visible = height.saturating_sub(3);
+    let mut out = option_header(iw, height, theme);
+    let visible = height.saturating_sub(out.len());
     let first = scroll_offset(selected, m.device_options.len(), visible);
-    let mut out = vec![
-        Line::from(""),
-        Line::from(Span::styled(
-            fit_text("  Device options", iw),
-            Style::default()
-                .fg(theme.value_hi)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::from(""),
-    ];
     for (index, option) in m
         .device_options
         .iter()
@@ -85,35 +76,57 @@ fn lines(
         .skip(first)
         .take(visible)
     {
-        let active = index == selected;
-        let marker = if active { "\u{25b8} " } else { "  " };
-        let value_style = Style::default()
-            .fg(if active { theme.value_hi } else { theme.value })
-            .add_modifier(if active {
-                Modifier::BOLD
-            } else {
-                Modifier::empty()
-            });
-        if iw < 7 {
-            out.push(Line::from(Span::styled(
-                fit_text(marker, iw),
-                Style::default().fg(theme.border_accent),
-            )));
-            continue;
-        }
-        let content_width = iw - 7;
-        let label_width = content_width.min(18).min(content_width / 2);
-        let choice_width = content_width - label_width;
-        let label = fit_cell(&option.label, label_width);
-        let choice = fit_text(&option.selected_choice, choice_width);
-        out.push(Line::from(vec![
-            Span::styled(marker, Style::default().fg(theme.border_accent)),
-            Span::styled(label, Style::default().fg(theme.label)),
-            Span::raw(" "),
-            Span::styled(format!("\u{25c0} {choice} \u{25b6}"), value_style),
-        ]));
+        out.push(option_line(option, index == selected, iw, theme));
     }
     out
+}
+
+fn option_header(iw: usize, height: usize, theme: &crate::Theme) -> Vec<Line<'static>> {
+    let heading = Line::from(Span::styled(
+        fit_text("  Device options", iw),
+        Style::default()
+            .fg(theme.value_hi)
+            .add_modifier(Modifier::BOLD),
+    ));
+    match height {
+        0 | 1 => Vec::new(),
+        2 => vec![heading],
+        3 => vec![heading, Line::from("")],
+        _ => vec![Line::from(""), heading, Line::from("")],
+    }
+}
+
+fn option_line(
+    option: &crate::hardware::DeviceOption,
+    active: bool,
+    iw: usize,
+    theme: &crate::Theme,
+) -> Line<'static> {
+    let marker = if active { "\u{25b8} " } else { "  " };
+    let value_style = Style::default()
+        .fg(if active { theme.value_hi } else { theme.value })
+        .add_modifier(if active {
+            Modifier::BOLD
+        } else {
+            Modifier::empty()
+        });
+    if iw < 7 {
+        return Line::from(Span::styled(
+            fit_text(marker, iw),
+            Style::default().fg(theme.border_accent),
+        ));
+    }
+    let content_width = iw - 7;
+    let label_width = content_width.min(18).min(content_width / 2);
+    let choice_width = content_width - label_width;
+    let label = fit_cell(&option.label, label_width);
+    let choice = fit_text(&option.selected_choice, choice_width);
+    Line::from(vec![
+        Span::styled(marker, Style::default().fg(theme.border_accent)),
+        Span::styled(label, Style::default().fg(theme.label)),
+        Span::raw(" "),
+        Span::styled(format!("\u{25c0} {choice} \u{25b6}"), value_style),
+    ])
 }
 
 fn scroll_offset(cursor: usize, total: usize, visible: usize) -> usize {
@@ -239,6 +252,25 @@ mod tests {
             .join("\n");
         assert!(text.contains("Option 5"), "{text}");
         assert!(!text.contains("Option 0"), "{text}");
+    }
+
+    #[test]
+    fn the_selected_option_uses_the_only_available_row() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options.push(crate::hardware::DeviceOption {
+            id: "bandwidth".into(),
+            label: "Bandwidth".into(),
+            choices: vec!["Narrow".into(), "Wide".into()],
+            selected_choice: "Wide".into(),
+        });
+
+        let text = lines(&m, 0, 60, 1, &crate::Theme::sdr())
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Bandwidth"), "{text}");
+        assert!(text.contains("Wide"), "{text}");
     }
 
     #[test]


### PR DESCRIPTION
This PR adds the reusable device-settings UI boundary needed by the tinySA stack after native sweeps merged in #9. The contract is backend-neutral.

The acquisition backend is complete, but the Options pane has no shared way to list choices or apply changes. Concrete controls would otherwise require device-specific UI code.

This PR adds an asynchronous device-options contract with pending state. Successful changes refresh the complete authoritative option snapshot. #11 uses the contract for tinySA controls and persistence.