### PR TITLE
Add tinySA device controls

### DIFF
--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -38,6 +38,7 @@ impl App {
         cfg: AppConfig,
         config_path: Option<PathBuf>,
         device: Arc<dyn hardware::SdrDevice>,
+        device_kind: hardware::DeviceKind,
     ) -> anyhow::Result<Self> {
         let info = device.info();
         let caps = Arc::new(device.capabilities().clone());
@@ -178,6 +179,7 @@ impl App {
             Some(Arc::clone(&device)),
             Some(Arc::clone(&rx_ctx)),
             None,
+            device_kind,
         )?;
 
         match caps.acquisition {
@@ -220,6 +222,7 @@ impl App {
         config_path: Option<PathBuf>,
         sysinfo: hardware::sysfs::HackRfSysInfo,
         profile: hardware::discovery::ObserverProfile,
+        device_kind: hardware::DeviceKind,
     ) -> anyhow::Result<Self> {
         let state = Arc::new(Mutex::new(initial_metrics(
             &cfg,
@@ -243,6 +246,7 @@ impl App {
             None,
             None,
             Some("observer"),
+            device_kind,
         )?;
         tasks::spawn_observer_task(Arc::clone(&state), sysinfo.bus, sysinfo.dev, profile);
         tasks::spawn_sys_resource_task(Arc::clone(&state));
@@ -263,6 +267,7 @@ impl App {
         device: Option<Arc<dyn hardware::SdrDevice>>,
         rx_ctx: Option<Arc<hardware::RxContext>>,
         preset_override: Option<&str>,
+        device_kind: hardware::DeviceKind,
     ) -> anyhow::Result<Self> {
         let themes_dir = config_path
             .as_deref()
@@ -339,6 +344,8 @@ impl App {
             theme,
             focus_keys,
             theme_config: cfg.theme.clone(),
+            tinysa_config: cfg.tinysa.clone(),
+            device_kind,
             user_presets: cfg.presets,
         })
     }

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -345,6 +345,7 @@ impl App {
             focus_keys,
             theme_config: cfg.theme.clone(),
             tinysa_config: cfg.tinysa.clone(),
+            tinysa_basic_input: None,
             device_kind,
             user_presets: cfg.presets,
         })

--- a/src/app/builder/mod.rs
+++ b/src/app/builder/mod.rs
@@ -38,7 +38,6 @@ impl App {
         cfg: AppConfig,
         config_path: Option<PathBuf>,
         device: Arc<dyn hardware::SdrDevice>,
-        device_kind: hardware::DeviceKind,
     ) -> anyhow::Result<Self> {
         let info = device.info();
         let caps = Arc::new(device.capabilities().clone());
@@ -179,7 +178,6 @@ impl App {
             Some(Arc::clone(&device)),
             Some(Arc::clone(&rx_ctx)),
             None,
-            device_kind,
         )?;
 
         match caps.acquisition {
@@ -222,7 +220,6 @@ impl App {
         config_path: Option<PathBuf>,
         sysinfo: hardware::sysfs::HackRfSysInfo,
         profile: hardware::discovery::ObserverProfile,
-        device_kind: hardware::DeviceKind,
     ) -> anyhow::Result<Self> {
         let state = Arc::new(Mutex::new(initial_metrics(
             &cfg,
@@ -246,7 +243,6 @@ impl App {
             None,
             None,
             Some("observer"),
-            device_kind,
         )?;
         tasks::spawn_observer_task(Arc::clone(&state), sysinfo.bus, sysinfo.dev, profile);
         tasks::spawn_sys_resource_task(Arc::clone(&state));
@@ -267,7 +263,6 @@ impl App {
         device: Option<Arc<dyn hardware::SdrDevice>>,
         rx_ctx: Option<Arc<hardware::RxContext>>,
         preset_override: Option<&str>,
-        device_kind: hardware::DeviceKind,
     ) -> anyhow::Result<Self> {
         let themes_dir = config_path
             .as_deref()
@@ -345,8 +340,6 @@ impl App {
             focus_keys,
             theme_config: cfg.theme.clone(),
             tinysa_config: cfg.tinysa.clone(),
-            tinysa_basic_input: None,
-            device_kind,
             user_presets: cfg.presets,
         })
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -49,6 +49,7 @@ pub struct App {
     /// to write back.
     pub(super) theme_config: crate::config::ThemeConfig,
     pub(super) tinysa_config: crate::config::TinySaSettings,
+    pub(super) tinysa_basic_input: Option<crate::hardware::tinysa::BasicInput>,
     pub(super) device_kind: hardware::DeviceKind,
 }
 
@@ -58,7 +59,10 @@ impl App {
         config_path: Option<PathBuf>,
         listing: &hardware::DeviceListing,
     ) -> anyhow::Result<Self> {
-        match hardware::open_device(listing, &cfg.tinysa) {
+        let tinysa_basic_input = (listing.kind == hardware::DeviceKind::TinySa).then(|| {
+            hardware::tinysa::resolve_basic_input(listing.tiny_sa_input, cfg.tinysa.basic_input)
+        });
+        let mut app = match hardware::open_device(listing, &cfg.tinysa) {
             Ok(device) => Self::new_normal(cfg, config_path, device, listing.kind),
             Err(open_err) => {
                 // Device is present but couldn't be opened (e.g. busy) - fall back
@@ -73,7 +77,9 @@ impl App {
                 };
                 Self::new_observer(cfg, config_path, sysinfo, profile, listing.kind)
             }
-        }
+        }?;
+        app.tinysa_basic_input = tinysa_basic_input;
+        Ok(app)
     }
 
     pub fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
@@ -421,7 +427,11 @@ impl App {
             return Ok(());
         };
         let tinysa = if self.device_kind == hardware::DeviceKind::TinySa {
-            crate::hardware::tinysa::persisted_settings(&self.tinysa_config, &device.options())?
+            crate::hardware::tinysa::persisted_settings(
+                &self.tinysa_config,
+                &device.options(),
+                self.tinysa_basic_input,
+            )?
         } else {
             self.tinysa_config.clone()
         };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -108,7 +108,7 @@ impl App {
                                         return Err(self.forced_option_quit_error());
                                     }
                                 } else {
-                                    self.finish_session();
+                                    self.finish_session()?;
                                     return Ok(());
                                 }
                             }
@@ -123,7 +123,7 @@ impl App {
                 AppEvent::Tick => true,
                 AppEvent::DeviceOptionComplete(completion) => {
                     if input::complete_device_option(&self.state, completion) {
-                        self.finish_session();
+                        self.finish_session()?;
                         return Ok(());
                     }
                     true
@@ -192,10 +192,10 @@ impl App {
         )
     }
 
-    fn finish_session(&self) {
+    fn finish_session(&self) -> io::Result<()> {
         self.restore_noise_sweep();
         self.restore_sweep_tuning();
-        self.save_config();
+        self.save_config().map_err(io::Error::other)
     }
 
     fn draw<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
@@ -413,17 +413,17 @@ impl App {
         let _ = device.set_frequency(hz);
     }
 
-    fn save_config(&self) {
-        if self.device.is_none() {
-            return;
-        }
-        let Some(path) = &self.config_path else {
-            return;
+    fn save_config(&self) -> anyhow::Result<()> {
+        let Some(device) = self.device.as_ref() else {
+            return Ok(());
         };
-        let tinysa_options = if self.device_kind == hardware::DeviceKind::TinySa {
-            self.device.as_ref().map(|device| device.options())
+        let Some(path) = &self.config_path else {
+            return Ok(());
+        };
+        let tinysa = if self.device_kind == hardware::DeviceKind::TinySa {
+            crate::hardware::tinysa::persisted_settings(&self.tinysa_config, &device.options())?
         } else {
-            None
+            self.tinysa_config.clone()
         };
         let (freq, rate, gains, amp, wf_rows, wf_palette, spec_style, markers, sweep_cfg, recall) = {
             let m = self.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -440,11 +440,6 @@ impl App {
                 crate::state::recall_to_hz(&m.ui.recall),
             )
         };
-        let tinysa = persisted_tinysa_settings(
-            self.device_kind,
-            &self.tinysa_config,
-            tinysa_options.as_deref(),
-        );
         let cfg = AppConfig {
             radio: RadioConfig {
                 frequency_hz: freq,
@@ -480,42 +475,8 @@ impl App {
             tinysa,
             presets: self.user_presets.clone(),
         };
-        let _ = cfg.save(path);
+        cfg.save(path)
     }
-}
-
-fn persisted_tinysa_settings(
-    device_kind: hardware::DeviceKind,
-    loaded: &crate::config::TinySaSettings,
-    options: Option<&[crate::hardware::DeviceOption]>,
-) -> crate::config::TinySaSettings {
-    if device_kind != hardware::DeviceKind::TinySa {
-        return loaded.clone();
-    }
-    let mut settings = loaded.clone();
-    for option in options.unwrap_or_default() {
-        let value = option.selected_choice.as_str();
-        match option.id.as_str() {
-            "points" => {
-                if let Ok(points) = value.parse() {
-                    settings.points = points;
-                }
-            }
-            "rbw" => settings.rbw = value.to_string(),
-            "attenuation" => settings.attenuation = value.to_string(),
-            "lna" => settings.lna = value == "on",
-            "lna2" => settings.lna2 = value.to_string(),
-            "agc" => settings.agc = value.to_string(),
-            "spur" => settings.spur = value.to_string(),
-            "ext_gain" => {
-                if let Ok(db) = value.parse() {
-                    settings.ext_gain_db = db;
-                }
-            }
-            _ => {}
-        }
-    }
-    settings
 }
 
 #[cfg(test)]
@@ -526,83 +487,6 @@ mod tests {
     use std::cell::Cell;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{mpsc, Arc, Mutex};
-
-    fn device_option(id: &str, choice: &str) -> crate::hardware::DeviceOption {
-        crate::hardware::DeviceOption {
-            id: id.into(),
-            label: id.into(),
-            choices: vec![choice.into()],
-            selected_choice: choice.into(),
-        }
-    }
-
-    #[test]
-    fn non_tinysa_backends_preserve_loaded_tinysa_settings() {
-        let loaded = crate::config::TinySaSettings {
-            points: 1800,
-            rbw: "custom".into(),
-            attenuation: "31".into(),
-            lna: true,
-            lna2: "7".into(),
-            agc: "6".into(),
-            spur: "off".into(),
-            ext_gain_db: 99,
-        };
-        let options = [device_option("points", "64")];
-        assert_eq!(
-            persisted_tinysa_settings(hardware::DeviceKind::HackRf, &loaded, Some(&options),),
-            loaded
-        );
-    }
-
-    #[test]
-    fn tinysa_persistence_uses_authoritative_dependent_settings() {
-        let loaded = crate::config::TinySaSettings::default();
-        let options = [
-            device_option("points", "900"),
-            device_option("rbw", "0.2"),
-            device_option("attenuation", "0"),
-            device_option("lna", "on"),
-            device_option("lna2", "3"),
-            device_option("agc", "7"),
-            device_option("spur", "off"),
-            device_option("ext_gain", "-12"),
-        ];
-        let saved =
-            persisted_tinysa_settings(hardware::DeviceKind::TinySa, &loaded, Some(&options));
-        assert_eq!(saved.points, 900);
-        assert_eq!(saved.rbw, "0.2");
-        assert_eq!(saved.attenuation, "0");
-        assert!(saved.lna);
-        assert_eq!(saved.lna2, "3");
-        assert_eq!(saved.agc, "7");
-        assert_eq!(saved.spur, "off");
-        assert_eq!(saved.ext_gain_db, -12);
-    }
-
-    #[test]
-    fn basic_tinysa_persistence_preserves_ultra_fields() {
-        let loaded = crate::config::TinySaSettings {
-            lna: true,
-            lna2: "5".into(),
-            agc: "4".into(),
-            ..crate::config::TinySaSettings::default()
-        };
-        let options = [
-            device_option("points", "64"),
-            device_option("rbw", "3"),
-            device_option("attenuation", "12"),
-            device_option("spur", "on"),
-            device_option("ext_gain", "7"),
-        ];
-        let saved =
-            persisted_tinysa_settings(hardware::DeviceKind::TinySa, &loaded, Some(&options));
-        assert_eq!(saved.points, 64);
-        assert!(saved.lna);
-        assert_eq!(saved.lna2, "5");
-        assert_eq!(saved.agc, "4");
-    }
-
     struct QuitDevice {
         caps: DeviceCapabilities,
         tuned_hz: AtomicU64,
@@ -702,6 +586,7 @@ mod tests {
             Some(device.clone()),
             None,
             None,
+            hardware::DeviceKind::HackRf,
         )
         .unwrap();
         let (tx, rx) = mpsc::channel();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -49,8 +49,6 @@ pub struct App {
     /// to write back.
     pub(super) theme_config: crate::config::ThemeConfig,
     pub(super) tinysa_config: crate::config::TinySaSettings,
-    pub(super) tinysa_basic_input: Option<crate::hardware::tinysa::BasicInput>,
-    pub(super) device_kind: hardware::DeviceKind,
 }
 
 impl App {
@@ -59,11 +57,8 @@ impl App {
         config_path: Option<PathBuf>,
         listing: &hardware::DeviceListing,
     ) -> anyhow::Result<Self> {
-        let tinysa_basic_input = (listing.kind == hardware::DeviceKind::TinySa).then(|| {
-            hardware::tinysa::resolve_basic_input(listing.tiny_sa_input, cfg.tinysa.basic_input)
-        });
-        let mut app = match hardware::open_device(listing, &cfg.tinysa) {
-            Ok(device) => Self::new_normal(cfg, config_path, device, listing.kind),
+        match hardware::open_device(listing, &cfg.tinysa) {
+            Ok(device) => Self::new_normal(cfg, config_path, device),
             Err(open_err) => {
                 // Device is present but couldn't be opened (e.g. busy) - fall back
                 // to read-only observer mode via the matching backend's sysfs
@@ -75,11 +70,9 @@ impl App {
                 let Some(sysinfo) = (profile.scan)() else {
                     return Err(open_err);
                 };
-                Self::new_observer(cfg, config_path, sysinfo, profile, listing.kind)
+                Self::new_observer(cfg, config_path, sysinfo, profile)
             }
-        }?;
-        app.tinysa_basic_input = tinysa_basic_input;
-        Ok(app)
+        }
     }
 
     pub fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
@@ -426,15 +419,6 @@ impl App {
         let Some(path) = &self.config_path else {
             return Ok(());
         };
-        let tinysa = if self.device_kind == hardware::DeviceKind::TinySa {
-            crate::hardware::tinysa::persisted_settings(
-                &self.tinysa_config,
-                &device.options(),
-                self.tinysa_basic_input,
-            )?
-        } else {
-            self.tinysa_config.clone()
-        };
         let (freq, rate, gains, amp, wf_rows, wf_palette, spec_style, markers, sweep_cfg, recall) = {
             let m = self.state.lock().unwrap_or_else(|e| e.into_inner());
             (
@@ -450,7 +434,7 @@ impl App {
                 crate::state::recall_to_hz(&m.ui.recall),
             )
         };
-        let cfg = AppConfig {
+        let mut cfg = AppConfig {
             radio: RadioConfig {
                 frequency_hz: freq,
                 sample_rate: rate,
@@ -482,9 +466,10 @@ impl App {
                 stop_hz: sweep_cfg.stop_hz,
                 dwell_ms: sweep_cfg.dwell_ms,
             },
-            tinysa,
+            tinysa: self.tinysa_config.clone(),
             presets: self.user_presets.clone(),
         };
+        device.update_config(&mut cfg)?;
         cfg.save(path)
     }
 }
@@ -589,14 +574,15 @@ mod tests {
             NEXT_PATH.fetch_add(1, Ordering::Relaxed)
         ));
         let _ = std::fs::remove_file(&path);
+        let mut config = AppConfig::default();
+        config.tinysa.lna = true;
         let mut app = App::assemble(
-            AppConfig::default(),
+            config,
             Some(path.clone()),
             state,
             Some(device.clone()),
             None,
             None,
-            hardware::DeviceKind::HackRf,
         )
         .unwrap();
         let (tx, rx) = mpsc::channel();
@@ -629,6 +615,7 @@ mod tests {
             AppConfig::load_or_default(&path).radio.frequency_hz,
             100_000_000
         );
+        assert!(AppConfig::load_or_default(&path).tinysa.lna);
         let m = app.state.lock().unwrap();
         assert_eq!(m.device_options[0].selected_choice, "Wide");
         assert!(matches!(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -48,6 +48,8 @@ pub struct App {
     /// and never touches again - so without a copy of them there is nothing left
     /// to write back.
     pub(super) theme_config: crate::config::ThemeConfig,
+    pub(super) tinysa_config: crate::config::TinySaSettings,
+    pub(super) device_kind: hardware::DeviceKind,
 }
 
 impl App {
@@ -56,8 +58,8 @@ impl App {
         config_path: Option<PathBuf>,
         listing: &hardware::DeviceListing,
     ) -> anyhow::Result<Self> {
-        match hardware::open_device(listing) {
-            Ok(device) => Self::new_normal(cfg, config_path, device),
+        match hardware::open_device(listing, &cfg.tinysa) {
+            Ok(device) => Self::new_normal(cfg, config_path, device, listing.kind),
             Err(open_err) => {
                 // Device is present but couldn't be opened (e.g. busy) - fall back
                 // to read-only observer mode via the matching backend's sysfs
@@ -69,7 +71,7 @@ impl App {
                 let Some(sysinfo) = (profile.scan)() else {
                     return Err(open_err);
                 };
-                Self::new_observer(cfg, config_path, sysinfo, profile)
+                Self::new_observer(cfg, config_path, sysinfo, profile, listing.kind)
             }
         }
     }
@@ -418,6 +420,11 @@ impl App {
         let Some(path) = &self.config_path else {
             return;
         };
+        let tinysa_options = if self.device_kind == hardware::DeviceKind::TinySa {
+            self.device.as_ref().map(|device| device.options())
+        } else {
+            None
+        };
         let (freq, rate, gains, amp, wf_rows, wf_palette, spec_style, markers, sweep_cfg, recall) = {
             let m = self.state.lock().unwrap_or_else(|e| e.into_inner());
             (
@@ -433,6 +440,11 @@ impl App {
                 crate::state::recall_to_hz(&m.ui.recall),
             )
         };
+        let tinysa = persisted_tinysa_settings(
+            self.device_kind,
+            &self.tinysa_config,
+            tinysa_options.as_deref(),
+        );
         let cfg = AppConfig {
             radio: RadioConfig {
                 frequency_hz: freq,
@@ -465,10 +477,45 @@ impl App {
                 stop_hz: sweep_cfg.stop_hz,
                 dwell_ms: sweep_cfg.dwell_ms,
             },
+            tinysa,
             presets: self.user_presets.clone(),
         };
         let _ = cfg.save(path);
     }
+}
+
+fn persisted_tinysa_settings(
+    device_kind: hardware::DeviceKind,
+    loaded: &crate::config::TinySaSettings,
+    options: Option<&[crate::hardware::DeviceOption]>,
+) -> crate::config::TinySaSettings {
+    if device_kind != hardware::DeviceKind::TinySa {
+        return loaded.clone();
+    }
+    let mut settings = loaded.clone();
+    for option in options.unwrap_or_default() {
+        let value = option.selected_choice.as_str();
+        match option.id.as_str() {
+            "points" => {
+                if let Ok(points) = value.parse() {
+                    settings.points = points;
+                }
+            }
+            "rbw" => settings.rbw = value.to_string(),
+            "attenuation" => settings.attenuation = value.to_string(),
+            "lna" => settings.lna = value == "on",
+            "lna2" => settings.lna2 = value.to_string(),
+            "agc" => settings.agc = value.to_string(),
+            "spur" => settings.spur = value.to_string(),
+            "ext_gain" => {
+                if let Ok(db) = value.parse() {
+                    settings.ext_gain_db = db;
+                }
+            }
+            _ => {}
+        }
+    }
+    settings
 }
 
 #[cfg(test)]
@@ -479,6 +526,82 @@ mod tests {
     use std::cell::Cell;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{mpsc, Arc, Mutex};
+
+    fn device_option(id: &str, choice: &str) -> crate::hardware::DeviceOption {
+        crate::hardware::DeviceOption {
+            id: id.into(),
+            label: id.into(),
+            choices: vec![choice.into()],
+            selected_choice: choice.into(),
+        }
+    }
+
+    #[test]
+    fn non_tinysa_backends_preserve_loaded_tinysa_settings() {
+        let loaded = crate::config::TinySaSettings {
+            points: 1800,
+            rbw: "custom".into(),
+            attenuation: "31".into(),
+            lna: true,
+            lna2: "7".into(),
+            agc: "6".into(),
+            spur: "off".into(),
+            ext_gain_db: 99,
+        };
+        let options = [device_option("points", "64")];
+        assert_eq!(
+            persisted_tinysa_settings(hardware::DeviceKind::HackRf, &loaded, Some(&options),),
+            loaded
+        );
+    }
+
+    #[test]
+    fn tinysa_persistence_uses_authoritative_dependent_settings() {
+        let loaded = crate::config::TinySaSettings::default();
+        let options = [
+            device_option("points", "900"),
+            device_option("rbw", "0.2"),
+            device_option("attenuation", "0"),
+            device_option("lna", "on"),
+            device_option("lna2", "3"),
+            device_option("agc", "7"),
+            device_option("spur", "off"),
+            device_option("ext_gain", "-12"),
+        ];
+        let saved =
+            persisted_tinysa_settings(hardware::DeviceKind::TinySa, &loaded, Some(&options));
+        assert_eq!(saved.points, 900);
+        assert_eq!(saved.rbw, "0.2");
+        assert_eq!(saved.attenuation, "0");
+        assert!(saved.lna);
+        assert_eq!(saved.lna2, "3");
+        assert_eq!(saved.agc, "7");
+        assert_eq!(saved.spur, "off");
+        assert_eq!(saved.ext_gain_db, -12);
+    }
+
+    #[test]
+    fn basic_tinysa_persistence_preserves_ultra_fields() {
+        let loaded = crate::config::TinySaSettings {
+            lna: true,
+            lna2: "5".into(),
+            agc: "4".into(),
+            ..crate::config::TinySaSettings::default()
+        };
+        let options = [
+            device_option("points", "64"),
+            device_option("rbw", "3"),
+            device_option("attenuation", "12"),
+            device_option("spur", "on"),
+            device_option("ext_gain", "7"),
+        ];
+        let saved =
+            persisted_tinysa_settings(hardware::DeviceKind::TinySa, &loaded, Some(&options));
+        assert_eq!(saved.points, 64);
+        assert!(saved.lna);
+        assert_eq!(saved.lna2, "5");
+        assert_eq!(saved.agc, "4");
+    }
 
     struct QuitDevice {
         caps: DeviceCapabilities,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -781,6 +781,46 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_quit_reports_save_failure_and_preserves_existing_config() {
+        static NEXT_PATH: AtomicUsize = AtomicUsize::new(0);
+        let root = std::env::temp_dir().join(format!(
+            "sdrtop-quit-save-failure-{}-{}",
+            std::process::id(),
+            NEXT_PATH.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("config.toml");
+        let original = b"[radio]\nfrequency_hz = 123456789\n";
+        std::fs::write(&path, original).unwrap();
+        std::fs::create_dir(path.with_extension("tmp")).unwrap();
+
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        let device = Arc::new(QuitDevice::new(state.lock().unwrap().caps.as_ref().clone()));
+        let mut app = App::assemble(
+            AppConfig::default(),
+            Some(path.clone()),
+            state,
+            Some(device),
+            None,
+            None,
+        )
+        .unwrap();
+        let (tx, rx) = mpsc::channel();
+        app.events = EventStream::from_channel(tx.clone(), rx);
+        tx.send(AppEvent::Key(KeyEvent::from(KeyCode::Char('q'))))
+            .unwrap();
+        let mut terminal = Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+
+        let error = app.run(&mut terminal).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+        std::fs::remove_dir(path.with_extension("tmp")).unwrap();
+        std::fs::remove_file(path).unwrap();
+        std::fs::remove_dir(root).unwrap();
+    }
+
+    #[test]
     fn numeric_menu_entry_preserves_the_deck_footer_setting() {
         use crate::state::{InputMode, MenuPane, MenuState};
         let (mut app, _, _, _) = quit_test_app();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -434,7 +434,7 @@ impl App {
                 crate::state::recall_to_hz(&m.ui.recall),
             )
         };
-        let mut cfg = AppConfig {
+        let cfg = AppConfig {
             radio: RadioConfig {
                 frequency_hz: freq,
                 sample_rate: rate,
@@ -469,8 +469,22 @@ impl App {
             tinysa: self.tinysa_config.clone(),
             presets: self.user_presets.clone(),
         };
-        device.update_config(&mut cfg)?;
-        cfg.save(path)
+        let mut candidate = cfg.clone();
+        let hook_error = device.update_config(&mut candidate).err();
+        let save_result = if hook_error.is_some() {
+            cfg.save(path)
+        } else {
+            candidate.save(path)
+        };
+        match (hook_error, save_result) {
+            (None, result) => result,
+            (Some(error), Ok(())) => Err(error.context(
+                "device settings could not be updated; previous device settings and other settings were saved",
+            )),
+            (Some(hook_error), Err(save_error)) => anyhow::bail!(
+                "failed to save config: {save_error:#}; device settings update also failed: {hook_error:#}"
+            ),
+        }
     }
 }
 
@@ -482,11 +496,20 @@ mod tests {
     use std::cell::Cell;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{mpsc, Arc, Mutex};
+
+    #[derive(Clone, Copy)]
+    enum ConfigHook {
+        Preserve,
+        Apply,
+        FailAfterMutation,
+    }
+
     struct QuitDevice {
         caps: DeviceCapabilities,
         tuned_hz: AtomicU64,
         tune_calls: AtomicUsize,
         drops: Arc<AtomicUsize>,
+        config_hook: ConfigHook,
     }
 
     impl QuitDevice {
@@ -496,7 +519,13 @@ mod tests {
                 tuned_hz: AtomicU64::new(0),
                 tune_calls: AtomicUsize::new(0),
                 drops: Arc::new(AtomicUsize::new(0)),
+                config_hook: ConfigHook::Preserve,
             }
+        }
+
+        fn with_config_hook(mut self, config_hook: ConfigHook) -> Self {
+            self.config_hook = config_hook;
+            self
         }
     }
 
@@ -539,6 +568,20 @@ mod tests {
 
         fn set_lna_gain(&self, _db: u32) -> anyhow::Result<()> {
             Ok(())
+        }
+
+        fn update_config(&self, config: &mut AppConfig) -> anyhow::Result<()> {
+            match self.config_hook {
+                ConfigHook::Preserve => Ok(()),
+                ConfigHook::Apply => {
+                    config.tinysa.points = 900;
+                    Ok(())
+                }
+                ConfigHook::FailAfterMutation => {
+                    config.tinysa.points = 900;
+                    anyhow::bail!("injected backend config failure")
+                }
+            }
         }
     }
 
@@ -629,6 +672,112 @@ mod tests {
             .is_some_and(|entry| entry.text.contains("Bandwidth set to Wide")));
         drop(m);
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn successful_backend_config_hook_updates_the_saved_snapshot() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        state.lock().unwrap().radio.frequency = 144_390_000;
+        let device = Arc::new(
+            QuitDevice::new(state.lock().unwrap().caps.as_ref().clone())
+                .with_config_hook(ConfigHook::Apply),
+        );
+        let path = std::env::temp_dir().join(format!(
+            "sdrtop-config-hook-success-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let app = App::assemble(
+            AppConfig::default(),
+            Some(path.clone()),
+            state,
+            Some(device),
+            None,
+            None,
+        )
+        .unwrap();
+
+        app.save_config().unwrap();
+
+        let saved = AppConfig::load_or_default(&path);
+        assert_eq!(saved.radio.frequency_hz, 144_390_000);
+        assert_eq!(saved.tinysa.points, 900);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn failed_backend_config_hook_saves_the_unmodified_backend_block() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        {
+            let mut metrics = state.lock().unwrap();
+            metrics.radio.frequency = 433_920_000;
+            metrics.spectrum.markers.push(crate::state::SpectrumMarker {
+                freq_hz: 434_500_000,
+                label: "review".into(),
+                channel_bw_hz: Some(25_000),
+                measured_bw_hz: None,
+            });
+        }
+        let device = Arc::new(
+            QuitDevice::new(state.lock().unwrap().caps.as_ref().clone())
+                .with_config_hook(ConfigHook::FailAfterMutation),
+        );
+        let path = std::env::temp_dir().join(format!(
+            "sdrtop-config-hook-failure-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let mut config = AppConfig::default();
+        config.tinysa.points = 450;
+        config.tinysa.lna = true;
+        let app =
+            App::assemble(config, Some(path.clone()), state, Some(device), None, None).unwrap();
+
+        let error = format!("{:#}", app.save_config().unwrap_err());
+
+        assert!(error.contains("device settings could not be updated"));
+        assert!(error.contains("previous device settings and other settings were saved"));
+        assert!(error.contains("injected backend config failure"));
+        let saved = AppConfig::load_or_default(&path);
+        assert_eq!(saved.radio.frequency_hz, 433_920_000);
+        assert_eq!(saved.tinysa.points, 450);
+        assert!(saved.tinysa.lna);
+        assert_eq!(saved.display.spectrum_markers.len(), 1);
+        assert_eq!(saved.display.spectrum_markers[0].freq_hz, 434_500_000);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn backend_hook_and_file_save_failures_are_both_reported() {
+        let state = Arc::new(Mutex::new(SdrMetrics::fixture()));
+        let device = Arc::new(
+            QuitDevice::new(state.lock().unwrap().caps.as_ref().clone())
+                .with_config_hook(ConfigHook::FailAfterMutation),
+        );
+        let root = std::env::temp_dir().join(format!(
+            "sdrtop-config-hook-double-failure-{}",
+            std::process::id()
+        ));
+        let blocker = root.join("not-a-directory");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&blocker, b"block config parent").unwrap();
+        let app = App::assemble(
+            AppConfig::default(),
+            Some(blocker.join("config.toml")),
+            state,
+            Some(device),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let error = app.save_config().unwrap_err().to_string();
+
+        assert!(error.contains("failed to save config"));
+        assert!(error.contains("device settings update also failed"));
+        assert!(error.contains("injected backend config failure"));
+        std::fs::remove_file(blocker).unwrap();
+        std::fs::remove_dir(root).unwrap();
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,12 +172,16 @@ fn default_auto() -> String {
 /// Settings applied when a tinySA backend opens.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct TinySaSettings {
+    #[serde(default)]
+    pub basic_input: crate::hardware::tinysa::BasicInput,
     #[serde(default = "default_tinysa_points")]
     pub points: u32,
     #[serde(default = "default_auto")]
     pub rbw: String,
     #[serde(default = "default_auto")]
     pub attenuation: String,
+    #[serde(default)]
+    pub high_attenuation: bool,
     #[serde(default)]
     pub lna: bool,
     #[serde(default = "default_auto")]
@@ -193,9 +197,11 @@ pub struct TinySaSettings {
 impl Default for TinySaSettings {
     fn default() -> Self {
         Self {
+            basic_input: crate::hardware::tinysa::BasicInput::default(),
             points: default_tinysa_points(),
             rbw: default_auto(),
             attenuation: default_auto(),
+            high_attenuation: false,
             lna: false,
             lna2: default_auto(),
             agc: default_auto(),
@@ -817,9 +823,11 @@ panels = [
 
         let source = r#"
             [tinysa]
+            basic_input = "high"
             points = 900
             rbw = "0.2"
             attenuation = "12"
+            high_attenuation = true
             lna = true
             lna2 = "3"
             agc = "7"
@@ -831,14 +839,21 @@ panels = [
         let restored: AppConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(restored.tinysa, config.tinysa);
         assert!(serialized.contains("[tinysa]"));
+        assert!(serialized.contains("basic_input = \"high\""));
+        assert!(restored.tinysa.high_attenuation);
     }
 
     #[test]
     fn partial_tinysa_settings_fill_field_defaults() {
         let config: AppConfig = toml::from_str("[tinysa]\npoints = 64\n").unwrap();
         assert_eq!(config.tinysa.points, 64);
+        assert_eq!(
+            config.tinysa.basic_input,
+            crate::hardware::tinysa::BasicInput::Low
+        );
         assert_eq!(config.tinysa.rbw, "auto");
         assert_eq!(config.tinysa.attenuation, "auto");
+        assert!(!config.tinysa.high_attenuation);
         assert!(!config.tinysa.lna);
         assert_eq!(config.tinysa.lna2, "auto");
         assert_eq!(config.tinysa.agc, "auto");

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,50 @@ impl Default for SweepSettings {
     }
 }
 
+fn default_tinysa_points() -> u32 {
+    450
+}
+
+fn default_auto() -> String {
+    "auto".into()
+}
+
+/// Settings applied when a tinySA backend opens.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct TinySaSettings {
+    #[serde(default = "default_tinysa_points")]
+    pub points: u32,
+    #[serde(default = "default_auto")]
+    pub rbw: String,
+    #[serde(default = "default_auto")]
+    pub attenuation: String,
+    #[serde(default)]
+    pub lna: bool,
+    #[serde(default = "default_auto")]
+    pub lna2: String,
+    #[serde(default = "default_auto")]
+    pub agc: String,
+    #[serde(default = "default_auto")]
+    pub spur: String,
+    #[serde(default)]
+    pub ext_gain_db: i32,
+}
+
+impl Default for TinySaSettings {
+    fn default() -> Self {
+        Self {
+            points: default_tinysa_points(),
+            rbw: default_auto(),
+            attenuation: default_auto(),
+            lna: false,
+            lna2: default_auto(),
+            agc: default_auto(),
+            spur: default_auto(),
+            ext_gain_db: 0,
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct AppConfig {
     #[serde(default)]
@@ -171,6 +215,8 @@ pub struct AppConfig {
     pub theme: ThemeConfig,
     #[serde(default)]
     pub sweep: SweepSettings,
+    #[serde(default)]
+    pub tinysa: TinySaSettings,
     /// User-defined layout presets, merged into the built-in set at startup.
     /// A preset here with the same name as a built-in overrides it. Preserved
     /// verbatim across save so hand-written presets survive a quit.
@@ -762,6 +808,42 @@ panels = [
         let restored: AppConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(restored.radio.gain.as_deref(), Some("LNA=24,VGA=30"));
         assert_eq!(restored.display.active_preset, "spectrum");
+    }
+
+    #[test]
+    fn tinysa_settings_default_and_round_trip() {
+        let defaults: AppConfig = toml::from_str("").unwrap();
+        assert_eq!(defaults.tinysa, TinySaSettings::default());
+
+        let source = r#"
+            [tinysa]
+            points = 900
+            rbw = "0.2"
+            attenuation = "12"
+            lna = true
+            lna2 = "3"
+            agc = "7"
+            spur = "off"
+            ext_gain_db = -8
+        "#;
+        let config: AppConfig = toml::from_str(source).unwrap();
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let restored: AppConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(restored.tinysa, config.tinysa);
+        assert!(serialized.contains("[tinysa]"));
+    }
+
+    #[test]
+    fn partial_tinysa_settings_fill_field_defaults() {
+        let config: AppConfig = toml::from_str("[tinysa]\npoints = 64\n").unwrap();
+        assert_eq!(config.tinysa.points, 64);
+        assert_eq!(config.tinysa.rbw, "auto");
+        assert_eq!(config.tinysa.attenuation, "auto");
+        assert!(!config.tinysa.lna);
+        assert_eq!(config.tinysa.lna2, "auto");
+        assert_eq!(config.tinysa.agc, "auto");
+        assert_eq!(config.tinysa.spur, "auto");
+        assert_eq!(config.tinysa.ext_gain_db, 0);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,10 +185,6 @@ pub struct TinySaSettings {
     #[serde(default)]
     pub lna: bool,
     #[serde(default = "default_auto")]
-    pub lna2: String,
-    #[serde(default = "default_auto")]
-    pub agc: String,
-    #[serde(default = "default_auto")]
     pub spur: String,
     #[serde(default)]
     pub ext_gain_db: i32,
@@ -203,8 +199,6 @@ impl Default for TinySaSettings {
             attenuation: default_auto(),
             high_attenuation: false,
             lna: false,
-            lna2: default_auto(),
-            agc: default_auto(),
             spur: default_auto(),
             ext_gain_db: 0,
         }
@@ -829,8 +823,6 @@ panels = [
             attenuation = "12"
             high_attenuation = true
             lna = true
-            lna2 = "3"
-            agc = "7"
             spur = "off"
             ext_gain_db = -8
         "#;
@@ -855,8 +847,6 @@ panels = [
         assert_eq!(config.tinysa.attenuation, "auto");
         assert!(!config.tinysa.high_attenuation);
         assert!(!config.tinysa.lna);
-        assert_eq!(config.tinysa.lna2, "auto");
-        assert_eq!(config.tinysa.agc, "auto");
         assert_eq!(config.tinysa.spur, "auto");
         assert_eq!(config.tinysa.ext_gain_db, 0);
     }

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -263,9 +263,12 @@ pub fn open_device(
             let Some(path) = listing.path.as_deref() else {
                 anyhow::bail!("a tinySA listing with no serial port cannot be opened");
             };
+            let basic_input =
+                tinysa::resolve_basic_input(listing.tiny_sa_input, tinysa_settings.basic_input);
             Ok(Arc::new(tinysa::TinySaDevice::open(
                 path,
-                listing.tiny_sa_input.unwrap_or_default(),
+                basic_input,
+                listing.tiny_sa_input,
                 tinysa_settings,
             )?))
         }

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -246,7 +246,10 @@ fn offer_soapy(
 }
 
 /// Opens the device a listing points at, as a trait object.
-pub fn open_device(listing: &DeviceListing) -> anyhow::Result<Arc<dyn SdrDevice>> {
+pub fn open_device(
+    listing: &DeviceListing,
+    tinysa_settings: &crate::config::TinySaSettings,
+) -> anyhow::Result<Arc<dyn SdrDevice>> {
     match listing.kind {
         DeviceKind::HackRf => Ok(Arc::new(hackrf::HackRfDevice::open(listing.index)?)),
         DeviceKind::RtlSdr => Ok(Arc::new(rtlsdr::RtlDevice::open(listing.index)?)),
@@ -263,6 +266,7 @@ pub fn open_device(listing: &DeviceListing) -> anyhow::Result<Arc<dyn SdrDevice>
             Ok(Arc::new(tinysa::TinySaDevice::open(
                 path,
                 listing.tiny_sa_input.unwrap_or_default(),
+                tinysa_settings,
             )?))
         }
     }

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -1510,7 +1510,8 @@ fn manual_attenuation_commands(choice: &str) -> Vec<String> {
     let target: u8 = choice
         .parse()
         .expect("validated tinySA attenuation choice must be numeric");
-    let transition = if target == 0 { 1 } else { 0 };
+    // Use a high attenuation transition because firmware ignores an equal numeric value
+    let transition = if target == 31 { 30 } else { 31 };
     vec![
         format!("attenuate {transition}"),
         format!("attenuate {target}"),
@@ -1955,7 +1956,7 @@ mod tests {
             commands,
             [
                 "rbw 0.2",
-                "attenuate 1",
+                "attenuate 31",
                 "attenuate 0",
                 "lna on",
                 "spur off",
@@ -2078,6 +2079,7 @@ mod tests {
 
         for (high_input, target, commands) in [
             (false, 30, manual_attenuation_commands("30")),
+            (false, 31, manual_attenuation_commands("31")),
             (true, 0, high_attenuation_commands("off")),
             (true, 1, high_attenuation_commands("on")),
         ] {
@@ -2106,7 +2108,7 @@ mod tests {
             startup,
             [
                 "rbw auto",
-                "attenuate 0",
+                "attenuate 31",
                 "attenuate 30",
                 "spur on",
                 "ext_gain 0",
@@ -2131,7 +2133,7 @@ mod tests {
             Ok(())
         })
         .unwrap();
-        assert_eq!(commands, ["attenuate 1", "attenuate 0", "lna on"]);
+        assert_eq!(commands, ["attenuate 31", "attenuate 0", "lna on"]);
         assert_eq!(selected_option_value(&options, "attenuation"), Some("0"));
         assert!(
             prepare_option_update(&options, Model::Zs407, "attenuation", "auto", 10_000, None,)
@@ -2151,7 +2153,7 @@ mod tests {
                 .unwrap();
         assert_eq!(
             prepared.commands,
-            ["lna off", "attenuate 1", "attenuate 0", "lna on",]
+            ["lna off", "attenuate 31", "attenuate 0", "lna on",]
         );
     }
 
@@ -2186,7 +2188,7 @@ mod tests {
             Ok(())
         });
         assert!(result.is_err());
-        assert_eq!(commands, ["attenuate 1", "attenuate 0", "lna on"]);
+        assert_eq!(commands, ["attenuate 31", "attenuate 0", "lna on"]);
         assert_eq!(options, before);
     }
 
@@ -2205,7 +2207,7 @@ mod tests {
             [
                 "lna off",
                 "rbw 30",
-                "attenuate 0",
+                "attenuate 31",
                 "attenuate 12",
                 "spur off",
                 "ext_gain -7",
@@ -2222,7 +2224,7 @@ mod tests {
             [
                 "lna off",
                 "rbw 30",
-                "attenuate 1",
+                "attenuate 31",
                 "attenuate 0",
                 "lna on",
                 "spur off",

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -14,8 +14,9 @@ use anyhow::{anyhow, bail, Context};
 use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
 use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
 
+use crate::config::TinySaSettings;
 use crate::hardware::{
-    AcquisitionKind, DeliveryModel, DeviceCapabilities, DeviceInfo, DeviceListing,
+    AcquisitionKind, DeliveryModel, DeviceCapabilities, DeviceInfo, DeviceListing, DeviceOption,
     DirectSweepConfig, GainModel, LevelUnit, PowerTrace, PowerTraceTarget, RxContext, SampleFormat,
     SampleGeometry, SdrDevice, SoftwareStack,
 };
@@ -26,6 +27,7 @@ use protocol::{Identity, Model, PROMPT};
 const MIN_FREQUENCY_HZ: u64 = 100_000;
 const DEFAULT_FREQUENCY_HZ: u64 = 100_000_000;
 const DEFAULT_SPAN_HZ: u64 = 10_000_000;
+#[cfg(test)]
 const DEFAULT_POINTS: u32 = 450;
 const READ_TIMEOUT: Duration = Duration::from_millis(50);
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -73,19 +75,6 @@ impl BasicInput {
             Self::High => (BASIC_HIGH_MIN_HZ, BASIC_HIGH_MAX_HZ),
         }
     }
-}
-
-#[derive(Clone, Copy)]
-struct ScanSettings {
-    points: u32,
-    rbw_khz: Option<f64>,
-    spur: SpurMode,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SpurMode {
-    On,
-    Auto,
 }
 
 pub fn list(selector: Option<&str>) -> Vec<DeviceListing> {
@@ -140,12 +129,18 @@ pub struct TinySaDevice {
     caps: DeviceCapabilities,
     info: DeviceInfo,
     notes: Vec<String>,
+    options: Arc<Mutex<Vec<DeviceOption>>>,
     command_tx: Sender<Command>,
     worker: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl TinySaDevice {
-    pub fn open(path: &Path, basic_input: BasicInput) -> anyhow::Result<Self> {
+    pub fn open(
+        path: &Path,
+        basic_input: BasicInput,
+        settings: &TinySaSettings,
+    ) -> anyhow::Result<Self> {
+        validate_settings_shape(settings)?;
         let port = serialport::new(path.to_string_lossy(), 115_200)
             .data_bits(DataBits::Eight)
             .stop_bits(StopBits::One)
@@ -156,9 +151,21 @@ impl TinySaDevice {
             .with_context(|| format!("failed to open tinySA at {}", path.display()))?;
         let (command_tx, command_rx) = crossbeam_channel::unbounded();
         let (init_tx, init_rx) = bounded(1);
+        let options = Arc::new(Mutex::new(Vec::new()));
+        let worker_options = Arc::clone(&options);
+        let settings = settings.clone();
         let worker = thread::Builder::new()
             .name("tinysa-serial".to_string())
-            .spawn(move || worker_entry(port, command_rx, init_tx, basic_input))
+            .spawn(move || {
+                worker_entry(
+                    port,
+                    command_rx,
+                    init_tx,
+                    basic_input,
+                    settings,
+                    worker_options,
+                )
+            })
             .context("failed to start tinySA serial worker")?;
         let initialized = match init_rx.recv() {
             Ok(Ok(initialized)) => initialized,
@@ -191,6 +198,7 @@ impl TinySaDevice {
             caps,
             info,
             notes,
+            options,
             command_tx,
             worker: Mutex::new(Some(worker)),
         })
@@ -247,6 +255,28 @@ impl SdrDevice for TinySaDevice {
         self.request(|reply| Command::SetDirectSweep(config, reply))
     }
 
+    fn options(&self) -> Vec<DeviceOption> {
+        self.options
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+
+    fn set_option(&self, id: &str, choice: &str) -> anyhow::Result<()> {
+        {
+            let options = self
+                .options
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            validate_option_choice(&options, id, choice)?;
+        }
+        self.request(|reply| Command::SetOption {
+            id: id.to_string(),
+            choice: choice.to_string(),
+            reply,
+        })
+    }
+
     fn open_notes(&self) -> &[String] {
         &self.notes
     }
@@ -276,6 +306,11 @@ enum Command {
     SetSpan(f64, Sender<anyhow::Result<RateSet>>),
     NoOp(UnitReply),
     SetDirectSweep(Option<DirectSweepConfig>, UnitReply),
+    SetOption {
+        id: String,
+        choice: String,
+        reply: UnitReply,
+    },
     Shutdown(UnitReply),
 }
 
@@ -287,12 +322,14 @@ struct Worker {
     port: Box<dyn SerialPort>,
     command_rx: Receiver<Command>,
     identity: Identity,
-    settings: ScanSettings,
+    options: Vec<DeviceOption>,
+    option_state: Arc<Mutex<Vec<DeviceOption>>>,
     basic_input: BasicInput,
     center_hz: u64,
     span_hz: u64,
     direct_sweep: Option<DirectSweepConfig>,
     rx_context: Option<Arc<RxContext>>,
+    prompt_ready: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -328,14 +365,19 @@ fn worker_entry(
     command_rx: Receiver<Command>,
     init_tx: Sender<anyhow::Result<Initialized>>,
     basic_input: BasicInput,
+    settings: TinySaSettings,
+    option_state: Arc<Mutex<Vec<DeviceOption>>>,
 ) {
-    let (identity, settings) = match initialize(&mut *port, basic_input) {
+    let (identity, options) = match initialize(&mut *port, basic_input, &settings) {
         Ok(value) => value,
         Err(error) => {
             let _ = init_tx.send(Err(error));
             return;
         }
     };
+    *option_state
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = options.clone();
     if init_tx
         .send(Ok(Initialized {
             identity: identity.clone(),
@@ -349,12 +391,14 @@ fn worker_entry(
         port,
         command_rx,
         identity,
-        settings,
+        options,
+        option_state,
+        basic_input,
         center_hz,
         span_hz: DEFAULT_SPAN_HZ,
-        basic_input,
         direct_sweep: None,
         rx_context: None,
+        prompt_ready: true,
     }
     .run();
 }
@@ -404,10 +448,7 @@ impl Worker {
                                     .unwrap_or(0),
                                 frequencies_hz,
                                 levels_dbm,
-                                rbw_hz: self
-                                    .settings
-                                    .rbw_khz
-                                    .map(|khz| (khz * 1_000.0).round() as u32),
+                                rbw_hz: current_rbw_hz(&self.options),
                             })
                             .is_ok();
                         if published && target == PowerTraceTarget::Spectrum {
@@ -426,6 +467,7 @@ impl Worker {
                 Ok(ScanResult::Interrupted(command, abort_result)) => {
                     if let Err(error) = abort_result {
                         let message = error.to_string();
+                        self.prompt_ready = false;
                         self.stop_acquisition(&message);
                         reject_command(command, anyhow!(message));
                         return;
@@ -436,6 +478,7 @@ impl Worker {
                 }
                 Err(error) => {
                     best_effort_abort(&mut *self.port);
+                    self.prompt_ready = false;
                     self.stop_acquisition(&error.to_string());
                     return;
                 }
@@ -455,7 +498,11 @@ impl Worker {
     fn handle_command(&mut self, command: Command) -> bool {
         match command {
             Command::Start(context, reply) => {
-                let result = if self.rx_context.is_some() {
+                let result = if !self.prompt_ready {
+                    Err(anyhow!(
+                        "tinySA serial state is unknown; reconnect the analyzer"
+                    ))
+                } else if self.rx_context.is_some() {
                     Err(anyhow!("tinySA acquisition is already running"))
                 } else {
                     self.rx_context = Some(context);
@@ -478,16 +525,15 @@ impl Worker {
             Command::SetSpan(hz, reply) => {
                 let (minimum, maximum) = frequency_range(self.identity.model, self.basic_input);
                 let maximum = maximum - minimum;
-                let result = normalize_span(hz, maximum, self.settings.points).map(|span_hz| {
-                    self.span_hz = span_hz;
-                    RateSet::new(
-                        hz,
-                        Some(self.span_hz as f64),
-                        self.settings
-                            .rbw_khz
-                            .map(|khz| (khz * 1_000.0).round() as u32)
-                            .unwrap_or(0),
-                    )
+                let result = selected_points(&self.options).and_then(|points| {
+                    normalize_span(hz, maximum, points).map(|span_hz| {
+                        self.span_hz = span_hz;
+                        RateSet::new(
+                            hz,
+                            Some(self.span_hz as f64),
+                            current_rbw_hz(&self.options).unwrap_or(0),
+                        )
+                    })
                 });
                 let _ = reply.send(result);
             }
@@ -495,8 +541,16 @@ impl Worker {
                 let _ = reply.send(Ok(()));
             }
             Command::SetDirectSweep(config, reply) => {
-                let result = validate_direct_sweep(config, self.identity.model, self.basic_input)
-                    .map(|()| self.direct_sweep = config);
+                let result = selected_points(&self.options).and_then(|points| {
+                    validate_direct_sweep(config, self.identity.model, self.basic_input, points)
+                        .map(|()| {
+                            self.direct_sweep = config;
+                        })
+                });
+                let _ = reply.send(result);
+            }
+            Command::SetOption { id, choice, reply } => {
+                let result = self.apply_option(&id, &choice);
                 let _ = reply.send(result);
             }
             Command::Shutdown(reply) => {
@@ -519,6 +573,45 @@ impl Worker {
         }
     }
 
+    fn apply_option(&mut self, id: &str, choice: &str) -> anyhow::Result<()> {
+        if !self.prompt_ready {
+            bail!("tinySA serial state is unknown; reconnect the analyzer");
+        }
+        let prepared = prepare_option_update(
+            &self.options,
+            self.identity.model,
+            id,
+            choice,
+            self.span_hz,
+            self.direct_sweep,
+        )?;
+        if let Err(error) =
+            execute_option_update(&mut self.options, prepared, id, choice, |command| {
+                send_setter_command(&mut *self.port, command)
+            })
+        {
+            self.stop_acquisition(&error.to_string());
+            let recovery = recover_option_state(
+                &mut *self.port,
+                self.identity.model,
+                self.basic_input,
+                &self.options,
+            );
+            self.prompt_ready = recovery.is_ok();
+            return match recovery {
+                Ok(()) => Err(error),
+                Err(recovery_error) => Err(error.context(format!(
+                    "failed to restore tinySA controls after the error: {recovery_error}"
+                ))),
+            };
+        }
+        *self
+            .option_state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = self.options.clone();
+        Ok(())
+    }
+
     fn scan_once(&mut self) -> anyhow::Result<ScanResult> {
         let (minimum_hz, maximum_hz) = frequency_range(self.identity.model, self.basic_input);
         let (start_hz, stop_hz) = self
@@ -527,7 +620,7 @@ impl Worker {
             .unwrap_or_else(|| {
                 centered_window(self.center_hz, self.span_hz, minimum_hz, maximum_hz)
             });
-        let points = self.settings.points;
+        let points = selected_points(&self.options)?;
         let scan_span_hz = stop_hz - start_hz;
         if scan_span_hz < points as u64 {
             bail!("tinySA scan span is too narrow for {points} points");
@@ -540,7 +633,7 @@ impl Worker {
             points,
         };
         let inactivity_timeout =
-            scan_inactivity_timeout(segment, self.identity.model, self.settings)?;
+            scan_inactivity_timeout(segment, self.identity.model, &self.options)?;
         match scan_segment(
             &mut *self.port,
             &self.command_rx,
@@ -577,7 +670,8 @@ impl Worker {
 fn initialize(
     port: &mut dyn SerialPort,
     basic_input: BasicInput,
-) -> anyhow::Result<(Identity, ScanSettings)> {
+    settings: &TinySaSettings,
+) -> anyhow::Result<(Identity, Vec<DeviceOption>)> {
     best_effort_abort(port);
     drain_startup(port)?;
     let mut last_error = None;
@@ -599,7 +693,7 @@ fn initialize(
     }
     let version = version
         .ok_or_else(|| last_error.unwrap_or_else(|| anyhow!("tinySA version probe failed")))?;
-    send_text_command(port, "output off")?;
+    send_setter_command(port, "output off")?;
     let info = send_text_command(port, "info")?;
     let help = send_text_command(port, "help")?;
     let zero = send_text_command(port, "zero")?;
@@ -607,18 +701,16 @@ fn initialize(
     if identity.model.is_ultra() && basic_input == BasicInput::High {
         bail!("tinySA HIGH input selection applies only to the basic model");
     }
-    send_text_command(port, "abort on")?;
-    send_text_command(port, input_mode_command(identity.model, basic_input))?;
-    let (settings, _) = startup_settings(identity.model);
-    apply_scan_settings(port, identity.model)?;
-    Ok((identity, settings))
-}
-
-fn apply_scan_settings(port: &mut dyn SerialPort, model: Model) -> anyhow::Result<()> {
-    for command in startup_settings(model).1 {
-        send_text_command(port, command)?;
+    let (options, saved_commands) = startup_options(identity.model, settings)?;
+    send_setter_command(port, input_mode_command(identity.model, basic_input))?;
+    send_setter_command(port, "abort on")?;
+    for command in baseline_commands(identity.model) {
+        send_setter_command(port, command)?;
     }
-    Ok(())
+    for command in saved_commands {
+        send_setter_command(port, &command)?;
+    }
+    Ok((identity, options))
 }
 
 fn best_effort_abort(port: &mut dyn SerialPort) {
@@ -643,6 +735,11 @@ fn send_text_command(port: &mut dyn SerialPort, command: &str) -> anyhow::Result
         .with_context(|| format!("failed to flush tinySA {command} command"))?;
     let frame = read_until_prompt(port, RESPONSE_TIMEOUT)?;
     protocol::parse_text_frame(&frame, command)
+}
+
+fn send_setter_command(port: &mut dyn SerialPort, command: &str) -> anyhow::Result<()> {
+    let body = send_text_command(port, command)?;
+    protocol::validate_setter_body(&body, command)
 }
 
 fn read_until_prompt(
@@ -951,6 +1048,7 @@ fn reject_command(command: Command, error: anyhow::Error) {
         | Command::SetFrequency(_, reply)
         | Command::NoOp(reply)
         | Command::SetDirectSweep(_, reply)
+        | Command::SetOption { reply, .. }
         | Command::Shutdown(reply) => {
             let _ = reply.send(Err(anyhow!(message)));
         }
@@ -967,6 +1065,7 @@ fn validate_direct_sweep(
     config: Option<DirectSweepConfig>,
     model: Model,
     basic_input: BasicInput,
+    points: u32,
 ) -> anyhow::Result<()> {
     let Some(config) = config else {
         return Ok(());
@@ -982,6 +1081,9 @@ fn validate_direct_sweep(
             maximum_hz
         );
     }
+    if config.stop_hz - config.start_hz < points as u64 {
+        bail!("tinySA sweep span is too narrow for {points} points");
+    }
     Ok(())
 }
 
@@ -996,7 +1098,7 @@ fn capabilities(model: Model, basic_input: BasicInput) -> DeviceCapabilities {
         trace_stale_ms: 5_000,
         freq_min_hz: minimum_hz,
         freq_max_hz: maximum_hz,
-        sample_rate_min_hz: DEFAULT_POINTS as f64,
+        sample_rate_min_hz: allowed_points()[0] as f64,
         sample_rate_max_hz: (maximum_hz - minimum_hz) as f64,
         default_frequency_hz: default_frequency(model, basic_input),
         default_sample_rate_hz: DEFAULT_SPAN_HZ as f64,
@@ -1108,51 +1210,379 @@ fn trace_frequencies(measured_hz: Vec<u64>, target: PowerTraceTarget) -> anyhow:
     }
 }
 
-fn startup_settings(model: Model) -> (ScanSettings, Vec<&'static str>) {
-    let spur = if model.is_ultra() {
-        SpurMode::Auto
+fn validate_settings_shape(settings: &TinySaSettings) -> anyhow::Result<()> {
+    if !allowed_points().contains(&settings.points) {
+        bail!("tinySA points must be one of 64, 128, 290, 450, 900, or 1800");
+    }
+    if !(-100..=100).contains(&settings.ext_gain_db) {
+        bail!("tinySA external gain must be within -100..100 dB");
+    }
+    Ok(())
+}
+
+fn startup_options(
+    model: Model,
+    settings: &TinySaSettings,
+) -> anyhow::Result<(Vec<DeviceOption>, Vec<String>)> {
+    validate_settings_shape(settings)?;
+    let mut options = option_definitions(model);
+    let rbw = if model == Model::Basic && matches!(settings.rbw.as_str(), "0.2" | "1" | "850") {
+        "auto"
     } else {
-        SpurMode::On
+        &settings.rbw
     };
-    let mut commands = Vec::new();
-    if model.is_ultra() {
-        commands.extend(["ultra on", "ultra auto"]);
-    }
-    commands.extend(["rbw auto", "attenuate auto"]);
-    if model.is_ultra() {
-        commands.extend(["lna off", "lna2 auto", "agc auto", "spur auto"]);
+    let attenuation = if model.is_ultra() && settings.lna {
+        "0"
     } else {
-        commands.push("spur on");
+        &settings.attenuation
+    };
+    let spur = if model == Model::Basic && settings.spur == "auto" {
+        "on"
+    } else {
+        &settings.spur
+    };
+
+    let mut values = vec![
+        ("points", settings.points.to_string()),
+        ("rbw", rbw.to_string()),
+        ("attenuation", attenuation.to_string()),
+    ];
+    if model.is_ultra() {
+        values.extend([
+            ("lna", if settings.lna { "on" } else { "off" }.to_string()),
+            ("lna2", settings.lna2.clone()),
+            ("agc", settings.agc.clone()),
+        ]);
     }
-    (
-        ScanSettings {
-            points: DEFAULT_POINTS,
-            rbw_khz: None,
-            spur,
+    values.extend([
+        ("spur", spur.to_string()),
+        ("ext_gain", settings.ext_gain_db.to_string()),
+    ]);
+
+    let mut commands = Vec::new();
+    for (id, choice) in values {
+        let option_index = validate_option_choice(&options, id, &choice)?;
+        if let Some(command) = option_command(model, &options, id, &choice)? {
+            commands.push(command);
+        }
+        options[option_index].selected_choice = choice;
+    }
+    Ok((options, commands))
+}
+
+fn baseline_commands(model: Model) -> &'static [&'static str] {
+    if model.is_ultra() {
+        &[
+            "ultra on",
+            "ultra auto",
+            "rbw auto",
+            "lna off",
+            "attenuate auto",
+            "lna2 auto",
+            "agc auto",
+            "spur auto",
+            "ext_gain 0",
+        ]
+    } else {
+        &["rbw auto", "attenuate auto", "spur on", "ext_gain 0"]
+    }
+}
+
+fn option_definitions(model: Model) -> Vec<DeviceOption> {
+    let mut options = vec![
+        option(
+            "points",
+            "Points",
+            allowed_points().map(|value| value.to_string()).to_vec(),
+        ),
+        option(
+            "rbw",
+            "RBW (kHz)",
+            if model.is_ultra() {
+                strings(&[
+                    "auto", "0.2", "1", "3", "10", "30", "100", "300", "600", "850",
+                ])
+            } else {
+                strings(&["auto", "3", "10", "30", "100", "300", "600"])
+            },
+        ),
+        option(
+            "attenuation",
+            "Attenuation (dB)",
+            std::iter::once("auto".to_string())
+                .chain((0..=31).map(|value| value.to_string()))
+                .collect(),
+        ),
+    ];
+    if model.is_ultra() {
+        options.extend([
+            option("lna", "LNA", strings(&["off", "on"])),
+            option(
+                "lna2",
+                "LNA2",
+                std::iter::once("auto".to_string())
+                    .chain((0..=7).map(|value| value.to_string()))
+                    .collect(),
+            ),
+            option(
+                "agc",
+                "AGC",
+                std::iter::once("auto".to_string())
+                    .chain((0..=7).map(|value| value.to_string()))
+                    .collect(),
+            ),
+        ]);
+    }
+    options.push(option(
+        "spur",
+        "Spur removal",
+        if model.is_ultra() {
+            strings(&["off", "on", "auto"])
+        } else {
+            strings(&["off", "on"])
         },
+    ));
+    options.push(option(
+        "ext_gain",
+        "External gain (dB)",
+        (-100..=100).map(|value| value.to_string()).collect(),
+    ));
+    options
+}
+
+fn option(id: &str, label: &str, choices: Vec<String>) -> DeviceOption {
+    DeviceOption {
+        id: id.to_string(),
+        label: label.to_string(),
+        selected_choice: choices.first().cloned().unwrap_or_default(),
+        choices,
+    }
+}
+
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+fn allowed_points() -> [u32; 6] {
+    [64, 128, 290, 450, 900, 1800]
+}
+
+fn validate_option_choice(
+    options: &[DeviceOption],
+    id: &str,
+    choice: &str,
+) -> anyhow::Result<usize> {
+    let option_index = options
+        .iter()
+        .position(|option| option.id == id)
+        .with_context(|| format!("unknown tinySA option {id}"))?;
+    if !options[option_index]
+        .choices
+        .iter()
+        .any(|candidate| candidate == choice)
+    {
+        bail!("invalid choice {choice:?} for tinySA option {id}");
+    }
+    Ok(option_index)
+}
+
+fn selected_option_value<'a>(options: &'a [DeviceOption], id: &str) -> Option<&'a str> {
+    options
+        .iter()
+        .find(|option| option.id == id)
+        .map(|option| option.selected_choice.as_str())
+}
+
+fn set_selected_option(options: &mut [DeviceOption], id: &str, choice: &str) -> anyhow::Result<()> {
+    let option_index = validate_option_choice(options, id, choice)?;
+    options[option_index].selected_choice = choice.to_string();
+    Ok(())
+}
+
+fn option_command(
+    model: Model,
+    options: &[DeviceOption],
+    id: &str,
+    choice: &str,
+) -> anyhow::Result<Option<String>> {
+    validate_option_choice(options, id, choice)?;
+    let command = match id {
+        "points" => return Ok(None),
+        "rbw" => format!("rbw {choice}"),
+        "attenuation" => format!("attenuate {choice}"),
+        "lna" if model.is_ultra() => format!("lna {choice}"),
+        "lna2" if model.is_ultra() => format!("lna2 {choice}"),
+        "agc" if model.is_ultra() => format!("agc {choice}"),
+        "spur" => format!("spur {choice}"),
+        "ext_gain" => format!("ext_gain {choice}"),
+        _ => bail!("unknown tinySA option {id}"),
+    };
+    Ok(Some(command))
+}
+
+struct PreparedOption {
+    option_index: usize,
+    commands: Vec<String>,
+}
+
+fn prepare_option_update(
+    options: &[DeviceOption],
+    model: Model,
+    id: &str,
+    choice: &str,
+    span_hz: u64,
+    direct_sweep: Option<DirectSweepConfig>,
+) -> anyhow::Result<PreparedOption> {
+    let option_index = validate_option_choice(options, id, choice)?;
+    if id == "attenuation" && choice != "0" && selected_option_value(options, "lna") == Some("on") {
+        bail!("turn the tinySA LNA off before changing attenuation");
+    }
+    if id == "points" {
+        let points: u32 = choice.parse().context("tinySA point setting is invalid")?;
+        if span_hz < points as u64 {
+            bail!("tinySA span is too narrow for {points} points");
+        }
+        if direct_sweep.is_some_and(|config| config.stop_hz - config.start_hz < points as u64) {
+            bail!("tinySA sweep span is too narrow for {points} points");
+        }
+    }
+    let mut commands = Vec::new();
+    if id == "lna" && choice == "on" {
+        commands.push("attenuate 0".to_string());
+    }
+    if let Some(command) = option_command(model, options, id, choice)? {
+        commands.push(command);
+    }
+    Ok(PreparedOption {
+        option_index,
         commands,
-    )
+    })
+}
+
+fn commit_option_update(
+    options: &mut [DeviceOption],
+    option_index: usize,
+    id: &str,
+    choice: &str,
+) -> anyhow::Result<()> {
+    options[option_index].selected_choice = choice.to_string();
+    if id == "lna" && choice == "on" {
+        set_selected_option(options, "attenuation", "0")?;
+    }
+    Ok(())
+}
+
+fn execute_option_update(
+    options: &mut [DeviceOption],
+    prepared: PreparedOption,
+    id: &str,
+    choice: &str,
+    mut send: impl FnMut(&str) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    for command in &prepared.commands {
+        send(command)?;
+    }
+    commit_option_update(options, prepared.option_index, id, choice)
+}
+
+fn selected_points(options: &[DeviceOption]) -> anyhow::Result<u32> {
+    selected_option_value(options, "points")
+        .context("tinySA point setting is missing")?
+        .parse()
+        .context("tinySA point setting is invalid")
+}
+
+fn current_rbw_hz(options: &[DeviceOption]) -> Option<u32> {
+    let value = selected_option_value(options, "rbw")?;
+    if value == "auto" {
+        return None;
+    }
+    value
+        .parse::<f64>()
+        .ok()
+        .map(|khz| (khz * 1_000.0).round() as u32)
+}
+
+fn basic_option_commands(options: &[DeviceOption]) -> anyhow::Result<Vec<String>> {
+    let mut commands = Vec::new();
+    for id in ["rbw", "attenuation", "spur", "ext_gain"] {
+        let choice = selected_option_value(options, id)
+            .with_context(|| format!("tinySA {id} is missing"))?;
+        if let Some(command) = option_command(Model::Basic, options, id, choice)? {
+            commands.push(command);
+        }
+    }
+    Ok(commands)
+}
+
+fn restore_option_commands(model: Model, options: &[DeviceOption]) -> anyhow::Result<Vec<String>> {
+    if !model.is_ultra() {
+        return basic_option_commands(options);
+    }
+
+    let mut commands = vec!["lna off".to_string()];
+    for id in ["rbw", "attenuation"] {
+        let choice = selected_option_value(options, id)
+            .with_context(|| format!("tinySA {id} is missing"))?;
+        if let Some(command) = option_command(model, options, id, choice)? {
+            commands.push(command);
+        }
+    }
+    if selected_option_value(options, "lna") == Some("on") {
+        commands.push("lna on".to_string());
+    }
+    for id in ["lna2", "agc", "spur", "ext_gain"] {
+        let choice = selected_option_value(options, id)
+            .with_context(|| format!("tinySA {id} is missing"))?;
+        if let Some(command) = option_command(model, options, id, choice)? {
+            commands.push(command);
+        }
+    }
+    Ok(commands)
+}
+
+fn recover_option_state(
+    port: &mut dyn SerialPort,
+    model: Model,
+    basic_input: BasicInput,
+    options: &[DeviceOption],
+) -> anyhow::Result<()> {
+    best_effort_abort(port);
+    drain_startup(port)?;
+    send_setter_command(port, input_mode_command(model, basic_input))?;
+    send_setter_command(port, "abort on")?;
+    for command in baseline_commands(model) {
+        send_setter_command(port, command)?;
+    }
+    for command in restore_option_commands(model, options)? {
+        send_setter_command(port, &command)?;
+    }
+    Ok(())
 }
 
 fn scan_inactivity_timeout(
     segment: Segment,
     model: Model,
-    settings: ScanSettings,
+    options: &[DeviceOption],
 ) -> anyhow::Result<Duration> {
+    let rbw_setting = selected_option_value(options, "rbw").context("tinySA RBW is missing")?;
     let span_hz = segment.stop_hz.saturating_sub(segment.start_hz) as f64;
     let (minimum_rbw, maximum_rbw) = if model.is_ultra() {
         (0.2, 850.0)
     } else {
         (3.0, 600.0)
     };
-    let rbw_khz = settings
-        .rbw_khz
-        .unwrap_or_else(|| (span_hz * 7e-6).clamp(minimum_rbw, maximum_rbw));
+    let rbw_khz = if rbw_setting == "auto" {
+        (span_hz * 7e-6).clamp(minimum_rbw, maximum_rbw)
+    } else {
+        rbw_setting
+            .parse::<f64>()
+            .context("tinySA RBW setting is invalid")?
+    };
     let points = segment.points.max(1) as f64;
     let mut total_seconds = (span_hz / 20_000.0) / rbw_khz.powi(2) + points / 500.0;
-    if (settings.spur == SpurMode::On && segment.stop_hz > 800_000_000)
-        || settings.spur == SpurMode::Auto
-    {
+    let spur = selected_option_value(options, "spur").context("tinySA spur setting is missing")?;
+    if (spur == "on" && segment.stop_hz > 800_000_000) || spur == "auto" {
         total_seconds *= 2.0;
     }
     let block_seconds = total_seconds * 20.0 / points + 1.0;
@@ -1302,26 +1732,295 @@ mod tests {
     }
 
     #[test]
-    fn startup_uses_safe_automatic_controls() {
-        let (ultra, commands) = startup_settings(Model::Zs407);
-        assert_eq!(ultra.points, DEFAULT_POINTS);
-        assert_eq!(ultra.rbw_khz, None);
+    fn option_definitions_match_each_model() {
+        let basic = option_definitions(Model::Basic);
         assert_eq!(
-            commands,
+            basic
+                .iter()
+                .find(|option| option.id == "points")
+                .unwrap()
+                .choices,
+            ["64", "128", "290", "450", "900", "1800"]
+        );
+        assert_eq!(
+            basic
+                .iter()
+                .find(|option| option.id == "rbw")
+                .unwrap()
+                .choices,
+            ["auto", "3", "10", "30", "100", "300", "600"]
+        );
+        assert!(!basic.iter().any(|option| option.id == "lna"));
+        assert_eq!(
+            basic
+                .iter()
+                .find(|option| option.id == "spur")
+                .unwrap()
+                .choices,
+            ["off", "on"]
+        );
+
+        let ultra = option_definitions(Model::Zs407);
+        assert_eq!(
+            ultra
+                .iter()
+                .find(|option| option.id == "rbw")
+                .unwrap()
+                .choices,
+            ["auto", "0.2", "1", "3", "10", "30", "100", "300", "600", "850"]
+        );
+        for id in ["lna", "lna2", "agc"] {
+            assert!(ultra.iter().any(|option| option.id == id));
+        }
+        assert_eq!(
+            ultra
+                .iter()
+                .find(|option| option.id == "ext_gain")
+                .unwrap()
+                .choices
+                .len(),
+            201
+        );
+    }
+
+    #[test]
+    fn startup_sets_a_safe_baseline_before_saved_values() {
+        assert_eq!(
+            baseline_commands(Model::Zs407),
             [
                 "ultra on",
                 "ultra auto",
                 "rbw auto",
-                "attenuate auto",
                 "lna off",
+                "attenuate auto",
                 "lna2 auto",
                 "agc auto",
                 "spur auto",
+                "ext_gain 0",
             ]
         );
-        let (basic, commands) = startup_settings(Model::Basic);
-        assert_eq!(basic.spur, SpurMode::On);
-        assert_eq!(commands, ["rbw auto", "attenuate auto", "spur on"]);
+        assert_eq!(
+            baseline_commands(Model::Basic),
+            ["rbw auto", "attenuate auto", "spur on", "ext_gain 0"]
+        );
+
+        let settings = TinySaSettings {
+            points: 900,
+            rbw: "0.2".into(),
+            attenuation: "12".into(),
+            lna: true,
+            lna2: "3".into(),
+            agc: "7".into(),
+            spur: "off".into(),
+            ext_gain_db: -7,
+        };
+        let (options, commands) = startup_options(Model::Zs407, &settings).unwrap();
+        assert_eq!(
+            commands,
+            [
+                "rbw 0.2",
+                "attenuate 0",
+                "lna on",
+                "lna2 3",
+                "agc 7",
+                "spur off",
+                "ext_gain -7",
+            ]
+        );
+        assert_eq!(selected_points(&options).unwrap(), 900);
+        assert_eq!(selected_option_value(&options, "attenuation"), Some("0"));
+        assert_eq!(selected_option_value(&options, "lna"), Some("on"));
+    }
+
+    #[test]
+    fn basic_saved_values_normalize_only_documented_choices() {
+        for rbw in ["0.2", "1", "850"] {
+            let settings = TinySaSettings {
+                rbw: rbw.into(),
+                spur: "auto".into(),
+                ..TinySaSettings::default()
+            };
+            let (options, commands) = startup_options(Model::Basic, &settings).unwrap();
+            assert_eq!(selected_option_value(&options, "rbw"), Some("auto"));
+            assert_eq!(selected_option_value(&options, "spur"), Some("on"));
+            assert!(commands.iter().any(|command| command == "rbw auto"));
+            assert!(commands.iter().any(|command| command == "spur on"));
+        }
+
+        assert!(startup_options(
+            Model::Basic,
+            &TinySaSettings {
+                attenuation: "32".into(),
+                ..TinySaSettings::default()
+            },
+        )
+        .is_err());
+        assert!(startup_options(
+            Model::Basic,
+            &TinySaSettings {
+                rbw: "2".into(),
+                ..TinySaSettings::default()
+            },
+        )
+        .is_err());
+        assert!(startup_options(
+            Model::Basic,
+            &TinySaSettings {
+                spur: "maybe".into(),
+                ..TinySaSettings::default()
+            },
+        )
+        .is_err());
+        assert!(validate_settings_shape(&TinySaSettings {
+            points: 451,
+            ..TinySaSettings::default()
+        })
+        .is_err());
+        assert!(validate_settings_shape(&TinySaSettings {
+            ext_gain_db: 101,
+            ..TinySaSettings::default()
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn option_commands_are_whitelisted_after_choice_validation() {
+        let basic = option_definitions(Model::Basic);
+        assert_eq!(
+            option_command(Model::Basic, &basic, "points", "450").unwrap(),
+            None
+        );
+        assert_eq!(
+            option_command(Model::Basic, &basic, "rbw", "10").unwrap(),
+            Some("rbw 10".into())
+        );
+        assert!(option_command(Model::Basic, &basic, "rbw", "10; reset").is_err());
+        assert!(option_command(Model::Basic, &basic, "lna", "on").is_err());
+        assert!(option_command(Model::Basic, &basic, "missing", "on").is_err());
+    }
+
+    #[test]
+    fn lna_forces_zero_attenuation_and_blocks_other_values() {
+        let (mut options, _) = startup_options(Model::Zs407, &TinySaSettings::default()).unwrap();
+        set_selected_option(&mut options, "attenuation", "12").unwrap();
+        let prepared =
+            prepare_option_update(&options, Model::Zs407, "lna", "on", 10_000, None).unwrap();
+        let mut commands = Vec::new();
+        execute_option_update(&mut options, prepared, "lna", "on", |command| {
+            commands.push(command.to_string());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(commands, ["attenuate 0", "lna on"]);
+        assert_eq!(selected_option_value(&options, "attenuation"), Some("0"));
+        assert!(
+            prepare_option_update(&options, Model::Zs407, "attenuation", "auto", 10_000, None,)
+                .is_err()
+        );
+        assert!(
+            prepare_option_update(&options, Model::Zs407, "attenuation", "1", 10_000, None,)
+                .is_err()
+        );
+        assert!(
+            prepare_option_update(&options, Model::Zs407, "attenuation", "0", 10_000, None,)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn failed_setter_commands_do_not_change_option_state() {
+        let (mut options, _) = startup_options(Model::Zs407, &TinySaSettings::default()).unwrap();
+        let before = options.clone();
+        let prepared =
+            prepare_option_update(&options, Model::Zs407, "rbw", "30", 10_000, None).unwrap();
+        let result = execute_option_update(&mut options, prepared, "rbw", "30", |_| {
+            bail!("injected serial failure")
+        });
+        assert!(result.is_err());
+        assert_eq!(options, before);
+    }
+
+    #[test]
+    fn failed_lna_activation_does_not_publish_dependent_state() {
+        let (mut options, _) = startup_options(Model::Zs407, &TinySaSettings::default()).unwrap();
+        set_selected_option(&mut options, "attenuation", "12").unwrap();
+        let before = options.clone();
+        let prepared =
+            prepare_option_update(&options, Model::Zs407, "lna", "on", 10_000, None).unwrap();
+        let mut commands = Vec::new();
+        let result = execute_option_update(&mut options, prepared, "lna", "on", |command| {
+            commands.push(command.to_string());
+            if command == "lna on" {
+                bail!("injected serial failure");
+            }
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert_eq!(commands, ["attenuate 0", "lna on"]);
+        assert_eq!(options, before);
+    }
+
+    #[test]
+    fn restoring_ultra_controls_reestablishes_cached_dependencies() {
+        let settings = TinySaSettings {
+            rbw: "30".into(),
+            attenuation: "12".into(),
+            lna2: "3".into(),
+            agc: "7".into(),
+            spur: "off".into(),
+            ext_gain_db: -7,
+            ..TinySaSettings::default()
+        };
+        let (options, _) = startup_options(Model::Zs407, &settings).unwrap();
+        assert_eq!(
+            restore_option_commands(Model::Zs407, &options).unwrap(),
+            [
+                "lna off",
+                "rbw 30",
+                "attenuate 12",
+                "lna2 3",
+                "agc 7",
+                "spur off",
+                "ext_gain -7",
+            ]
+        );
+
+        let lna_settings = TinySaSettings {
+            lna: true,
+            ..settings
+        };
+        let (options, _) = startup_options(Model::Zs407, &lna_settings).unwrap();
+        assert_eq!(
+            restore_option_commands(Model::Zs407, &options).unwrap(),
+            [
+                "lna off",
+                "rbw 30",
+                "attenuate 0",
+                "lna on",
+                "lna2 3",
+                "agc 7",
+                "spur off",
+                "ext_gain -7",
+            ]
+        );
+    }
+
+    #[test]
+    fn rejected_set_option_commands_receive_one_reply() {
+        let (reply, replies) = bounded(1);
+        reject_command(
+            Command::SetOption {
+                id: "rbw".into(),
+                choice: "30".into(),
+                reply,
+            },
+            anyhow!("injected abort failure"),
+        );
+        assert!(replies.recv().unwrap().is_err());
+        assert!(matches!(
+            replies.try_recv(),
+            Err(TryRecvError::Disconnected)
+        ));
     }
 
     #[test]
@@ -1341,6 +2040,8 @@ mod tests {
             normalize_span(1.0, 959_900_000, DEFAULT_POINTS).unwrap(),
             DEFAULT_POINTS as u64
         );
+        assert_eq!(normalize_span(899.0, 959_900_000, 900).unwrap(), 900);
+        assert_eq!(normalize_span(900.0, 959_900_000, 900).unwrap(), 900);
         let frequencies =
             protocol::scan_frequencies(100_000, 100_000 + DEFAULT_POINTS as u64, DEFAULT_POINTS);
         assert!(frequencies.windows(2).all(|pair| pair[1] > pair[0]));
@@ -1438,8 +2139,8 @@ mod tests {
             stop_hz: 108_000_000,
             generation: 7,
         };
-        assert!(validate_direct_sweep(Some(valid), Model::Basic, BasicInput::Low).is_ok());
-        assert!(validate_direct_sweep(None, Model::Basic, BasicInput::Low).is_ok());
+        assert!(validate_direct_sweep(Some(valid), Model::Basic, BasicInput::Low, 450).is_ok());
+        assert!(validate_direct_sweep(None, Model::Basic, BasicInput::Low, 450).is_ok());
         assert!(validate_direct_sweep(
             Some(DirectSweepConfig {
                 start_hz: valid.stop_hz,
@@ -1447,7 +2148,8 @@ mod tests {
                 ..valid
             }),
             Model::Basic,
-            BasicInput::Low
+            BasicInput::Low,
+            450,
         )
         .is_err());
         assert!(validate_direct_sweep(
@@ -1456,7 +2158,8 @@ mod tests {
                 ..valid
             }),
             Model::Basic,
-            BasicInput::Low
+            BasicInput::Low,
+            450,
         )
         .is_err());
         assert!(validate_direct_sweep(
@@ -1466,7 +2169,8 @@ mod tests {
                 ..valid
             }),
             Model::Basic,
-            BasicInput::High
+            BasicInput::High,
+            450,
         )
         .is_ok());
         assert!(validate_direct_sweep(
@@ -1476,7 +2180,8 @@ mod tests {
                 ..valid
             }),
             Model::Basic,
-            BasicInput::High
+            BasicInput::High,
+            450,
         )
         .is_err());
         assert!(validate_direct_sweep(
@@ -1486,9 +2191,39 @@ mod tests {
                 ..valid
             }),
             Model::Basic,
-            BasicInput::Low
+            BasicInput::Low,
+            450,
         )
         .is_err());
+        let exact = DirectSweepConfig {
+            start_hz: 100_000,
+            stop_hz: 100_450,
+            generation: 1,
+        };
+        assert!(validate_direct_sweep(Some(exact), Model::Basic, BasicInput::Low, 450).is_ok());
+        assert!(validate_direct_sweep(Some(exact), Model::Basic, BasicInput::Low, 900).is_err());
+    }
+
+    #[test]
+    fn point_updates_fit_both_normal_and_direct_spans() {
+        let (options, _) = startup_options(Model::Basic, &TinySaSettings::default()).unwrap();
+        assert_eq!(
+            capabilities(Model::Basic, BasicInput::Low).sample_rate_min_hz,
+            64.0
+        );
+        assert!(prepare_option_update(&options, Model::Basic, "points", "900", 900, None).is_ok());
+        assert!(prepare_option_update(&options, Model::Basic, "points", "900", 899, None).is_err());
+        let direct = Some(DirectSweepConfig {
+            start_hz: 100_000,
+            stop_hz: 100_899,
+            generation: 1,
+        });
+        assert!(
+            prepare_option_update(&options, Model::Basic, "points", "900", 10_000, direct).is_err()
+        );
+        assert!(
+            prepare_option_update(&options, Model::Basic, "points", "450", 450, direct).is_ok()
+        );
     }
 
     #[test]
@@ -1557,18 +2292,39 @@ mod tests {
 
     #[test]
     fn narrow_rbw_expands_the_scan_deadline() {
-        let settings = ScanSettings {
-            points: DEFAULT_POINTS,
-            rbw_khz: Some(0.2),
-            spur: SpurMode::Auto,
+        let settings = TinySaSettings {
+            rbw: "0.2".into(),
+            ..TinySaSettings::default()
         };
+        let (options, _) = startup_options(Model::Zs405, &settings).unwrap();
         let segment = Segment {
             start_hz: 400_000_000,
             stop_hz: 500_000_000,
             points: 450,
         };
-        let timeout = scan_inactivity_timeout(segment, Model::Zs405, settings).unwrap();
+        assert_eq!(current_rbw_hz(&options), Some(200));
+        let timeout = scan_inactivity_timeout(segment, Model::Zs405, &options).unwrap();
         assert!(timeout > Duration::from_secs(120), "{timeout:?}");
+        let (automatic, _) = startup_options(Model::Zs405, &TinySaSettings::default()).unwrap();
+        assert_eq!(current_rbw_hz(&automatic), None);
+    }
+
+    #[test]
+    fn explicit_rbw_updates_the_next_trace_metadata_and_timeout() {
+        let (mut options, _) = startup_options(Model::Zs405, &TinySaSettings::default()).unwrap();
+        let segment = Segment {
+            start_hz: 400_000_000,
+            stop_hz: 500_000_000,
+            points: 450,
+        };
+        let automatic_timeout = scan_inactivity_timeout(segment, Model::Zs405, &options).unwrap();
+        let prepared =
+            prepare_option_update(&options, Model::Zs405, "rbw", "0.2", 10_000, None).unwrap();
+        execute_option_update(&mut options, prepared, "rbw", "0.2", |_| Ok(())).unwrap();
+        assert_eq!(current_rbw_hz(&options), Some(200));
+        assert!(
+            scan_inactivity_timeout(segment, Model::Zs405, &options).unwrap() > automatic_timeout
+        );
     }
 
     #[cfg(test)]
@@ -1579,7 +2335,12 @@ mod tests {
         #[ignore = "requires SDRTOP_TINYSA_TEST to name a connected serial port"]
         fn connected_device_streams_spectrum_frames() {
             let path = std::env::var("SDRTOP_TINYSA_TEST").expect("SDRTOP_TINYSA_TEST is not set");
-            let device = TinySaDevice::open(Path::new(&path), BasicInput::Low).unwrap();
+            let device = TinySaDevice::open(
+                Path::new(&path),
+                BasicInput::Low,
+                &TinySaSettings::default(),
+            )
+            .unwrap();
             assert!(device
                 .info()
                 .board_name
@@ -1607,6 +2368,8 @@ mod tests {
             assert_eq!(spectrum.target, PowerTraceTarget::Spectrum);
             assert_eq!(spectrum.frequencies_hz.len(), spectrum.levels_dbm.len());
             assert!(!spectrum.frequencies_hz.is_empty());
+            assert!(device.options().iter().any(|option| option.id == "rbw"));
+            device.set_option("points", "64").unwrap();
             device.stop_rx().unwrap();
             assert!(!device.is_streaming());
         }

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context};
 use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
+use serde::{Deserialize, Serialize};
 use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
 
 use crate::config::TinySaSettings;
@@ -39,7 +40,8 @@ const BASIC_HIGH_MAX_HZ: u64 = 959_000_000;
 
 type UnitReply = Sender<anyhow::Result<()>>;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum BasicInput {
     #[default]
     Low,
@@ -75,6 +77,10 @@ impl BasicInput {
             Self::High => (BASIC_HIGH_MIN_HZ, BASIC_HIGH_MAX_HZ),
         }
     }
+}
+
+pub fn resolve_basic_input(explicit: Option<BasicInput>, configured: BasicInput) -> BasicInput {
+    explicit.unwrap_or(configured)
 }
 
 pub fn list(selector: Option<&str>) -> Vec<DeviceListing> {
@@ -138,6 +144,7 @@ impl TinySaDevice {
     pub fn open(
         path: &Path,
         basic_input: BasicInput,
+        explicit_basic_input: Option<BasicInput>,
         settings: &TinySaSettings,
     ) -> anyhow::Result<Self> {
         validate_settings_shape(settings)?;
@@ -179,12 +186,17 @@ impl TinySaDevice {
             }
         };
         let caps = capabilities(initialized.identity.model, basic_input);
-        let notes = initialized
+        let mut notes = initialized
             .identity
             .hardware
             .iter()
             .cloned()
             .collect::<Vec<_>>();
+        if let Some(note) =
+            ignored_explicit_basic_input_note(initialized.identity.model, explicit_basic_input)
+        {
+            notes.push(note);
+        }
         let info = DeviceInfo {
             board_name: initialized.identity.board.clone(),
             serial: path.display().to_string(),
@@ -698,13 +710,10 @@ fn initialize(
     let help = send_text_command(port, "help")?;
     let zero = send_text_command(port, "zero")?;
     let identity = protocol::parse_identity(&version, &info, &help, &zero)?;
-    if identity.model.is_ultra() && basic_input == BasicInput::High {
-        bail!("tinySA HIGH input selection applies only to the basic model");
-    }
-    let (options, saved_commands) = startup_options(identity.model, settings)?;
+    let (options, saved_commands) = startup_options(identity.model, basic_input, settings)?;
     send_setter_command(port, input_mode_command(identity.model, basic_input))?;
     send_setter_command(port, "abort on")?;
-    for command in baseline_commands(identity.model) {
+    for command in baseline_commands(identity.model, basic_input) {
         send_setter_command(port, command)?;
     }
     for command in saved_commands {
@@ -724,6 +733,20 @@ fn input_mode_command(model: Model, basic_input: BasicInput) -> &'static str {
     } else {
         basic_input.mode_command()
     }
+}
+
+fn ignored_explicit_basic_input_note(
+    model: Model,
+    explicit_basic_input: Option<BasicInput>,
+) -> Option<String> {
+    explicit_basic_input.and_then(|input| {
+        model.is_ultra().then(|| {
+            format!(
+                "tinySA Ultra uses automatic input selection; explicit Basic {} input selection was ignored",
+                input.label()
+            )
+        })
+    })
 }
 
 fn send_text_command(port: &mut dyn SerialPort, command: &str) -> anyhow::Result<Vec<u8>> {
@@ -1223,6 +1246,7 @@ fn validate_settings_shape(settings: &TinySaSettings) -> anyhow::Result<()> {
 pub(crate) fn persisted_settings(
     loaded: &TinySaSettings,
     options: &[DeviceOption],
+    resolved_basic_input: Option<BasicInput>,
 ) -> anyhow::Result<TinySaSettings> {
     let mut settings = loaded.clone();
     for option in options {
@@ -1234,6 +1258,13 @@ pub(crate) fn persisted_settings(
             }
             "rbw" => settings.rbw = value.to_string(),
             "attenuation" => settings.attenuation = value.to_string(),
+            "high_attenuation" => {
+                settings.high_attenuation = match value {
+                    "off" => false,
+                    "on" => true,
+                    _ => bail!("tinySA HIGH attenuation setting is invalid"),
+                };
+            }
             "lna" => {
                 settings.lna = match value {
                     "off" => false,
@@ -1250,25 +1281,26 @@ pub(crate) fn persisted_settings(
             id => bail!("unknown tinySA option {id}"),
         }
     }
+    if !options.iter().any(|option| option.id == "lna") {
+        settings.basic_input =
+            resolved_basic_input.context("resolved tinySA Basic input is missing")?;
+    }
     validate_settings_shape(&settings)?;
     Ok(settings)
 }
 
 fn startup_options(
     model: Model,
+    basic_input: BasicInput,
     settings: &TinySaSettings,
 ) -> anyhow::Result<(Vec<DeviceOption>, Vec<String>)> {
     validate_settings_shape(settings)?;
-    let mut options = option_definitions(model);
+    validate_legacy_diagnostics(model, settings)?;
+    let mut options = option_definitions(model, basic_input);
     let rbw = if model == Model::Basic && matches!(settings.rbw.as_str(), "0.2" | "1" | "850") {
         "auto"
     } else {
         &settings.rbw
-    };
-    let attenuation = if model.is_ultra() && settings.lna {
-        "0"
-    } else {
-        &settings.attenuation
     };
     let spur = if model == Model::Basic && settings.spur == "auto" {
         "on"
@@ -1279,8 +1311,25 @@ fn startup_options(
     let mut values = vec![
         ("points", settings.points.to_string()),
         ("rbw", rbw.to_string()),
-        ("attenuation", attenuation.to_string()),
     ];
+    if model == Model::Basic && basic_input == BasicInput::High {
+        values.push((
+            "high_attenuation",
+            if settings.high_attenuation {
+                "on"
+            } else {
+                "off"
+            }
+            .to_string(),
+        ));
+    } else {
+        let attenuation = if model.is_ultra() && settings.lna {
+            "0"
+        } else {
+            &settings.attenuation
+        };
+        values.push(("attenuation", attenuation.to_string()));
+    }
     if model.is_ultra() {
         values.push(("lna", if settings.lna { "on" } else { "off" }.to_string()));
     }
@@ -1300,7 +1349,19 @@ fn startup_options(
     Ok((options, commands))
 }
 
-fn baseline_commands(model: Model) -> &'static [&'static str] {
+fn validate_legacy_diagnostics(model: Model, settings: &TinySaSettings) -> anyhow::Result<()> {
+    if !model.is_ultra() {
+        return Ok(());
+    }
+    for (name, value) in [("LNA2", &settings.lna2), ("AGC", &settings.agc)] {
+        if value != "auto" {
+            bail!("tinySA Ultra {name} must be 'auto': firmware overwrites it before every scan");
+        }
+    }
+    Ok(())
+}
+
+fn baseline_commands(model: Model, basic_input: BasicInput) -> &'static [&'static str] {
     if model.is_ultra() {
         &[
             "ultra on",
@@ -1311,12 +1372,14 @@ fn baseline_commands(model: Model) -> &'static [&'static str] {
             "spur auto",
             "ext_gain 0",
         ]
+    } else if basic_input == BasicInput::High {
+        &["rbw auto", "attenuate 0", "spur on", "ext_gain 0"]
     } else {
         &["rbw auto", "attenuate auto", "spur on", "ext_gain 0"]
     }
 }
 
-fn option_definitions(model: Model) -> Vec<DeviceOption> {
+fn option_definitions(model: Model, basic_input: BasicInput) -> Vec<DeviceOption> {
     let mut options = vec![
         option(
             "points",
@@ -1334,14 +1397,22 @@ fn option_definitions(model: Model) -> Vec<DeviceOption> {
                 strings(&["auto", "3", "10", "30", "100", "300", "600"])
             },
         ),
-        option(
+    ];
+    if model == Model::Basic && basic_input == BasicInput::High {
+        options.push(option(
+            "high_attenuation",
+            "Coarse attenuation",
+            strings(&["off", "on"]),
+        ));
+    } else {
+        options.push(option(
             "attenuation",
             "Attenuation (dB)",
             std::iter::once("auto".to_string())
                 .chain((0..=31).map(|value| value.to_string()))
                 .collect(),
-        ),
-    ];
+        ));
+    }
     if model.is_ultra() {
         options.push(option("lna", "LNA", strings(&["off", "on"])));
     }
@@ -1422,6 +1493,14 @@ fn option_command(
         "points" => return Ok(None),
         "rbw" => format!("rbw {choice}"),
         "attenuation" => format!("attenuate {choice}"),
+        "high_attenuation" => format!(
+            "attenuate {}",
+            match choice {
+                "off" => "0",
+                "on" => "1",
+                _ => unreachable!("validated tinySA HIGH attenuation choice"),
+            }
+        ),
         "lna" if model.is_ultra() => format!("lna {choice}"),
         "spur" => format!("spur {choice}"),
         "ext_gain" => format!("ext_gain {choice}"),
@@ -1515,7 +1594,12 @@ fn current_rbw_hz(options: &[DeviceOption]) -> Option<u32> {
 
 fn basic_option_commands(options: &[DeviceOption]) -> anyhow::Result<Vec<String>> {
     let mut commands = Vec::new();
-    for id in ["rbw", "attenuation", "spur", "ext_gain"] {
+    let attenuation_id = if options.iter().any(|option| option.id == "high_attenuation") {
+        "high_attenuation"
+    } else {
+        "attenuation"
+    };
+    for id in ["rbw", attenuation_id, "spur", "ext_gain"] {
         let choice = selected_option_value(options, id)
             .with_context(|| format!("tinySA {id} is missing"))?;
         if let Some(command) = option_command(Model::Basic, options, id, choice)? {
@@ -1561,7 +1645,7 @@ fn recover_option_state(
     drain_startup(port)?;
     send_setter_command(port, input_mode_command(model, basic_input))?;
     send_setter_command(port, "abort on")?;
-    for command in baseline_commands(model) {
+    for command in baseline_commands(model, basic_input) {
         send_setter_command(port, command)?;
     }
     for command in restore_option_commands(model, options)? {
@@ -1743,7 +1827,7 @@ mod tests {
 
     #[test]
     fn option_definitions_match_each_model() {
-        let basic = option_definitions(Model::Basic);
+        let basic = option_definitions(Model::Basic, BasicInput::Low);
         assert_eq!(
             basic
                 .iter()
@@ -1760,6 +1844,13 @@ mod tests {
                 .choices,
             ["auto", "3", "10", "30", "100", "300", "600"]
         );
+        let low_attenuation = basic
+            .iter()
+            .find(|option| option.id == "attenuation")
+            .unwrap();
+        assert_eq!(low_attenuation.label, "Attenuation (dB)");
+        assert_eq!(low_attenuation.choices.first().unwrap(), "auto");
+        assert_eq!(low_attenuation.choices.last().unwrap(), "31");
         assert!(!basic.iter().any(|option| option.id == "lna"));
         assert_eq!(
             basic
@@ -1770,7 +1861,16 @@ mod tests {
             ["off", "on"]
         );
 
-        let ultra = option_definitions(Model::Zs407);
+        let high = option_definitions(Model::Basic, BasicInput::High);
+        let high_attenuation = high
+            .iter()
+            .find(|option| option.id == "high_attenuation")
+            .unwrap();
+        assert_eq!(high_attenuation.label, "Coarse attenuation");
+        assert_eq!(high_attenuation.choices, ["off", "on"]);
+        assert!(!high.iter().any(|option| option.id == "attenuation"));
+
+        let ultra = option_definitions(Model::Zs407, BasicInput::Low);
         assert_eq!(
             ultra
                 .iter()
@@ -1796,7 +1896,7 @@ mod tests {
     #[test]
     fn startup_sets_a_safe_baseline_before_saved_values() {
         assert_eq!(
-            baseline_commands(Model::Zs407),
+            baseline_commands(Model::Zs407, BasicInput::Low),
             [
                 "ultra on",
                 "ultra auto",
@@ -1808,21 +1908,28 @@ mod tests {
             ]
         );
         assert_eq!(
-            baseline_commands(Model::Basic),
+            baseline_commands(Model::Basic, BasicInput::Low),
             ["rbw auto", "attenuate auto", "spur on", "ext_gain 0"]
+        );
+        assert_eq!(
+            baseline_commands(Model::Basic, BasicInput::High),
+            ["rbw auto", "attenuate 0", "spur on", "ext_gain 0"]
         );
 
         let settings = TinySaSettings {
+            basic_input: BasicInput::Low,
             points: 900,
             rbw: "0.2".into(),
             attenuation: "12".into(),
+            high_attenuation: false,
             lna: true,
-            lna2: "3".into(),
-            agc: "7".into(),
+            lna2: "auto".into(),
+            agc: "auto".into(),
             spur: "off".into(),
             ext_gain_db: -7,
         };
-        let (options, commands) = startup_options(Model::Zs407, &settings).unwrap();
+        let (options, commands) =
+            startup_options(Model::Zs407, BasicInput::Low, &settings).unwrap();
         assert_eq!(
             commands,
             [
@@ -1846,7 +1953,8 @@ mod tests {
                 spur: "auto".into(),
                 ..TinySaSettings::default()
             };
-            let (options, commands) = startup_options(Model::Basic, &settings).unwrap();
+            let (options, commands) =
+                startup_options(Model::Basic, BasicInput::Low, &settings).unwrap();
             assert_eq!(selected_option_value(&options, "rbw"), Some("auto"));
             assert_eq!(selected_option_value(&options, "spur"), Some("on"));
             assert!(commands.iter().any(|command| command == "rbw auto"));
@@ -1855,6 +1963,7 @@ mod tests {
 
         assert!(startup_options(
             Model::Basic,
+            BasicInput::Low,
             &TinySaSettings {
                 attenuation: "32".into(),
                 ..TinySaSettings::default()
@@ -1863,6 +1972,7 @@ mod tests {
         .is_err());
         assert!(startup_options(
             Model::Basic,
+            BasicInput::Low,
             &TinySaSettings {
                 rbw: "2".into(),
                 ..TinySaSettings::default()
@@ -1871,6 +1981,7 @@ mod tests {
         .is_err());
         assert!(startup_options(
             Model::Basic,
+            BasicInput::Low,
             &TinySaSettings {
                 spur: "maybe".into(),
                 ..TinySaSettings::default()
@@ -1891,7 +2002,7 @@ mod tests {
 
     #[test]
     fn option_commands_are_whitelisted_after_choice_validation() {
-        let basic = option_definitions(Model::Basic);
+        let basic = option_definitions(Model::Basic, BasicInput::Low);
         assert_eq!(
             option_command(Model::Basic, &basic, "points", "450").unwrap(),
             None
@@ -1903,11 +2014,23 @@ mod tests {
         assert!(option_command(Model::Basic, &basic, "rbw", "10; reset").is_err());
         assert!(option_command(Model::Basic, &basic, "lna", "on").is_err());
         assert!(option_command(Model::Basic, &basic, "missing", "on").is_err());
+
+        let high = option_definitions(Model::Basic, BasicInput::High);
+        assert_eq!(
+            option_command(Model::Basic, &high, "high_attenuation", "off").unwrap(),
+            Some("attenuate 0".into())
+        );
+        assert_eq!(
+            option_command(Model::Basic, &high, "high_attenuation", "on").unwrap(),
+            Some("attenuate 1".into())
+        );
+        assert!(option_command(Model::Basic, &high, "high_attenuation", "auto").is_err());
     }
 
     #[test]
     fn lna_forces_zero_attenuation_and_blocks_other_values() {
-        let (mut options, _) = startup_options(Model::Zs407, &TinySaSettings::default()).unwrap();
+        let (mut options, _) =
+            startup_options(Model::Zs407, BasicInput::Low, &TinySaSettings::default()).unwrap();
         set_selected_option(&mut options, "attenuation", "12").unwrap();
         let prepared =
             prepare_option_update(&options, Model::Zs407, "lna", "on", 10_000, None).unwrap();
@@ -1935,7 +2058,8 @@ mod tests {
 
     #[test]
     fn failed_setter_commands_do_not_change_option_state() {
-        let (mut options, _) = startup_options(Model::Zs407, &TinySaSettings::default()).unwrap();
+        let (mut options, _) =
+            startup_options(Model::Zs407, BasicInput::Low, &TinySaSettings::default()).unwrap();
         let before = options.clone();
         let prepared =
             prepare_option_update(&options, Model::Zs407, "rbw", "30", 10_000, None).unwrap();
@@ -1948,7 +2072,8 @@ mod tests {
 
     #[test]
     fn failed_lna_activation_does_not_publish_dependent_state() {
-        let (mut options, _) = startup_options(Model::Zs407, &TinySaSettings::default()).unwrap();
+        let (mut options, _) =
+            startup_options(Model::Zs407, BasicInput::Low, &TinySaSettings::default()).unwrap();
         set_selected_option(&mut options, "attenuation", "12").unwrap();
         let before = options.clone();
         let prepared =
@@ -1971,13 +2096,11 @@ mod tests {
         let settings = TinySaSettings {
             rbw: "30".into(),
             attenuation: "12".into(),
-            lna2: "3".into(),
-            agc: "7".into(),
             spur: "off".into(),
             ext_gain_db: -7,
             ..TinySaSettings::default()
         };
-        let (options, _) = startup_options(Model::Zs407, &settings).unwrap();
+        let (options, _) = startup_options(Model::Zs407, BasicInput::Low, &settings).unwrap();
         assert_eq!(
             restore_option_commands(Model::Zs407, &options).unwrap(),
             [
@@ -1993,7 +2116,7 @@ mod tests {
             lna: true,
             ..settings
         };
-        let (options, _) = startup_options(Model::Zs407, &lna_settings).unwrap();
+        let (options, _) = startup_options(Model::Zs407, BasicInput::Low, &lna_settings).unwrap();
         assert_eq!(
             restore_option_commands(Model::Zs407, &options).unwrap(),
             [
@@ -2016,7 +2139,8 @@ mod tests {
             agc: "4".into(),
             ..TinySaSettings::default()
         };
-        let (mut options, _) = startup_options(Model::Zs407, &loaded).unwrap();
+        let (mut options, _) =
+            startup_options(Model::Zs407, BasicInput::Low, &TinySaSettings::default()).unwrap();
         for (id, choice) in [
             ("points", "900"),
             ("rbw", "0.2"),
@@ -2028,7 +2152,7 @@ mod tests {
             set_selected_option(&mut options, id, choice).unwrap();
         }
 
-        let saved = persisted_settings(&loaded, &options).unwrap();
+        let saved = persisted_settings(&loaded, &options, Some(BasicInput::High)).unwrap();
 
         assert_eq!(saved.points, 900);
         assert_eq!(saved.rbw, "0.2");
@@ -2041,6 +2165,73 @@ mod tests {
     }
 
     #[test]
+    fn low_and_high_attenuation_persist_independently() {
+        let loaded = TinySaSettings {
+            basic_input: BasicInput::Low,
+            attenuation: "12".into(),
+            high_attenuation: true,
+            ..TinySaSettings::default()
+        };
+
+        let (mut low_options, _) = startup_options(Model::Basic, BasicInput::Low, &loaded).unwrap();
+        set_selected_option(&mut low_options, "attenuation", "7").unwrap();
+        let low_saved = persisted_settings(&loaded, &low_options, Some(BasicInput::Low)).unwrap();
+        assert_eq!(low_saved.basic_input, BasicInput::Low);
+        assert_eq!(low_saved.attenuation, "7");
+        assert!(low_saved.high_attenuation);
+
+        let (mut high_options, _) =
+            startup_options(Model::Basic, BasicInput::High, &loaded).unwrap();
+        set_selected_option(&mut high_options, "high_attenuation", "off").unwrap();
+        let high_saved =
+            persisted_settings(&loaded, &high_options, Some(BasicInput::High)).unwrap();
+        assert_eq!(high_saved.basic_input, BasicInput::High);
+        assert_eq!(high_saved.attenuation, "12");
+        assert!(!high_saved.high_attenuation);
+    }
+
+    #[test]
+    fn high_recovery_restores_the_coarse_attenuation_choice() {
+        let settings = TinySaSettings {
+            high_attenuation: true,
+            ..TinySaSettings::default()
+        };
+        let (options, commands) =
+            startup_options(Model::Basic, BasicInput::High, &settings).unwrap();
+        assert!(commands.iter().any(|command| command == "attenuate 1"));
+        assert_eq!(
+            restore_option_commands(Model::Basic, &options).unwrap(),
+            ["rbw auto", "attenuate 1", "spur on", "ext_gain 0"]
+        );
+    }
+
+    #[test]
+    fn legacy_diagnostics_are_ignored_on_basic_and_rejected_on_ultra() {
+        let manual = TinySaSettings {
+            lna2: "3".into(),
+            agc: "7".into(),
+            ..TinySaSettings::default()
+        };
+        assert!(startup_options(Model::Basic, BasicInput::Low, &manual).is_ok());
+
+        for settings in [
+            TinySaSettings {
+                lna2: "3".into(),
+                ..TinySaSettings::default()
+            },
+            TinySaSettings {
+                agc: "7".into(),
+                ..TinySaSettings::default()
+            },
+        ] {
+            let error = startup_options(Model::Zs407, BasicInput::Low, &settings)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("firmware overwrites it before every scan"));
+        }
+    }
+
+    #[test]
     fn basic_persistence_preserves_ultra_settings() {
         let loaded = TinySaSettings {
             lna: true,
@@ -2048,8 +2239,8 @@ mod tests {
             agc: "4".into(),
             ..TinySaSettings::default()
         };
-        let options = option_definitions(Model::Basic);
-        let saved = persisted_settings(&loaded, &options).unwrap();
+        let options = option_definitions(Model::Basic, BasicInput::Low);
+        let saved = persisted_settings(&loaded, &options, Some(BasicInput::Low)).unwrap();
 
         assert!(saved.lna);
         assert_eq!(saved.lna2, "5");
@@ -2059,14 +2250,19 @@ mod tests {
     #[test]
     fn persistence_rejects_malformed_option_state() {
         for id in ["points", "ext_gain"] {
-            let mut options = option_definitions(Model::Zs407);
+            let mut options = option_definitions(Model::Zs407, BasicInput::Low);
             options
                 .iter_mut()
                 .find(|option| option.id == id)
                 .unwrap()
                 .selected_choice = "invalid".into();
 
-            assert!(persisted_settings(&TinySaSettings::default(), &options).is_err());
+            assert!(persisted_settings(
+                &TinySaSettings::default(),
+                &options,
+                Some(BasicInput::Low)
+            )
+            .is_err());
         }
     }
 
@@ -2271,7 +2467,8 @@ mod tests {
 
     #[test]
     fn point_updates_fit_both_normal_and_direct_spans() {
-        let (options, _) = startup_options(Model::Basic, &TinySaSettings::default()).unwrap();
+        let (options, _) =
+            startup_options(Model::Basic, BasicInput::Low, &TinySaSettings::default()).unwrap();
         assert_eq!(
             capabilities(Model::Basic, BasicInput::Low).sample_rate_min_hz,
             64.0
@@ -2334,6 +2531,46 @@ mod tests {
     }
 
     #[test]
+    fn basic_input_resolution_uses_config_until_the_cli_overrides_it() {
+        assert_eq!(
+            resolve_basic_input(None, BasicInput::High),
+            BasicInput::High
+        );
+        assert_eq!(
+            resolve_basic_input(Some(BasicInput::Low), BasicInput::High),
+            BasicInput::Low
+        );
+        assert_eq!(
+            resolve_basic_input(Some(BasicInput::High), BasicInput::Low),
+            BasicInput::High
+        );
+    }
+
+    #[test]
+    fn ultra_ignores_basic_input_and_warns_only_for_an_explicit_selector() {
+        let settings = TinySaSettings {
+            basic_input: BasicInput::High,
+            ..TinySaSettings::default()
+        };
+        let (options, _) = startup_options(Model::Zs407, settings.basic_input, &settings).unwrap();
+        let saved = persisted_settings(&settings, &options, Some(settings.basic_input)).unwrap();
+        assert_eq!(saved.basic_input, BasicInput::High);
+        assert_eq!(
+            input_mode_command(Model::Zs407, BasicInput::High),
+            "mode input"
+        );
+        assert!(ignored_explicit_basic_input_note(Model::Zs407, None).is_none());
+        for input in [BasicInput::Low, BasicInput::High] {
+            let note = ignored_explicit_basic_input_note(Model::Zs407, Some(input)).unwrap();
+            assert!(note.contains(&format!(
+                "explicit Basic {} input selection was ignored",
+                input.label()
+            )));
+        }
+        assert!(ignored_explicit_basic_input_note(Model::Basic, Some(BasicInput::High)).is_none());
+    }
+
+    #[test]
     fn only_an_explicit_selector_overrides_the_basic_input() {
         let bare = list(Some("/dev/ttyACM2"));
         assert_eq!(bare.len(), 1);
@@ -2361,7 +2598,7 @@ mod tests {
             rbw: "0.2".into(),
             ..TinySaSettings::default()
         };
-        let (options, _) = startup_options(Model::Zs405, &settings).unwrap();
+        let (options, _) = startup_options(Model::Zs405, BasicInput::Low, &settings).unwrap();
         let segment = Segment {
             start_hz: 400_000_000,
             stop_hz: 500_000_000,
@@ -2370,13 +2607,15 @@ mod tests {
         assert_eq!(current_rbw_hz(&options), Some(200));
         let timeout = scan_inactivity_timeout(segment, Model::Zs405, &options).unwrap();
         assert!(timeout > Duration::from_secs(120), "{timeout:?}");
-        let (automatic, _) = startup_options(Model::Zs405, &TinySaSettings::default()).unwrap();
+        let (automatic, _) =
+            startup_options(Model::Zs405, BasicInput::Low, &TinySaSettings::default()).unwrap();
         assert_eq!(current_rbw_hz(&automatic), None);
     }
 
     #[test]
     fn explicit_rbw_updates_the_next_trace_metadata_and_timeout() {
-        let (mut options, _) = startup_options(Model::Zs405, &TinySaSettings::default()).unwrap();
+        let (mut options, _) =
+            startup_options(Model::Zs405, BasicInput::Low, &TinySaSettings::default()).unwrap();
         let segment = Segment {
             start_hz: 400_000_000,
             stop_hz: 500_000_000,
@@ -2403,6 +2642,7 @@ mod tests {
             let device = TinySaDevice::open(
                 Path::new(&path),
                 BasicInput::Low,
+                None,
                 &TinySaSettings::default(),
             )
             .unwrap();

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -539,7 +539,7 @@ impl Worker {
             Command::Start(context, reply) => {
                 let result = if !self.prompt_ready {
                     Err(anyhow!(
-                        "tinySA serial state is unknown; reconnect the analyzer"
+                        "tinySA serial state is unknown; restart sdrtop, reconnecting the analyzer first if needed"
                     ))
                 } else if self.rx_context.is_some() {
                     Err(anyhow!("tinySA acquisition is already running"))
@@ -614,7 +614,9 @@ impl Worker {
 
     fn apply_option(&mut self, id: &str, choice: &str) -> anyhow::Result<()> {
         if !self.prompt_ready {
-            bail!("tinySA serial state is unknown; reconnect the analyzer");
+            bail!(
+                "tinySA serial state is unknown; restart sdrtop, reconnecting the analyzer first if needed"
+            );
         }
         let prepared = prepare_option_update(
             &self.options,
@@ -1862,6 +1864,69 @@ mod tests {
 
     fn bytes(value: &[u8]) -> ReadStep {
         ReadStep::Bytes(value.iter().copied().collect())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unknown_serial_state_rejects_start_and_options_without_device_writes() {
+        let (worker_port, peer_port) = serialport::TTYPort::pair().unwrap();
+        let (_command_tx, command_rx) = crossbeam_channel::unbounded();
+        let options = option_definitions(Model::Basic, BasicInput::Low);
+        let mut worker = Worker {
+            port: Box::new(worker_port),
+            command_rx,
+            identity: Identity {
+                firmware: "test".into(),
+                hardware: None,
+                board: "test".into(),
+                zero_dbm: 0,
+                model: Model::Basic,
+            },
+            option_state: Arc::new(Mutex::new(options.clone())),
+            modified_options: Arc::new(Mutex::new(HashSet::new())),
+            options,
+            basic_input: BasicInput::Low,
+            center_hz: default_frequency(Model::Basic, BasicInput::Low),
+            span_hz: DEFAULT_SPAN_HZ,
+            direct_sweep: None,
+            rx_context: None,
+            prompt_ready: false,
+        };
+        let state = Arc::new(Mutex::new(crate::state::SdrMetrics::fixture()));
+        let (sample_tx, _) = crossbeam_channel::bounded(1);
+        let (demod_tx, _) = crossbeam_channel::bounded(1);
+        let (net_tx, _) = crossbeam_channel::bounded(1);
+        let (power_tx, _) = crossbeam_channel::bounded(1);
+        let context = Arc::new(RxContext {
+            metrics: state,
+            sample_tx,
+            fft_feed: crate::hardware::FeedHealth::default(),
+            demod_tx,
+            net_tx,
+            net_feed: crate::hardware::FeedHealth::default(),
+            power_tx,
+            geometry: capabilities(Model::Basic, BasicInput::Low).sample_geometry,
+        });
+
+        let (start_tx, start_rx) = bounded(1);
+        assert!(worker.handle_command(Command::Start(context, start_tx)));
+        let start_error = start_rx.recv().unwrap().unwrap_err().to_string();
+        assert!(start_error.contains("restart sdrtop"));
+        assert!(worker.rx_context.is_none());
+
+        let (option_tx, option_rx) = bounded(1);
+        assert!(worker.handle_command(Command::SetOption {
+            id: "spur".into(),
+            choice: "off".into(),
+            reply: option_tx,
+        }));
+        let option_error = option_rx.recv().unwrap().unwrap_err().to_string();
+        assert!(option_error.contains("restart sdrtop"));
+        assert_eq!(peer_port.bytes_to_read().unwrap(), 0);
+
+        let (shutdown_tx, shutdown_rx) = bounded(1);
+        assert!(!worker.handle_command(Command::Shutdown(shutdown_tx)));
+        shutdown_rx.recv().unwrap().unwrap();
     }
 
     #[test]

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -714,7 +714,7 @@ fn initialize(
     send_setter_command(port, input_mode_command(identity.model, basic_input))?;
     send_setter_command(port, "abort on")?;
     for command in baseline_commands(identity.model, basic_input) {
-        send_setter_command(port, command)?;
+        send_setter_command(port, &command)?;
     }
     for command in saved_commands {
         send_setter_command(port, &command)?;
@@ -1341,9 +1341,7 @@ fn startup_options(
     let mut commands = Vec::new();
     for (id, choice) in values {
         let option_index = validate_option_choice(&options, id, &choice)?;
-        if let Some(command) = option_command(model, &options, id, &choice)? {
-            commands.push(command);
-        }
+        commands.extend(option_commands(model, &options, id, &choice)?);
         options[option_index].selected_choice = choice;
     }
     Ok((options, commands))
@@ -1361,9 +1359,9 @@ fn validate_legacy_diagnostics(model: Model, settings: &TinySaSettings) -> anyho
     Ok(())
 }
 
-fn baseline_commands(model: Model, basic_input: BasicInput) -> &'static [&'static str] {
+fn baseline_commands(model: Model, basic_input: BasicInput) -> Vec<String> {
     if model.is_ultra() {
-        &[
+        strings(&[
             "ultra on",
             "ultra auto",
             "rbw auto",
@@ -1371,11 +1369,14 @@ fn baseline_commands(model: Model, basic_input: BasicInput) -> &'static [&'stati
             "attenuate auto",
             "spur auto",
             "ext_gain 0",
-        ]
+        ])
     } else if basic_input == BasicInput::High {
-        &["rbw auto", "attenuate 0", "spur on", "ext_gain 0"]
+        let mut commands = vec!["rbw auto".to_string()];
+        commands.extend(high_attenuation_commands("off"));
+        commands.extend(strings(&["spur on", "ext_gain 0"]));
+        commands
     } else {
-        &["rbw auto", "attenuate auto", "spur on", "ext_gain 0"]
+        strings(&["rbw auto", "attenuate auto", "spur on", "ext_gain 0"])
     }
 }
 
@@ -1482,31 +1483,46 @@ fn set_selected_option(options: &mut [DeviceOption], id: &str, choice: &str) -> 
     Ok(())
 }
 
-fn option_command(
+fn option_commands(
     model: Model,
     options: &[DeviceOption],
     id: &str,
     choice: &str,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Vec<String>> {
     validate_option_choice(options, id, choice)?;
-    let command = match id {
-        "points" => return Ok(None),
-        "rbw" => format!("rbw {choice}"),
-        "attenuation" => format!("attenuate {choice}"),
-        "high_attenuation" => format!(
-            "attenuate {}",
-            match choice {
-                "off" => "0",
-                "on" => "1",
-                _ => unreachable!("validated tinySA HIGH attenuation choice"),
-            }
-        ),
-        "lna" if model.is_ultra() => format!("lna {choice}"),
-        "spur" => format!("spur {choice}"),
-        "ext_gain" => format!("ext_gain {choice}"),
+    let commands = match id {
+        "points" => Vec::new(),
+        "rbw" => vec![format!("rbw {choice}")],
+        "attenuation" => manual_attenuation_commands(choice),
+        "high_attenuation" => high_attenuation_commands(choice),
+        "lna" if model.is_ultra() => vec![format!("lna {choice}")],
+        "spur" => vec![format!("spur {choice}")],
+        "ext_gain" => vec![format!("ext_gain {choice}")],
         _ => bail!("unknown tinySA option {id}"),
     };
-    Ok(Some(command))
+    Ok(commands)
+}
+
+fn manual_attenuation_commands(choice: &str) -> Vec<String> {
+    if choice == "auto" {
+        return vec!["attenuate auto".to_string()];
+    }
+    let target: u8 = choice
+        .parse()
+        .expect("validated tinySA attenuation choice must be numeric");
+    let transition = if target == 0 { 1 } else { 0 };
+    vec![
+        format!("attenuate {transition}"),
+        format!("attenuate {target}"),
+    ]
+}
+
+fn high_attenuation_commands(choice: &str) -> Vec<String> {
+    let mut commands = vec!["attenuate 1".to_string(), "attenuate 0".to_string()];
+    if choice == "on" {
+        commands.push("attenuate 1".to_string());
+    }
+    commands
 }
 
 struct PreparedOption {
@@ -1535,12 +1551,17 @@ fn prepare_option_update(
             bail!("tinySA sweep span is too narrow for {points} points");
         }
     }
+    let lna_is_on = selected_option_value(options, "lna") == Some("on");
     let mut commands = Vec::new();
     if id == "lna" && choice == "on" {
-        commands.push("attenuate 0".to_string());
+        commands.extend(manual_attenuation_commands("0"));
     }
-    if let Some(command) = option_command(model, options, id, choice)? {
-        commands.push(command);
+    if id == "attenuation" && lna_is_on {
+        commands.push("lna off".to_string());
+        commands.extend(option_commands(model, options, id, choice)?);
+        commands.push("lna on".to_string());
+    } else {
+        commands.extend(option_commands(model, options, id, choice)?);
     }
     Ok(PreparedOption {
         option_index,
@@ -1602,9 +1623,7 @@ fn basic_option_commands(options: &[DeviceOption]) -> anyhow::Result<Vec<String>
     for id in ["rbw", attenuation_id, "spur", "ext_gain"] {
         let choice = selected_option_value(options, id)
             .with_context(|| format!("tinySA {id} is missing"))?;
-        if let Some(command) = option_command(Model::Basic, options, id, choice)? {
-            commands.push(command);
-        }
+        commands.extend(option_commands(Model::Basic, options, id, choice)?);
     }
     Ok(commands)
 }
@@ -1618,9 +1637,7 @@ fn restore_option_commands(model: Model, options: &[DeviceOption]) -> anyhow::Re
     for id in ["rbw", "attenuation"] {
         let choice = selected_option_value(options, id)
             .with_context(|| format!("tinySA {id} is missing"))?;
-        if let Some(command) = option_command(model, options, id, choice)? {
-            commands.push(command);
-        }
+        commands.extend(option_commands(model, options, id, choice)?);
     }
     if selected_option_value(options, "lna") == Some("on") {
         commands.push("lna on".to_string());
@@ -1628,9 +1645,7 @@ fn restore_option_commands(model: Model, options: &[DeviceOption]) -> anyhow::Re
     for id in ["spur", "ext_gain"] {
         let choice = selected_option_value(options, id)
             .with_context(|| format!("tinySA {id} is missing"))?;
-        if let Some(command) = option_command(model, options, id, choice)? {
-            commands.push(command);
-        }
+        commands.extend(option_commands(model, options, id, choice)?);
     }
     Ok(commands)
 }
@@ -1646,7 +1661,7 @@ fn recover_option_state(
     send_setter_command(port, input_mode_command(model, basic_input))?;
     send_setter_command(port, "abort on")?;
     for command in baseline_commands(model, basic_input) {
-        send_setter_command(port, command)?;
+        send_setter_command(port, &command)?;
     }
     for command in restore_option_commands(model, options)? {
         send_setter_command(port, &command)?;
@@ -1913,7 +1928,13 @@ mod tests {
         );
         assert_eq!(
             baseline_commands(Model::Basic, BasicInput::High),
-            ["rbw auto", "attenuate 0", "spur on", "ext_gain 0"]
+            [
+                "rbw auto",
+                "attenuate 1",
+                "attenuate 0",
+                "spur on",
+                "ext_gain 0",
+            ]
         );
 
         let settings = TinySaSettings {
@@ -1934,6 +1955,7 @@ mod tests {
             commands,
             [
                 "rbw 0.2",
+                "attenuate 1",
                 "attenuate 0",
                 "lna on",
                 "spur off",
@@ -2004,27 +2026,96 @@ mod tests {
     fn option_commands_are_whitelisted_after_choice_validation() {
         let basic = option_definitions(Model::Basic, BasicInput::Low);
         assert_eq!(
-            option_command(Model::Basic, &basic, "points", "450").unwrap(),
-            None
+            option_commands(Model::Basic, &basic, "points", "450").unwrap(),
+            Vec::<String>::new()
         );
         assert_eq!(
-            option_command(Model::Basic, &basic, "rbw", "10").unwrap(),
-            Some("rbw 10".into())
+            option_commands(Model::Basic, &basic, "rbw", "10").unwrap(),
+            ["rbw 10"]
         );
-        assert!(option_command(Model::Basic, &basic, "rbw", "10; reset").is_err());
-        assert!(option_command(Model::Basic, &basic, "lna", "on").is_err());
-        assert!(option_command(Model::Basic, &basic, "missing", "on").is_err());
+        assert!(option_commands(Model::Basic, &basic, "rbw", "10; reset").is_err());
+        assert!(option_commands(Model::Basic, &basic, "lna", "on").is_err());
+        assert!(option_commands(Model::Basic, &basic, "missing", "on").is_err());
 
         let high = option_definitions(Model::Basic, BasicInput::High);
         assert_eq!(
-            option_command(Model::Basic, &high, "high_attenuation", "off").unwrap(),
-            Some("attenuate 0".into())
+            option_commands(Model::Basic, &high, "high_attenuation", "off").unwrap(),
+            ["attenuate 1", "attenuate 0"]
         );
         assert_eq!(
-            option_command(Model::Basic, &high, "high_attenuation", "on").unwrap(),
-            Some("attenuate 1".into())
+            option_commands(Model::Basic, &high, "high_attenuation", "on").unwrap(),
+            ["attenuate 1", "attenuate 0", "attenuate 1"]
         );
-        assert!(option_command(Model::Basic, &high, "high_attenuation", "auto").is_err());
+        assert!(option_commands(Model::Basic, &high, "high_attenuation", "auto").is_err());
+    }
+
+    #[test]
+    fn manual_attenuation_plans_clear_firmware_auto_mode() {
+        struct FirmwareAttenuation {
+            value: u8,
+            automatic: bool,
+            high_input: bool,
+        }
+
+        impl FirmwareAttenuation {
+            fn apply(&mut self, command: &str) {
+                let choice = command.strip_prefix("attenuate ").unwrap();
+                if choice == "auto" {
+                    self.value = if self.high_input { 0 } else { 30 };
+                    self.automatic = true;
+                    return;
+                }
+                let value = choice.parse().unwrap();
+                if self.value == value {
+                    return;
+                }
+                self.value = value;
+                if !self.high_input || value == 0 {
+                    self.automatic = false;
+                }
+            }
+        }
+
+        for (high_input, target, commands) in [
+            (false, 30, manual_attenuation_commands("30")),
+            (true, 0, high_attenuation_commands("off")),
+            (true, 1, high_attenuation_commands("on")),
+        ] {
+            let mut firmware = FirmwareAttenuation {
+                value: if high_input { 0 } else { 30 },
+                automatic: true,
+                high_input,
+            };
+            for command in commands {
+                firmware.apply(&command);
+            }
+            assert_eq!(firmware.value, target);
+            assert!(!firmware.automatic);
+        }
+    }
+
+    #[test]
+    fn basic_low_startup_and_recovery_force_manual_attenuation() {
+        let settings = TinySaSettings {
+            attenuation: "30".into(),
+            ..TinySaSettings::default()
+        };
+        let (options, startup) = startup_options(Model::Basic, BasicInput::Low, &settings).unwrap();
+
+        assert_eq!(
+            startup,
+            [
+                "rbw auto",
+                "attenuate 0",
+                "attenuate 30",
+                "spur on",
+                "ext_gain 0",
+            ]
+        );
+        assert_eq!(
+            restore_option_commands(Model::Basic, &options).unwrap(),
+            startup
+        );
     }
 
     #[test]
@@ -2040,7 +2131,7 @@ mod tests {
             Ok(())
         })
         .unwrap();
-        assert_eq!(commands, ["attenuate 0", "lna on"]);
+        assert_eq!(commands, ["attenuate 1", "attenuate 0", "lna on"]);
         assert_eq!(selected_option_value(&options, "attenuation"), Some("0"));
         assert!(
             prepare_option_update(&options, Model::Zs407, "attenuation", "auto", 10_000, None,)
@@ -2053,6 +2144,14 @@ mod tests {
         assert!(
             prepare_option_update(&options, Model::Zs407, "attenuation", "0", 10_000, None,)
                 .is_ok()
+        );
+
+        let prepared =
+            prepare_option_update(&options, Model::Zs407, "attenuation", "0", 10_000, None)
+                .unwrap();
+        assert_eq!(
+            prepared.commands,
+            ["lna off", "attenuate 1", "attenuate 0", "lna on",]
         );
     }
 
@@ -2087,7 +2186,7 @@ mod tests {
             Ok(())
         });
         assert!(result.is_err());
-        assert_eq!(commands, ["attenuate 0", "lna on"]);
+        assert_eq!(commands, ["attenuate 1", "attenuate 0", "lna on"]);
         assert_eq!(options, before);
     }
 
@@ -2106,6 +2205,7 @@ mod tests {
             [
                 "lna off",
                 "rbw 30",
+                "attenuate 0",
                 "attenuate 12",
                 "spur off",
                 "ext_gain -7",
@@ -2122,6 +2222,7 @@ mod tests {
             [
                 "lna off",
                 "rbw 30",
+                "attenuate 1",
                 "attenuate 0",
                 "lna on",
                 "spur off",
@@ -2201,7 +2302,14 @@ mod tests {
         assert!(commands.iter().any(|command| command == "attenuate 1"));
         assert_eq!(
             restore_option_commands(Model::Basic, &options).unwrap(),
-            ["rbw auto", "attenuate 1", "spur on", "ext_gain 0"]
+            [
+                "rbw auto",
+                "attenuate 1",
+                "attenuate 0",
+                "attenuate 1",
+                "spur on",
+                "ext_gain 0",
+            ]
         );
     }
 

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -1220,6 +1220,40 @@ fn validate_settings_shape(settings: &TinySaSettings) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub(crate) fn persisted_settings(
+    loaded: &TinySaSettings,
+    options: &[DeviceOption],
+) -> anyhow::Result<TinySaSettings> {
+    let mut settings = loaded.clone();
+    for option in options {
+        let value = option.selected_choice.as_str();
+        validate_option_choice(options, &option.id, value)?;
+        match option.id.as_str() {
+            "points" => {
+                settings.points = value.parse().context("tinySA point setting is invalid")?;
+            }
+            "rbw" => settings.rbw = value.to_string(),
+            "attenuation" => settings.attenuation = value.to_string(),
+            "lna" => {
+                settings.lna = match value {
+                    "off" => false,
+                    "on" => true,
+                    _ => bail!("tinySA LNA setting is invalid"),
+                };
+            }
+            "spur" => settings.spur = value.to_string(),
+            "ext_gain" => {
+                settings.ext_gain_db = value
+                    .parse()
+                    .context("tinySA external gain setting is invalid")?;
+            }
+            id => bail!("unknown tinySA option {id}"),
+        }
+    }
+    validate_settings_shape(&settings)?;
+    Ok(settings)
+}
+
 fn startup_options(
     model: Model,
     settings: &TinySaSettings,
@@ -1248,11 +1282,7 @@ fn startup_options(
         ("attenuation", attenuation.to_string()),
     ];
     if model.is_ultra() {
-        values.extend([
-            ("lna", if settings.lna { "on" } else { "off" }.to_string()),
-            ("lna2", settings.lna2.clone()),
-            ("agc", settings.agc.clone()),
-        ]);
+        values.push(("lna", if settings.lna { "on" } else { "off" }.to_string()));
     }
     values.extend([
         ("spur", spur.to_string()),
@@ -1278,8 +1308,6 @@ fn baseline_commands(model: Model) -> &'static [&'static str] {
             "rbw auto",
             "lna off",
             "attenuate auto",
-            "lna2 auto",
-            "agc auto",
             "spur auto",
             "ext_gain 0",
         ]
@@ -1315,23 +1343,7 @@ fn option_definitions(model: Model) -> Vec<DeviceOption> {
         ),
     ];
     if model.is_ultra() {
-        options.extend([
-            option("lna", "LNA", strings(&["off", "on"])),
-            option(
-                "lna2",
-                "LNA2",
-                std::iter::once("auto".to_string())
-                    .chain((0..=7).map(|value| value.to_string()))
-                    .collect(),
-            ),
-            option(
-                "agc",
-                "AGC",
-                std::iter::once("auto".to_string())
-                    .chain((0..=7).map(|value| value.to_string()))
-                    .collect(),
-            ),
-        ]);
+        options.push(option("lna", "LNA", strings(&["off", "on"])));
     }
     options.push(option(
         "spur",
@@ -1411,8 +1423,6 @@ fn option_command(
         "rbw" => format!("rbw {choice}"),
         "attenuation" => format!("attenuate {choice}"),
         "lna" if model.is_ultra() => format!("lna {choice}"),
-        "lna2" if model.is_ultra() => format!("lna2 {choice}"),
-        "agc" if model.is_ultra() => format!("agc {choice}"),
         "spur" => format!("spur {choice}"),
         "ext_gain" => format!("ext_gain {choice}"),
         _ => bail!("unknown tinySA option {id}"),
@@ -1531,7 +1541,7 @@ fn restore_option_commands(model: Model, options: &[DeviceOption]) -> anyhow::Re
     if selected_option_value(options, "lna") == Some("on") {
         commands.push("lna on".to_string());
     }
-    for id in ["lna2", "agc", "spur", "ext_gain"] {
+    for id in ["spur", "ext_gain"] {
         let choice = selected_option_value(options, id)
             .with_context(|| format!("tinySA {id} is missing"))?;
         if let Some(command) = option_command(model, options, id, choice)? {
@@ -1769,9 +1779,9 @@ mod tests {
                 .choices,
             ["auto", "0.2", "1", "3", "10", "30", "100", "300", "600", "850"]
         );
-        for id in ["lna", "lna2", "agc"] {
-            assert!(ultra.iter().any(|option| option.id == id));
-        }
+        assert!(ultra.iter().any(|option| option.id == "lna"));
+        assert!(!ultra.iter().any(|option| option.id == "lna2"));
+        assert!(!ultra.iter().any(|option| option.id == "agc"));
         assert_eq!(
             ultra
                 .iter()
@@ -1793,8 +1803,6 @@ mod tests {
                 "rbw auto",
                 "lna off",
                 "attenuate auto",
-                "lna2 auto",
-                "agc auto",
                 "spur auto",
                 "ext_gain 0",
             ]
@@ -1821,8 +1829,6 @@ mod tests {
                 "rbw 0.2",
                 "attenuate 0",
                 "lna on",
-                "lna2 3",
-                "agc 7",
                 "spur off",
                 "ext_gain -7",
             ]
@@ -1978,8 +1984,6 @@ mod tests {
                 "lna off",
                 "rbw 30",
                 "attenuate 12",
-                "lna2 3",
-                "agc 7",
                 "spur off",
                 "ext_gain -7",
             ]
@@ -1997,12 +2001,73 @@ mod tests {
                 "rbw 30",
                 "attenuate 0",
                 "lna on",
-                "lna2 3",
-                "agc 7",
                 "spur off",
                 "ext_gain -7",
             ]
         );
+    }
+
+    #[test]
+    fn ultra_persistence_uses_authoritative_dependent_settings() {
+        let loaded = TinySaSettings {
+            attenuation: "12".into(),
+            lna: true,
+            lna2: "5".into(),
+            agc: "4".into(),
+            ..TinySaSettings::default()
+        };
+        let (mut options, _) = startup_options(Model::Zs407, &loaded).unwrap();
+        for (id, choice) in [
+            ("points", "900"),
+            ("rbw", "0.2"),
+            ("attenuation", "0"),
+            ("lna", "on"),
+            ("spur", "off"),
+            ("ext_gain", "-12"),
+        ] {
+            set_selected_option(&mut options, id, choice).unwrap();
+        }
+
+        let saved = persisted_settings(&loaded, &options).unwrap();
+
+        assert_eq!(saved.points, 900);
+        assert_eq!(saved.rbw, "0.2");
+        assert_eq!(saved.attenuation, "0");
+        assert!(saved.lna);
+        assert_eq!(saved.lna2, "5");
+        assert_eq!(saved.agc, "4");
+        assert_eq!(saved.spur, "off");
+        assert_eq!(saved.ext_gain_db, -12);
+    }
+
+    #[test]
+    fn basic_persistence_preserves_ultra_settings() {
+        let loaded = TinySaSettings {
+            lna: true,
+            lna2: "5".into(),
+            agc: "4".into(),
+            ..TinySaSettings::default()
+        };
+        let options = option_definitions(Model::Basic);
+        let saved = persisted_settings(&loaded, &options).unwrap();
+
+        assert!(saved.lna);
+        assert_eq!(saved.lna2, "5");
+        assert_eq!(saved.agc, "4");
+    }
+
+    #[test]
+    fn persistence_rejects_malformed_option_state() {
+        for id in ["points", "ext_gain"] {
+            let mut options = option_definitions(Model::Zs407);
+            options
+                .iter_mut()
+                .find(|option| option.id == id)
+                .unwrap()
+                .selected_choice = "invalid".into();
+
+            assert!(persisted_settings(&TinySaSettings::default(), &options).is_err());
+        }
     }
 
     #[test]

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -135,6 +135,8 @@ pub struct TinySaDevice {
     caps: DeviceCapabilities,
     info: DeviceInfo,
     notes: Vec<String>,
+    model: Model,
+    basic_input: BasicInput,
     options: Arc<Mutex<Vec<DeviceOption>>>,
     command_tx: Sender<Command>,
     worker: Mutex<Option<JoinHandle<()>>>,
@@ -210,6 +212,8 @@ impl TinySaDevice {
             caps,
             info,
             notes,
+            model: initialized.identity.model,
+            basic_input,
             options,
             command_tx,
             worker: Mutex::new(Some(worker)),
@@ -287,6 +291,16 @@ impl SdrDevice for TinySaDevice {
             choice: choice.to_string(),
             reply,
         })
+    }
+
+    fn update_config(&self, config: &mut crate::config::AppConfig) -> anyhow::Result<()> {
+        config.tinysa = persisted_settings(
+            &config.tinysa,
+            &self.options(),
+            self.model,
+            self.basic_input,
+        )?;
+        Ok(())
     }
 
     fn open_notes(&self) -> &[String] {
@@ -1235,18 +1249,25 @@ fn trace_frequencies(measured_hz: Vec<u64>, target: PowerTraceTarget) -> anyhow:
 
 fn validate_settings_shape(settings: &TinySaSettings) -> anyhow::Result<()> {
     if !allowed_points().contains(&settings.points) {
-        bail!("tinySA points must be one of 64, 128, 290, 450, 900, or 1800");
+        bail!(
+            "[tinysa].points has invalid value {}; allowed values: 64, 128, 290, 450, 900, 1800",
+            settings.points
+        );
     }
     if !(-100..=100).contains(&settings.ext_gain_db) {
-        bail!("tinySA external gain must be within -100..100 dB");
+        bail!(
+            "[tinysa].ext_gain_db has invalid value {}; allowed range: -100..=100 dB",
+            settings.ext_gain_db
+        );
     }
     Ok(())
 }
 
-pub(crate) fn persisted_settings(
+fn persisted_settings(
     loaded: &TinySaSettings,
     options: &[DeviceOption],
-    resolved_basic_input: Option<BasicInput>,
+    model: Model,
+    basic_input: BasicInput,
 ) -> anyhow::Result<TinySaSettings> {
     let mut settings = loaded.clone();
     for option in options {
@@ -1281,9 +1302,8 @@ pub(crate) fn persisted_settings(
             id => bail!("unknown tinySA option {id}"),
         }
     }
-    if !options.iter().any(|option| option.id == "lna") {
-        settings.basic_input =
-            resolved_basic_input.context("resolved tinySA Basic input is missing")?;
+    if model == Model::Basic {
+        settings.basic_input = basic_input;
     }
     validate_settings_shape(&settings)?;
     Ok(settings)
@@ -1295,7 +1315,6 @@ fn startup_options(
     settings: &TinySaSettings,
 ) -> anyhow::Result<(Vec<DeviceOption>, Vec<String>)> {
     validate_settings_shape(settings)?;
-    validate_legacy_diagnostics(model, settings)?;
     let mut options = option_definitions(model, basic_input);
     let rbw = if model == Model::Basic && matches!(settings.rbw.as_str(), "0.2" | "1" | "850") {
         "auto"
@@ -1340,23 +1359,11 @@ fn startup_options(
 
     let mut commands = Vec::new();
     for (id, choice) in values {
-        let option_index = validate_option_choice(&options, id, &choice)?;
+        let option_index = validate_setting_choice(&options, id, &choice)?;
         commands.extend(option_commands(model, &options, id, &choice)?);
         options[option_index].selected_choice = choice;
     }
     Ok((options, commands))
-}
-
-fn validate_legacy_diagnostics(model: Model, settings: &TinySaSettings) -> anyhow::Result<()> {
-    if !model.is_ultra() {
-        return Ok(());
-    }
-    for (name, value) in [("LNA2", &settings.lna2), ("AGC", &settings.agc)] {
-        if value != "auto" {
-            bail!("tinySA Ultra {name} must be 'auto': firmware overwrites it before every scan");
-        }
-    }
-    Ok(())
 }
 
 fn baseline_commands(model: Model, basic_input: BasicInput) -> Vec<String> {
@@ -1468,6 +1475,34 @@ fn validate_option_choice(
         bail!("invalid choice {choice:?} for tinySA option {id}");
     }
     Ok(option_index)
+}
+
+fn validate_setting_choice(
+    options: &[DeviceOption],
+    id: &str,
+    choice: &str,
+) -> anyhow::Result<usize> {
+    let option_index = options
+        .iter()
+        .position(|option| option.id == id)
+        .with_context(|| format!("unknown tinySA option {id}"))?;
+    if options[option_index]
+        .choices
+        .iter()
+        .any(|candidate| candidate == choice)
+    {
+        return Ok(option_index);
+    }
+    let key = match id {
+        "ext_gain" => "ext_gain_db",
+        other => other,
+    };
+    let allowed = match id {
+        "ext_gain" => "-100..=100".to_string(),
+        "attenuation" => "auto or 0..=31".to_string(),
+        _ => options[option_index].choices.join(", "),
+    };
+    bail!("[tinysa].{key} has invalid value {choice:?}; allowed values: {allowed}");
 }
 
 fn selected_option_value<'a>(options: &'a [DeviceOption], id: &str) -> Option<&'a str> {
@@ -1945,8 +1980,6 @@ mod tests {
             attenuation: "12".into(),
             high_attenuation: false,
             lna: true,
-            lna2: "auto".into(),
-            agc: "auto".into(),
             spur: "off".into(),
             ext_gain_db: -7,
         };
@@ -2236,10 +2269,9 @@ mod tests {
     #[test]
     fn ultra_persistence_uses_authoritative_dependent_settings() {
         let loaded = TinySaSettings {
+            basic_input: BasicInput::High,
             attenuation: "12".into(),
             lna: true,
-            lna2: "5".into(),
-            agc: "4".into(),
             ..TinySaSettings::default()
         };
         let (mut options, _) =
@@ -2255,16 +2287,51 @@ mod tests {
             set_selected_option(&mut options, id, choice).unwrap();
         }
 
-        let saved = persisted_settings(&loaded, &options, Some(BasicInput::High)).unwrap();
+        let saved = persisted_settings(&loaded, &options, Model::Zs407, BasicInput::Low).unwrap();
 
         assert_eq!(saved.points, 900);
         assert_eq!(saved.rbw, "0.2");
         assert_eq!(saved.attenuation, "0");
         assert!(saved.lna);
-        assert_eq!(saved.lna2, "5");
-        assert_eq!(saved.agc, "4");
+        assert_eq!(saved.basic_input, BasicInput::High);
         assert_eq!(saved.spur, "off");
         assert_eq!(saved.ext_gain_db, -12);
+    }
+
+    #[test]
+    fn config_hook_owns_the_resolved_basic_input_and_option_snapshot() {
+        let loaded = TinySaSettings {
+            basic_input: BasicInput::Low,
+            attenuation: "12".into(),
+            high_attenuation: true,
+            lna: true,
+            ..TinySaSettings::default()
+        };
+        let (mut options, _) = startup_options(Model::Basic, BasicInput::High, &loaded).unwrap();
+        set_selected_option(&mut options, "high_attenuation", "off").unwrap();
+        let (command_tx, command_rx) = crossbeam_channel::unbounded();
+        drop(command_rx);
+        let device = TinySaDevice {
+            caps: capabilities(Model::Basic, BasicInput::High),
+            info: DeviceInfo::default(),
+            notes: Vec::new(),
+            model: Model::Basic,
+            basic_input: BasicInput::High,
+            options: Arc::new(Mutex::new(options)),
+            command_tx,
+            worker: Mutex::new(None),
+        };
+        let mut config = crate::config::AppConfig {
+            tinysa: loaded,
+            ..crate::config::AppConfig::default()
+        };
+
+        device.update_config(&mut config).unwrap();
+
+        assert_eq!(config.tinysa.basic_input, BasicInput::High);
+        assert_eq!(config.tinysa.attenuation, "12");
+        assert!(!config.tinysa.high_attenuation);
+        assert!(config.tinysa.lna);
     }
 
     #[test]
@@ -2278,7 +2345,8 @@ mod tests {
 
         let (mut low_options, _) = startup_options(Model::Basic, BasicInput::Low, &loaded).unwrap();
         set_selected_option(&mut low_options, "attenuation", "7").unwrap();
-        let low_saved = persisted_settings(&loaded, &low_options, Some(BasicInput::Low)).unwrap();
+        let low_saved =
+            persisted_settings(&loaded, &low_options, Model::Basic, BasicInput::Low).unwrap();
         assert_eq!(low_saved.basic_input, BasicInput::Low);
         assert_eq!(low_saved.attenuation, "7");
         assert!(low_saved.high_attenuation);
@@ -2287,7 +2355,7 @@ mod tests {
             startup_options(Model::Basic, BasicInput::High, &loaded).unwrap();
         set_selected_option(&mut high_options, "high_attenuation", "off").unwrap();
         let high_saved =
-            persisted_settings(&loaded, &high_options, Some(BasicInput::High)).unwrap();
+            persisted_settings(&loaded, &high_options, Model::Basic, BasicInput::High).unwrap();
         assert_eq!(high_saved.basic_input, BasicInput::High);
         assert_eq!(high_saved.attenuation, "12");
         assert!(!high_saved.high_attenuation);
@@ -2316,45 +2384,42 @@ mod tests {
     }
 
     #[test]
-    fn legacy_diagnostics_are_ignored_on_basic_and_rejected_on_ultra() {
-        let manual = TinySaSettings {
-            lna2: "3".into(),
-            agc: "7".into(),
-            ..TinySaSettings::default()
-        };
-        assert!(startup_options(Model::Basic, BasicInput::Low, &manual).is_ok());
-
-        for settings in [
-            TinySaSettings {
-                lna2: "3".into(),
-                ..TinySaSettings::default()
-            },
-            TinySaSettings {
-                agc: "7".into(),
-                ..TinySaSettings::default()
-            },
-        ] {
-            let error = startup_options(Model::Zs407, BasicInput::Low, &settings)
-                .unwrap_err()
-                .to_string();
-            assert!(error.contains("firmware overwrites it before every scan"));
-        }
-    }
-
-    #[test]
     fn basic_persistence_preserves_ultra_settings() {
         let loaded = TinySaSettings {
             lna: true,
-            lna2: "5".into(),
-            agc: "4".into(),
             ..TinySaSettings::default()
         };
         let options = option_definitions(Model::Basic, BasicInput::Low);
-        let saved = persisted_settings(&loaded, &options, Some(BasicInput::Low)).unwrap();
+        let saved = persisted_settings(&loaded, &options, Model::Basic, BasicInput::Low).unwrap();
 
         assert!(saved.lna);
-        assert_eq!(saved.lna2, "5");
-        assert_eq!(saved.agc, "4");
+    }
+
+    #[test]
+    fn startup_errors_name_the_config_key_value_and_allowed_values() {
+        let points = validate_settings_shape(&TinySaSettings {
+            points: 451,
+            ..TinySaSettings::default()
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(points.contains("[tinysa].points"));
+        assert!(points.contains("451"));
+        assert!(points.contains("64, 128, 290, 450, 900, 1800"));
+
+        let rbw = startup_options(
+            Model::Basic,
+            BasicInput::Low,
+            &TinySaSettings {
+                rbw: "2".into(),
+                ..TinySaSettings::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(rbw.contains("[tinysa].rbw"));
+        assert!(rbw.contains("\"2\""));
+        assert!(rbw.contains("auto, 3, 10, 30, 100, 300, 600"));
     }
 
     #[test]
@@ -2370,7 +2435,8 @@ mod tests {
             assert!(persisted_settings(
                 &TinySaSettings::default(),
                 &options,
-                Some(BasicInput::Low)
+                Model::Zs407,
+                BasicInput::Low
             )
             .is_err());
         }
@@ -2663,7 +2729,8 @@ mod tests {
             ..TinySaSettings::default()
         };
         let (options, _) = startup_options(Model::Zs407, settings.basic_input, &settings).unwrap();
-        let saved = persisted_settings(&settings, &options, Some(settings.basic_input)).unwrap();
+        let saved =
+            persisted_settings(&settings, &options, Model::Zs407, settings.basic_input).unwrap();
         assert_eq!(saved.basic_input, BasicInput::High);
         assert_eq!(
             input_mode_command(Model::Zs407, BasicInput::High),

--- a/src/hardware/tinysa/mod.rs
+++ b/src/hardware/tinysa/mod.rs
@@ -4,6 +4,7 @@
 mod discovery;
 mod protocol;
 
+use std::collections::HashSet;
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -138,6 +139,7 @@ pub struct TinySaDevice {
     model: Model,
     basic_input: BasicInput,
     options: Arc<Mutex<Vec<DeviceOption>>>,
+    modified_options: Arc<Mutex<HashSet<String>>>,
     command_tx: Sender<Command>,
     worker: Mutex<Option<JoinHandle<()>>>,
 }
@@ -161,7 +163,9 @@ impl TinySaDevice {
         let (command_tx, command_rx) = crossbeam_channel::unbounded();
         let (init_tx, init_rx) = bounded(1);
         let options = Arc::new(Mutex::new(Vec::new()));
+        let modified_options = Arc::new(Mutex::new(HashSet::new()));
         let worker_options = Arc::clone(&options);
+        let worker_modified_options = Arc::clone(&modified_options);
         let settings = settings.clone();
         let worker = thread::Builder::new()
             .name("tinysa-serial".to_string())
@@ -173,6 +177,7 @@ impl TinySaDevice {
                     basic_input,
                     settings,
                     worker_options,
+                    worker_modified_options,
                 )
             })
             .context("failed to start tinySA serial worker")?;
@@ -215,6 +220,7 @@ impl TinySaDevice {
             model: initialized.identity.model,
             basic_input,
             options,
+            modified_options,
             command_tx,
             worker: Mutex::new(Some(worker)),
         })
@@ -299,6 +305,10 @@ impl SdrDevice for TinySaDevice {
             &self.options(),
             self.model,
             self.basic_input,
+            &self
+                .modified_options
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()),
         )?;
         Ok(())
     }
@@ -350,6 +360,7 @@ struct Worker {
     identity: Identity,
     options: Vec<DeviceOption>,
     option_state: Arc<Mutex<Vec<DeviceOption>>>,
+    modified_options: Arc<Mutex<HashSet<String>>>,
     basic_input: BasicInput,
     center_hz: u64,
     span_hz: u64,
@@ -393,6 +404,7 @@ fn worker_entry(
     basic_input: BasicInput,
     settings: TinySaSettings,
     option_state: Arc<Mutex<Vec<DeviceOption>>>,
+    modified_options: Arc<Mutex<HashSet<String>>>,
 ) {
     let (identity, options) = match initialize(&mut *port, basic_input, &settings) {
         Ok(value) => value,
@@ -419,6 +431,7 @@ fn worker_entry(
         identity,
         options,
         option_state,
+        modified_options,
         basic_input,
         center_hz,
         span_hz: DEFAULT_SPAN_HZ,
@@ -624,13 +637,12 @@ impl Worker {
                 &self.options,
             );
             self.prompt_ready = recovery.is_ok();
-            return match recovery {
-                Ok(()) => Err(error),
-                Err(recovery_error) => Err(error.context(format!(
-                    "failed to restore tinySA controls after the error: {recovery_error}"
-                ))),
-            };
+            return Err(option_update_failure(error, recovery));
         }
+        self.modified_options
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .insert(id.to_string());
         *self
             .option_state
             .lock()
@@ -690,6 +702,20 @@ impl Worker {
             effective_center_hz,
             effective_span_hz,
         })
+    }
+}
+
+fn option_update_failure(
+    setter_error: anyhow::Error,
+    recovery: anyhow::Result<()>,
+) -> anyhow::Error {
+    match recovery {
+        Ok(()) => anyhow!(
+            "{setter_error:#}; previous accepted tinySA controls were restored and acquisition was stopped"
+        ),
+        Err(recovery_error) => anyhow!(
+            "{setter_error:#}; acquisition was stopped; failed to restore tinySA controls: {recovery_error:#}"
+        ),
     }
 }
 
@@ -1268,11 +1294,18 @@ fn persisted_settings(
     options: &[DeviceOption],
     model: Model,
     basic_input: BasicInput,
+    modified_options: &HashSet<String>,
 ) -> anyhow::Result<TinySaSettings> {
     let mut settings = loaded.clone();
     for option in options {
         let value = option.selected_choice.as_str();
         validate_option_choice(options, &option.id, value)?;
+        if model == Model::Basic
+            && matches!(option.id.as_str(), "rbw" | "spur")
+            && !modified_options.contains(&option.id)
+        {
+            continue;
+        }
         match option.id.as_str() {
             "points" => {
                 settings.points = value.parse().context("tinySA point setting is invalid")?;
@@ -1413,12 +1446,13 @@ fn option_definitions(model: Model, basic_input: BasicInput) -> Vec<DeviceOption
             strings(&["off", "on"]),
         ));
     } else {
-        options.push(option(
+        options.push(integer_option(
             "attenuation",
             "Attenuation (dB)",
             std::iter::once("auto".to_string())
                 .chain((0..=31).map(|value| value.to_string()))
                 .collect(),
+            0..=31,
         ));
     }
     if model.is_ultra() {
@@ -1433,10 +1467,11 @@ fn option_definitions(model: Model, basic_input: BasicInput) -> Vec<DeviceOption
             strings(&["off", "on"])
         },
     ));
-    options.push(option(
+    options.push(integer_option(
         "ext_gain",
         "External gain (dB)",
         (-100..=100).map(|value| value.to_string()).collect(),
+        -100..=100,
     ));
     options
 }
@@ -1447,6 +1482,19 @@ fn option(id: &str, label: &str, choices: Vec<String>) -> DeviceOption {
         label: label.to_string(),
         selected_choice: choices.first().cloned().unwrap_or_default(),
         choices,
+        integer_range: None,
+    }
+}
+
+fn integer_option(
+    id: &str,
+    label: &str,
+    choices: Vec<String>,
+    range: std::ops::RangeInclusive<i32>,
+) -> DeviceOption {
+    DeviceOption {
+        integer_range: Some(range),
+        ..option(id, label, choices)
     }
 }
 
@@ -1902,6 +1950,11 @@ mod tests {
         assert_eq!(low_attenuation.label, "Attenuation (dB)");
         assert_eq!(low_attenuation.choices.first().unwrap(), "auto");
         assert_eq!(low_attenuation.choices.last().unwrap(), "31");
+        assert_eq!(low_attenuation.integer_range, Some(0..=31));
+        assert!(basic
+            .iter()
+            .filter(|option| option.id != "attenuation" && option.id != "ext_gain")
+            .all(|option| option.integer_range.is_none()));
         assert!(!basic.iter().any(|option| option.id == "lna"));
         assert_eq!(
             basic
@@ -1919,6 +1972,7 @@ mod tests {
             .unwrap();
         assert_eq!(high_attenuation.label, "Coarse attenuation");
         assert_eq!(high_attenuation.choices, ["off", "on"]);
+        assert!(high_attenuation.integer_range.is_none());
         assert!(!high.iter().any(|option| option.id == "attenuation"));
 
         let ultra = option_definitions(Model::Zs407, BasicInput::Low);
@@ -1933,15 +1987,9 @@ mod tests {
         assert!(ultra.iter().any(|option| option.id == "lna"));
         assert!(!ultra.iter().any(|option| option.id == "lna2"));
         assert!(!ultra.iter().any(|option| option.id == "agc"));
-        assert_eq!(
-            ultra
-                .iter()
-                .find(|option| option.id == "ext_gain")
-                .unwrap()
-                .choices
-                .len(),
-            201
-        );
+        let external_gain = ultra.iter().find(|option| option.id == "ext_gain").unwrap();
+        assert_eq!(external_gain.choices.len(), 201);
+        assert_eq!(external_gain.integer_range, Some(-100..=100));
     }
 
     #[test]
@@ -2287,7 +2335,16 @@ mod tests {
             set_selected_option(&mut options, id, choice).unwrap();
         }
 
-        let saved = persisted_settings(&loaded, &options, Model::Zs407, BasicInput::Low).unwrap();
+        let modified = HashSet::from([
+            "points".to_string(),
+            "rbw".to_string(),
+            "attenuation".to_string(),
+            "lna".to_string(),
+            "spur".to_string(),
+            "ext_gain".to_string(),
+        ]);
+        let saved = persisted_settings(&loaded, &options, Model::Zs407, BasicInput::Low, &modified)
+            .unwrap();
 
         assert_eq!(saved.points, 900);
         assert_eq!(saved.rbw, "0.2");
@@ -2318,6 +2375,7 @@ mod tests {
             model: Model::Basic,
             basic_input: BasicInput::High,
             options: Arc::new(Mutex::new(options)),
+            modified_options: Arc::new(Mutex::new(HashSet::from(["high_attenuation".to_string()]))),
             command_tx,
             worker: Mutex::new(None),
         };
@@ -2345,8 +2403,14 @@ mod tests {
 
         let (mut low_options, _) = startup_options(Model::Basic, BasicInput::Low, &loaded).unwrap();
         set_selected_option(&mut low_options, "attenuation", "7").unwrap();
-        let low_saved =
-            persisted_settings(&loaded, &low_options, Model::Basic, BasicInput::Low).unwrap();
+        let low_saved = persisted_settings(
+            &loaded,
+            &low_options,
+            Model::Basic,
+            BasicInput::Low,
+            &HashSet::from(["attenuation".to_string()]),
+        )
+        .unwrap();
         assert_eq!(low_saved.basic_input, BasicInput::Low);
         assert_eq!(low_saved.attenuation, "7");
         assert!(low_saved.high_attenuation);
@@ -2354,11 +2418,69 @@ mod tests {
         let (mut high_options, _) =
             startup_options(Model::Basic, BasicInput::High, &loaded).unwrap();
         set_selected_option(&mut high_options, "high_attenuation", "off").unwrap();
-        let high_saved =
-            persisted_settings(&loaded, &high_options, Model::Basic, BasicInput::High).unwrap();
+        let high_saved = persisted_settings(
+            &loaded,
+            &high_options,
+            Model::Basic,
+            BasicInput::High,
+            &HashSet::from(["high_attenuation".to_string()]),
+        )
+        .unwrap();
         assert_eq!(high_saved.basic_input, BasicInput::High);
         assert_eq!(high_saved.attenuation, "12");
         assert!(!high_saved.high_attenuation);
+    }
+
+    #[test]
+    fn basic_normalization_persists_only_after_successful_operator_updates() {
+        for rbw in ["0.2", "1", "850"] {
+            let loaded = TinySaSettings {
+                rbw: rbw.into(),
+                spur: "auto".into(),
+                ..TinySaSettings::default()
+            };
+            let (options, _) = startup_options(Model::Basic, BasicInput::Low, &loaded).unwrap();
+            assert_eq!(selected_option_value(&options, "rbw"), Some("auto"));
+            assert_eq!(selected_option_value(&options, "spur"), Some("on"));
+
+            let unchanged = persisted_settings(
+                &loaded,
+                &options,
+                Model::Basic,
+                BasicInput::Low,
+                &HashSet::new(),
+            )
+            .unwrap();
+            assert_eq!(unchanged.rbw, rbw);
+            assert_eq!(unchanged.spur, "auto");
+
+            let modified = HashSet::from(["rbw".to_string(), "spur".to_string()]);
+            let changed =
+                persisted_settings(&loaded, &options, Model::Basic, BasicInput::Low, &modified)
+                    .unwrap();
+            assert_eq!(changed.rbw, "auto");
+            assert_eq!(changed.spur, "on");
+        }
+    }
+
+    #[test]
+    fn option_failure_reports_successful_and_failed_recovery() {
+        let recovered =
+            option_update_failure(anyhow!("setter rejected: invalid\\x00response"), Ok(()))
+                .to_string();
+        assert!(recovered.contains("setter rejected: invalid\\x00response"));
+        assert!(recovered.contains("previous accepted tinySA controls were restored"));
+        assert!(recovered.contains("acquisition was stopped"));
+
+        let failed = option_update_failure(
+            anyhow!("setter rejected: invalid response"),
+            Err(anyhow!("recovery command was rejected")),
+        )
+        .to_string();
+        assert!(failed.contains("setter rejected: invalid response"));
+        assert!(failed.contains("failed to restore tinySA controls"));
+        assert!(failed.contains("recovery command was rejected"));
+        assert!(failed.contains("acquisition was stopped"));
     }
 
     #[test]
@@ -2390,7 +2512,14 @@ mod tests {
             ..TinySaSettings::default()
         };
         let options = option_definitions(Model::Basic, BasicInput::Low);
-        let saved = persisted_settings(&loaded, &options, Model::Basic, BasicInput::Low).unwrap();
+        let saved = persisted_settings(
+            &loaded,
+            &options,
+            Model::Basic,
+            BasicInput::Low,
+            &HashSet::new(),
+        )
+        .unwrap();
 
         assert!(saved.lna);
     }
@@ -2436,7 +2565,8 @@ mod tests {
                 &TinySaSettings::default(),
                 &options,
                 Model::Zs407,
-                BasicInput::Low
+                BasicInput::Low,
+                &HashSet::new(),
             )
             .is_err());
         }
@@ -2729,8 +2859,14 @@ mod tests {
             ..TinySaSettings::default()
         };
         let (options, _) = startup_options(Model::Zs407, settings.basic_input, &settings).unwrap();
-        let saved =
-            persisted_settings(&settings, &options, Model::Zs407, settings.basic_input).unwrap();
+        let saved = persisted_settings(
+            &settings,
+            &options,
+            Model::Zs407,
+            settings.basic_input,
+            &HashSet::new(),
+        )
+        .unwrap();
         assert_eq!(saved.basic_input, BasicInput::High);
         assert_eq!(
             input_mode_command(Model::Zs407, BasicInput::High),

--- a/src/hardware/tinysa/protocol.rs
+++ b/src/hardware/tinysa/protocol.rs
@@ -71,9 +71,27 @@ pub(super) fn parse_text_frame(frame: &[u8], command: &str) -> anyhow::Result<Ve
 
 pub(super) fn validate_setter_body(body: &[u8], command: &str) -> anyhow::Result<()> {
     if !body.is_empty() {
-        bail!("tinySA {command} command returned an unexpected response");
+        bail!(
+            "tinySA {command} command returned an unexpected response: {}",
+            escaped_excerpt(body)
+        );
     }
     Ok(())
+}
+
+fn escaped_excerpt(body: &[u8]) -> String {
+    const MAX_CHARS: usize = 120;
+    let mut excerpt = String::new();
+    for byte in body {
+        for escaped in std::ascii::escape_default(*byte) {
+            if excerpt.len() == MAX_CHARS {
+                excerpt.push_str("...");
+                return excerpt;
+            }
+            excerpt.push(char::from(escaped));
+        }
+    }
+    excerpt
 }
 
 pub(super) fn parse_identity(
@@ -214,6 +232,20 @@ mod tests {
         ] {
             assert!(validate_setter_body(body, "rbw 10").is_err());
         }
+    }
+
+    #[test]
+    fn setter_rejections_include_a_bounded_escaped_excerpt() {
+        let mut body = b"error:\tinvalid\x00value\r\n".to_vec();
+        body.extend(std::iter::repeat_n(b'x', 200));
+
+        let error = validate_setter_body(&body, "rbw 10")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains(r"error:\tinvalid\x00value\r\n"));
+        assert!(error.ends_with("..."));
+        assert!(error.len() < 200);
     }
 
     #[test]

--- a/src/hardware/tinysa/protocol.rs
+++ b/src/hardware/tinysa/protocol.rs
@@ -69,6 +69,13 @@ pub(super) fn parse_text_frame(frame: &[u8], command: &str) -> anyhow::Result<Ve
     Ok(body.to_vec())
 }
 
+pub(super) fn validate_setter_body(body: &[u8], command: &str) -> anyhow::Result<()> {
+    if !body.is_empty() {
+        bail!("tinySA {command} command returned an unexpected response");
+    }
+    Ok(())
+}
+
 pub(super) fn parse_identity(
     version: &[u8],
     info: &[u8],
@@ -194,6 +201,19 @@ mod tests {
         assert!(parse_text_frame(b"tinySA_v1.4\r\nch> ", "version").is_err());
         assert!(parse_text_frame(b"version\r\ntinySA_v1.4\r\n", "version").is_err());
         assert!(parse_text_frame(b"frobnicate\r\nfrobnicate?\r\nch> ", "frobnicate").is_err());
+    }
+
+    #[test]
+    fn setters_require_an_empty_response_body() {
+        assert!(validate_setter_body(b"", "rbw 10").is_ok());
+        for body in [
+            b"usage: rbw {auto|3|10}\r\n".as_slice(),
+            b"error: invalid value\r\n".as_slice(),
+            b"ok\r\n".as_slice(),
+            b"\r\n".as_slice(),
+        ] {
+            assert!(validate_setter_body(body, "rbw 10").is_err());
+        }
     }
 
     #[test]

--- a/src/hardware/traits.rs
+++ b/src/hardware/traits.rs
@@ -1131,6 +1131,11 @@ pub trait SdrDevice: Send + Sync {
         anyhow::bail!("this backend has no device options")
     }
 
+    /// Update backend-owned settings before the app saves its config snapshot.
+    fn update_config(&self, _config: &mut crate::config::AppConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Set one stage by position, exactly.
     ///
     /// **One path for every backend.** The default maps position onto the two

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ mod state;
 mod tasks;
 mod ui;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use app::App;
 use clap::Parser;
 use cli::Cli;
@@ -83,6 +83,12 @@ fn restore_stderr(saved: Option<i32>) {
             libc::close(s);
         }
     }
+}
+
+fn application_result(result: io::Result<()>) -> Result<()> {
+    result
+        .map_err(anyhow::Error::from)
+        .context("Application error")
 }
 
 #[tokio::main]
@@ -218,17 +224,37 @@ async fn main() -> Result<()> {
     )?;
     terminal.show_cursor()?;
 
-    if let Err(err) = result {
-        eprintln!("Application error: {:?}", err);
-    }
-
-    Ok(())
+    application_result(result)
 }
 
 #[cfg(test)]
 mod cli_tests {
-    use super::Cli;
+    use super::{application_result, Cli};
     use clap::CommandFactory;
+    use std::io;
+
+    #[test]
+    fn application_errors_keep_the_full_chain_for_process_failure() {
+        let error = anyhow::anyhow!("config file could not be replaced")
+            .context("failed to save session settings");
+        let rendered = format!(
+            "{:?}",
+            application_result(Err(io::Error::other(error))).unwrap_err()
+        );
+
+        assert_eq!(rendered.matches("Application error").count(), 1);
+        assert_eq!(
+            rendered.matches("failed to save session settings").count(),
+            1
+        );
+        assert_eq!(
+            rendered
+                .matches("config file could not be replaced")
+                .count(),
+            1
+        );
+        assert!(!rendered.contains("Custom {"));
+    }
 
     /// `--version` has to exist and lead with the crate's own version.
     ///

--- a/user_docs/config.md
+++ b/user_docs/config.md
@@ -157,10 +157,8 @@ Basic analyzers convert `spur = "auto"` to `"on"`. They also convert Ultra-only
 RBW values `0.2`, `1` and `850` to `"auto"`. The Ultra-only LNA value stays in
 the file when a Basic analyzer is used.
 
-Legacy `lna2` and `agc` fields remain readable and survive config saves. Basic
-sessions ignore them. Ultra sessions accept only `"auto"`. A manual value stops
-the open with an error because Ultra firmware overwrites LNA2 and AGC before
-every scan. Other invalid values are reported when a tinySA opens.
+Invalid values are reported with the `[tinysa]` key and its allowed choices when
+a tinySA opens.
 
 ---
 

--- a/user_docs/config.md
+++ b/user_docs/config.md
@@ -148,14 +148,19 @@ Basic LOW and Ultra use `attenuation`. Its choices are `auto` or 0–31 dB. Basi
 HIGH uses `high_attenuation`. `false` sends `attenuate 0`. `true` sends
 `attenuate 1`, which enables the firmware's frequency-dependent coarse
 attenuation of roughly 25–40 dB. Each connector's setting is saved separately.
+Press Enter on LOW or Ultra attenuation to type a value from 0 to 31. Use the
+arrow keys to select `auto`. External gain accepts direct integer entry from
+-100 to 100 dB.
 
 Ultra firmware always selects its input automatically. `basic_input` remains
 unchanged after an Ultra session. An explicit Basic input in `--device` is
 ignored on Ultra and produces a note in the startup log.
 
-Basic analyzers convert `spur = "auto"` to `"on"`. They also convert Ultra-only
-RBW values `0.2`, `1` and `850` to `"auto"`. The Ultra-only LNA value stays in
-the file when a Basic analyzer is used.
+Basic analyzers use `spur = "on"` when the file contains `"auto"` and use
+`rbw = "auto"` for Ultra-only RBW values `0.2`, `1` and `850`. These original
+values stay in the file unless you explicitly change the corresponding option
+during the Basic session. The Ultra-only LNA value also stays in the file when
+a Basic analyzer is used.
 
 Invalid values are reported with the `[tinysa]` key and its allowed choices when
 a tinySA opens.

--- a/user_docs/config.md
+++ b/user_docs/config.md
@@ -65,8 +65,6 @@ points = 450                # 64, 128, 290, 450, 900 or 1800
 rbw = "auto"                # resolution bandwidth in kHz
 attenuation = "auto"        # auto or 0–31 dB
 lna = false                 # Ultra only
-lna2 = "auto"               # Ultra only: auto or 0–7
-agc = "auto"                # Ultra only: auto or 0–7
 spur = "auto"               # Basic uses on/off; Ultra also accepts auto
 ext_gain_db = 0             # -100–100 dB
 ```
@@ -139,9 +137,11 @@ are saved from the analyzer's current state on quit. Other backends preserve the
 block unchanged.
 
 Basic analyzers convert `spur = "auto"` to `"on"`. They also convert Ultra-only
-RBW values `0.2`, `1` and `850` to `"auto"`. Ultra-only LNA, LNA2 and AGC values
-stay in the file when a Basic analyzer is used. Other invalid values are reported
-when a tinySA opens.
+RBW values `0.2`, `1` and `850` to `"auto"`. The Ultra-only LNA value stays in
+the file when a Basic analyzer is used. Legacy `lna2` and `agc` values are
+accepted and preserved without being applied. Verified ZS405 firmware reloads
+its internal LNA2 and AGC values before every scan. Other invalid values are
+reported when a tinySA opens.
 
 ---
 

--- a/user_docs/config.md
+++ b/user_docs/config.md
@@ -141,7 +141,7 @@ block unchanged.
 `basic_input` selects the Basic model's physical connector for the full session.
 It accepts `low` from 100 kHz to 350 MHz or `high` from 240 MHz to 959 MHz.
 This is a startup-only setting. Restart sdrtop after editing it. An explicit
-`?input=low` or `?input=high` in `--device` takes priority for that session. A
+`?input=low` or `?input=high` in `--device` takes priority at startup. A
 bare `--device tinysa` or `--device tinysa=PATH` uses `basic_input`.
 
 Basic LOW and Ultra use `attenuation`. Its choices are `auto` or 0–31 dB. Basic

--- a/user_docs/config.md
+++ b/user_docs/config.md
@@ -59,6 +59,16 @@ base = "nord"                        # see themes.md for the six palettes
 start_hz = 400000000       # scanner band start
 stop_hz  = 500000000       # scanner band end
 dwell_ms = 200             # measure time per step (50–2000)
+
+[tinysa]
+points = 450                # 64, 128, 290, 450, 900 or 1800
+rbw = "auto"                # resolution bandwidth in kHz
+attenuation = "auto"        # auto or 0–31 dB
+lna = false                 # Ultra only
+lna2 = "auto"               # Ultra only: auto or 0–7
+agc = "auto"                # Ultra only: auto or 0–7
+spur = "auto"               # Basic uses on/off; Ultra also accepts auto
+ext_gain_db = 0             # -100–100 dB
 ```
 
 Each waterfall cell shows two rows of history, so `waterfall_max_rows` is twice
@@ -122,6 +132,16 @@ spectrum focus, and both persist once you've picked one.
 [Themes](themes.md).
 
 **`[sweep]`** configures the band scanner, described below.
+
+**`[tinysa]`** sets the controls applied after the backend resets the analyzer to
+a safe input baseline. The Options pane updates these values at runtime. They
+are saved from the analyzer's current state on quit. Other backends preserve the
+block unchanged.
+
+Basic analyzers convert `spur = "auto"` to `"on"`. They also convert Ultra-only
+RBW values `0.2`, `1` and `850` to `"auto"`. Ultra-only LNA, LNA2 and AGC values
+stay in the file when a Basic analyzer is used. Other invalid values are reported
+when a tinySA opens.
 
 ---
 

--- a/user_docs/config.md
+++ b/user_docs/config.md
@@ -61,9 +61,11 @@ stop_hz  = 500000000       # scanner band end
 dwell_ms = 200             # measure time per step (50–2000)
 
 [tinysa]
+basic_input = "low"        # Basic only: low or high
 points = 450                # 64, 128, 290, 450, 900 or 1800
 rbw = "auto"                # resolution bandwidth in kHz
-attenuation = "auto"        # auto or 0–31 dB
+attenuation = "auto"        # Basic LOW and Ultra: auto or 0–31 dB
+high_attenuation = false    # Basic HIGH coarse attenuation
 lna = false                 # Ultra only
 spur = "auto"               # Basic uses on/off; Ultra also accepts auto
 ext_gain_db = 0             # -100–100 dB
@@ -136,12 +138,29 @@ a safe input baseline. The Options pane updates these values at runtime. They
 are saved from the analyzer's current state on quit. Other backends preserve the
 block unchanged.
 
+`basic_input` selects the Basic model's physical connector for the full session.
+It accepts `low` from 100 kHz to 350 MHz or `high` from 240 MHz to 959 MHz.
+This is a startup-only setting. Restart sdrtop after editing it. An explicit
+`?input=low` or `?input=high` in `--device` takes priority for that session. A
+bare `--device tinysa` or `--device tinysa=PATH` uses `basic_input`.
+
+Basic LOW and Ultra use `attenuation`. Its choices are `auto` or 0–31 dB. Basic
+HIGH uses `high_attenuation`. `false` sends `attenuate 0`. `true` sends
+`attenuate 1`, which enables the firmware's frequency-dependent coarse
+attenuation of roughly 25–40 dB. Each connector's setting is saved separately.
+
+Ultra firmware always selects its input automatically. `basic_input` remains
+unchanged after an Ultra session. An explicit Basic input in `--device` is
+ignored on Ultra and produces a note in the startup log.
+
 Basic analyzers convert `spur = "auto"` to `"on"`. They also convert Ultra-only
 RBW values `0.2`, `1` and `850` to `"auto"`. The Ultra-only LNA value stays in
-the file when a Basic analyzer is used. Legacy `lna2` and `agc` values are
-accepted and preserved without being applied. Verified ZS405 firmware reloads
-its internal LNA2 and AGC values before every scan. Other invalid values are
-reported when a tinySA opens.
+the file when a Basic analyzer is used.
+
+Legacy `lna2` and `agc` fields remain readable and survive config saves. Basic
+sessions ignore them. Ultra sessions accept only `"auto"`. A manual value stops
+the open with an error because Ultra firmware overwrites LNA2 and AGC before
+every scan. Other invalid values are reported when a tinySA opens.
 
 ---
 

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -44,8 +44,15 @@ supports the basic tinySA and the Ultra family. It was verified on a ZS405
 running `tinySA4_v1.4-236-ge5aa115`.
 
 The device supplies swept power readings without IQ samples. sdrtop offers the
-spectrum, waterfall, full band sweep and micro sweep layouts. RBW, attenuation,
-gain, AGC and spur handling use safe automatic defaults.
+spectrum, waterfall, full band sweep and micro sweep layouts. The Options pane
+controls scan points, RBW, attenuation, spur removal and external gain. Ultra
+models also expose LNA, LNA2 and AGC. Scan points are a host-side setting. The
+other controls use the matching tinySA console commands.
+
+sdrtop disables output and aborts pending work during startup. It then forces
+input mode and applies a safe automatic baseline before restoring `[tinysa]`
+settings. Basic input-path changes restore the active RBW, attenuation, spur and
+external gain settings after the firmware resets them.
 
 ```sh
 sdrtop --device tinysa

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -81,11 +81,6 @@ does not affect an Ultra open and remains saved for the next Basic session. An
 explicit `?input=low` or `?input=high` is ignored on Ultra. The startup log says
 that it was ignored.
 
-Legacy `lna2` and `agc` config fields remain readable and survive saves. They are
-not shown or applied. Basic sessions ignore manual values. Ultra requires
-`"auto"` because its firmware overwrites both controls before every scan. A
-manual Ultra value produces an error during open.
-
 > **RTL clones vary.** Different tuners, different gain tables, different quirks,
 > and no single person owns them all. If yours behaves oddly, please
 > [open an issue](../../../issues) with the tuner type (`rtl_test -t` prints it)

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -45,16 +45,18 @@ running `tinySA4_v1.4-236-ge5aa115`.
 
 The device supplies swept power readings without IQ samples. sdrtop offers the
 spectrum, waterfall, full band sweep and micro sweep layouts. The Options pane
-controls scan points, RBW, attenuation, spur removal and external gain. Ultra
-models also expose the external front-end LNA. Scan points are a host-side
-setting. The other controls use the matching tinySA console commands. LNA2 and
-AGC are hidden because the verified ZS405 firmware reloads its internal values
-before every scan.
+controls scan points, RBW, attenuation, spur removal and external gain. Basic
+LOW and Ultra offer `Attenuation (dB)` with `auto` and 0–31 dB choices. Basic
+HIGH offers `Coarse attenuation` with `off` and `on` choices. `on` asks the
+firmware for frequency-dependent attenuation of roughly 25–40 dB. Ultra models
+also expose the external front-end LNA. Scan points are a host-side setting.
+The other controls use the matching tinySA console commands.
 
 sdrtop disables output and aborts pending work during startup. It then forces
 input mode and applies a safe automatic baseline before restoring `[tinysa]`
-settings. Basic input-path changes restore the active RBW, attenuation, spur and
-external gain settings after the firmware resets them.
+settings. Basic HIGH uses a truthful coarse attenuation baseline of `off`.
+Recovery restores the active connector's attenuation setting. LOW numeric
+attenuation and HIGH coarse attenuation are saved independently.
 
 ```sh
 sdrtop --device tinysa
@@ -64,10 +66,25 @@ sdrtop --device 'tinysa=/dev/ttyACM2?input=high'
 
 Automatic discovery recognizes the official USB CDC identity on
 `/dev/ttyACM*`. The explicit form selects a path when several devices are
-present or discovery cannot inspect sysfs. A basic tinySA uses the LOW input by
-default from 100 kHz to 350 MHz. Select `input=high` for the HIGH connector from
-240 MHz to 959 MHz. The supported firmware defines 959 MHz as the HIGH input
-limit. One session stays on the selected connector.
+present or discovery cannot inspect sysfs. A Basic tinySA uses the persisted
+`[tinysa].basic_input` value. The default is LOW from 100 kHz to 350 MHz. HIGH
+covers 240 MHz to 959 MHz. The supported firmware defines 959 MHz as the HIGH
+limit. `?input=low` or `?input=high` overrides the config for one session. A bare
+`--device tinysa` or `tinysa=PATH` uses the config value.
+
+Connector selection happens only during startup. Restart sdrtop to use an edited
+config value. One Basic session stays on one connector. Quitting after a Basic
+session saves the connector that session used. This includes a CLI override.
+
+Ultra firmware always uses automatic input selection. The Basic connector value
+does not affect an Ultra open and remains saved for the next Basic session. An
+explicit `?input=low` or `?input=high` is ignored on Ultra. The startup log says
+that it was ignored.
+
+Legacy `lna2` and `agc` config fields remain readable and survive saves. They are
+not shown or applied. Basic sessions ignore manual values. Ultra requires
+`"auto"` because its firmware overwrites both controls before every scan. A
+manual Ultra value produces an error during open.
 
 > **RTL clones vary.** Different tuners, different gain tables, different quirks,
 > and no single person owns them all. If yours behaves oddly, please

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -46,8 +46,10 @@ running `tinySA4_v1.4-236-ge5aa115`.
 The device supplies swept power readings without IQ samples. sdrtop offers the
 spectrum, waterfall, full band sweep and micro sweep layouts. The Options pane
 controls scan points, RBW, attenuation, spur removal and external gain. Ultra
-models also expose LNA, LNA2 and AGC. Scan points are a host-side setting. The
-other controls use the matching tinySA console commands.
+models also expose the external front-end LNA. Scan points are a host-side
+setting. The other controls use the matching tinySA console commands. LNA2 and
+AGC are hidden because the verified ZS405 firmware reloads its internal values
+before every scan.
 
 sdrtop disables output and aborts pending work during startup. It then forces
 input mode and applies a safe automatic baseline before restoring `[tinysa]`

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -69,7 +69,7 @@ Automatic discovery recognizes the official USB CDC identity on
 present or discovery cannot inspect sysfs. A Basic tinySA uses the persisted
 `[tinysa].basic_input` value. The default is LOW from 100 kHz to 350 MHz. HIGH
 covers 240 MHz to 959 MHz. The supported firmware defines 959 MHz as the HIGH
-limit. `?input=low` or `?input=high` overrides the config for one session. A bare
+limit. `?input=low` or `?input=high` overrides the config at startup. A bare
 `--device tinysa` or `tinysa=PATH` uses the config value.
 
 Connector selection happens only during startup. Restart sdrtop to use an edited


### PR DESCRIPTION
This PR completes tinySA support with device controls and persistence. It builds on the options framework merged in #10 and numeric entry merged in #15.

The backend uses fixed automatic settings without this layer. Operators cannot adjust scan density, bandwidth, attenuation, LNA, spur removal, or external gain from sdrtop.

This PR exposes each model's supported controls with direct number entry for gain and attenuation. Saved settings preserve connector preferences and values unavailable on the current model. Safe transitions, recovery diagnostics, and isolated persistence failures keep hardware changes and saved configuration understandable.