### PR TITLE
Align spectrum and waterfall bin geometry

### DIFF
--- a/src/app/input/core.rs
+++ b/src/app/input/core.rs
@@ -29,6 +29,7 @@ fn strongest_bin_frequency(frame: &crate::state::FftFrame) -> Option<u64> {
         .map(|(index, _)| index)?;
     frame
         .frequency_of_bin(peak_bin)
+        .filter(|frequency| *frequency >= 0.0)
         .map(|frequency| frequency.round() as u64)
 }
 
@@ -324,5 +325,19 @@ mod tests {
         let mut frame = state.waterfall.last_fft.unwrap();
         frame.bins_dbfs = std::sync::Arc::new(Vec::new());
         assert_eq!(strongest_bin_frequency(&frame), None);
+    }
+
+    #[test]
+    fn peak_jump_falls_back_for_a_negative_frequency() {
+        let mut state = crate::state::SdrMetrics::fixture();
+        state.radio.frequency = 1_000_000;
+        state.radio.config_sample_rate = 32_000_000.0;
+        let state = state.with_carrier(-8_000_000.0, 70.0);
+        let frame = state.waterfall.last_fft.as_ref().unwrap();
+        assert_eq!(strongest_bin_frequency(frame), None);
+        assert_eq!(
+            strongest_bin_frequency(frame).unwrap_or(state.radio.frequency),
+            1_000_000
+        );
     }
 }

--- a/src/app/input/core.rs
+++ b/src/app/input/core.rs
@@ -20,6 +20,18 @@ use crate::ui::widgets::micro_common::fmt_bw;
 
 use super::{global, metrics, InputCtx, KeyAction};
 
+fn strongest_bin_frequency(frame: &crate::state::FftFrame) -> Option<u64> {
+    let peak_bin = frame
+        .bins_dbfs
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(index, _)| index)?;
+    frame
+        .frequency_of_bin(peak_bin)
+        .map(|frequency| frequency.round() as u64)
+}
+
 // ── Spectrum focus keys ───────────────────────────────────────────────────────
 
 pub(super) fn spectrum(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
@@ -131,16 +143,7 @@ pub(super) fn spectrum(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
                 let freq = if let Some(f) = m.spectrum.cursor_freq {
                     f
                 } else if let Some(frame) = &m.waterfall.last_fft {
-                    let peak_bin = frame
-                        .bins_dbfs
-                        .iter()
-                        .enumerate()
-                        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-                        .map(|(i, _)| i)
-                        .unwrap_or(frame.bins_dbfs.len() / 2);
-                    let left_hz = m.radio.frequency as f64 - frame.sample_rate / 2.0;
-                    (left_hz + peak_bin as f64 / frame.bins_dbfs.len() as f64 * frame.sample_rate)
-                        .round() as u64
+                    strongest_bin_frequency(frame).unwrap_or(m.radio.frequency)
                 } else {
                     m.radio.frequency
                 };
@@ -296,4 +299,30 @@ pub(super) fn waterfall(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
         _ => return global::handle_no_device(key, ctx),
     }
     KeyAction::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peak_jump_uses_the_captured_fft_frequency_after_retuning() {
+        let mut state = crate::state::SdrMetrics::fixture();
+        state.radio.frequency = 100_000_000;
+        state.radio.config_sample_rate = 32_000_000.0;
+        let mut state = state.with_carrier(8_000_000.0, 70.0);
+        state.radio.frequency = 200_000_000;
+        let frame = state.waterfall.last_fft.as_ref().unwrap();
+        assert_eq!(strongest_bin_frequency(frame), Some(108_000_000));
+        assert_eq!(frame.bin_axis, crate::state::BinAxis::FftBins);
+        assert_eq!(frame.window(4).unwrap().span_hz, 8_000_000.0);
+    }
+
+    #[test]
+    fn peak_jump_rejects_an_empty_frame() {
+        let state = crate::state::SdrMetrics::fixture().with_carrier(0.0, 70.0);
+        let mut frame = state.waterfall.last_fft.unwrap();
+        frame.bins_dbfs = std::sync::Arc::new(Vec::new());
+        assert_eq!(strongest_bin_frequency(&frame), None);
+    }
 }

--- a/src/signal/fft/publish.rs
+++ b/src/signal/fft/publish.rs
@@ -248,6 +248,7 @@ fn refresh_spectrum(m: &mut SdrMetrics, snap: &Snapshot<'_>) {
         channel_power_dbfs: r.channel_power_dbfs,
         occupied_bw_hz: r.occupied_bw_hz,
         enbw_hz: snap.enbw_hz,
+        bin_axis: crate::state::BinAxis::FftBins,
     });
 }
 
@@ -404,6 +405,8 @@ mod tests {
 
         let published = m.waterfall.last_fft.expect("a frame was published");
         assert_eq!(published.bins_dbfs[0], -70.0, "the new trace");
+        assert_eq!(published.bin_axis, crate::state::BinAxis::FftBins);
+        assert_eq!(published.frequency_of_bin(48), Some(100_250_000.0));
         let held = being_drawn.waterfall.last_fft.expect("the UI's copy");
         assert_eq!(held.bins_dbfs[0], -40.0, "still the frame it was drawing");
     }

--- a/src/state/fixture.rs
+++ b/src/state/fixture.rs
@@ -148,6 +148,7 @@ impl SdrMetrics {
             channel_power_dbfs: noise_floor + snr_db,
             occupied_bw_hz: 150_000,
             enbw_hz: sample_rate / N as f64,
+            bin_axis: crate::state::BinAxis::FftBins,
         });
         self.signal.peak_to_nf_db = snr_db;
         self.signal.channel_power_dbfs = noise_floor + snr_db;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -44,7 +44,7 @@ pub use ui::{
     active_recall_slot, recall_from_hz, recall_to_hz, InputMode, LogEntry, LogLevel, MenuPane,
     MenuState, RailMode, UiState, RECALL_SLOTS,
 };
-pub use waterfall::{FftFrame, WaterfallState, WATERFALL_MIN_ROWS};
+pub use waterfall::{BinAxis, FftFrame, WaterfallState, WATERFALL_MIN_ROWS};
 
 pub const THROUGHPUT_HISTORY_LEN: usize = 64;
 /// Depth of the per-callback gap ring feeding the `lab_timing` strip chart. ~256

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -44,7 +44,7 @@ pub use ui::{
     active_recall_slot, recall_from_hz, recall_to_hz, InputMode, LogEntry, LogLevel, MenuPane,
     MenuState, RailMode, UiState, RECALL_SLOTS,
 };
-pub use waterfall::{BinAxis, FftFrame, WaterfallState, WATERFALL_MIN_ROWS};
+pub use waterfall::{BinAxis, BinWindow, FftFrame, WaterfallState, WATERFALL_MIN_ROWS};
 
 pub const THROUGHPUT_HISTORY_LEN: usize = 64;
 /// Depth of the per-callback gap ring feeding the `lab_timing` strip chart. ~256

--- a/src/state/waterfall.rs
+++ b/src/state/waterfall.rs
@@ -5,12 +5,15 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
 
+/// Define how bins cover a frequency span
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum BinAxis {
+    /// Each FFT bin owns one interval starting at its frequency
     #[default]
     FftBins,
 }
 
+/// A nonempty centre slice retains the full frame's bin spacing
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BinWindow {
     pub first_bin: usize,
@@ -20,12 +23,15 @@ pub struct BinWindow {
 }
 
 impl BinAxis {
+    /// Return the number of frequency intervals, or `None` for an empty axis
     pub fn interval_count(self, bin_count: usize) -> Option<usize> {
         match self {
             Self::FftBins => (bin_count > 0).then_some(bin_count),
         }
     }
 
+    /// Select a centre slice with at least one bin. Zero zoom means full span.
+    /// Empty axes and non-positive or non-finite spans have no window.
     pub fn window(
         self,
         center_hz: u64,
@@ -53,6 +59,9 @@ impl BinAxis {
         })
     }
 
+    /// Return a bin's frequency
+    ///
+    /// The last FFT bin starts below the right edge.
     pub fn frequency_of_bin(
         self,
         left_hz: f64,
@@ -70,6 +79,9 @@ impl BinAxis {
         Some(left_hz + index as f64 * span_hz / intervals as f64)
     }
 
+    /// Look up the FFT interval containing `frequency_hz`
+    ///
+    /// The right edge reads the last bin. Frequencies outside the window return `None`.
     pub fn nearest_bin(
         self,
         left_hz: f64,
@@ -86,7 +98,10 @@ impl BinAxis {
             return None;
         }
         let intervals = self.interval_count(bin_count)?;
-        let index = ((frequency_hz - left_hz) * intervals as f64 / span_hz).round() as usize;
+        let position = (frequency_hz - left_hz) * intervals as f64 / span_hz;
+        let index = match self {
+            Self::FftBins => position.floor() as usize,
+        };
         Some(index.min(bin_count.saturating_sub(1)))
     }
 }

--- a/src/state/waterfall.rs
+++ b/src/state/waterfall.rs
@@ -5,6 +5,92 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BinAxis {
+    #[default]
+    FftBins,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BinWindow {
+    pub first_bin: usize,
+    pub bin_count: usize,
+    pub left_hz: f64,
+    pub span_hz: f64,
+}
+
+impl BinAxis {
+    pub fn interval_count(self, bin_count: usize) -> Option<usize> {
+        match self {
+            Self::FftBins => (bin_count > 0).then_some(bin_count),
+        }
+    }
+
+    pub fn window(
+        self,
+        center_hz: u64,
+        span_hz: f64,
+        bin_count: usize,
+        zoom: usize,
+    ) -> Option<BinWindow> {
+        if bin_count == 0 || !span_hz.is_finite() || span_hz <= 0.0 {
+            return None;
+        }
+
+        let visible = (bin_count / zoom.max(1)).max(1).min(bin_count);
+        let first = (bin_count / 2)
+            .saturating_sub(visible / 2)
+            .min(bin_count - visible);
+        let intervals = self.interval_count(bin_count)?;
+        let bin_hz = span_hz / intervals as f64;
+        let visible_intervals = self.interval_count(visible)?;
+
+        Some(BinWindow {
+            first_bin: first,
+            bin_count: visible,
+            left_hz: center_hz as f64 - span_hz / 2.0 + first as f64 * bin_hz,
+            span_hz: visible_intervals as f64 * bin_hz,
+        })
+    }
+
+    pub fn frequency_of_bin(
+        self,
+        left_hz: f64,
+        span_hz: f64,
+        bin_count: usize,
+        index: usize,
+    ) -> Option<f64> {
+        if bin_count == 0 || index >= bin_count {
+            return None;
+        }
+        let intervals = self.interval_count(bin_count)?;
+        if !left_hz.is_finite() || !span_hz.is_finite() || span_hz <= 0.0 {
+            return None;
+        }
+        Some(left_hz + index as f64 * span_hz / intervals as f64)
+    }
+
+    pub fn nearest_bin(
+        self,
+        left_hz: f64,
+        span_hz: f64,
+        bin_count: usize,
+        frequency_hz: f64,
+    ) -> Option<usize> {
+        if !left_hz.is_finite()
+            || !span_hz.is_finite()
+            || span_hz <= 0.0
+            || !frequency_hz.is_finite()
+            || !(left_hz..=left_hz + span_hz).contains(&frequency_hz)
+        {
+            return None;
+        }
+        let intervals = self.interval_count(bin_count)?;
+        let index = ((frequency_hz - left_hz) * intervals as f64 / span_hz).round() as usize;
+        Some(index.min(bin_count.saturating_sub(1)))
+    }
+}
+
 #[derive(Clone)]
 #[allow(dead_code)]
 pub struct FftFrame {
@@ -18,6 +104,24 @@ pub struct FftFrame {
     pub channel_power_dbfs: f32,
     pub occupied_bw_hz: u64,
     pub enbw_hz: f64,
+    pub bin_axis: BinAxis,
+}
+
+impl FftFrame {
+    pub fn window(&self, zoom: usize) -> Option<BinWindow> {
+        self.bin_axis.window(
+            self.center_freq_hz,
+            self.sample_rate,
+            self.bins_dbfs.len(),
+            zoom,
+        )
+    }
+
+    pub fn frequency_of_bin(&self, index: usize) -> Option<f64> {
+        let window = self.window(1)?;
+        self.bin_axis
+            .frequency_of_bin(window.left_hz, window.span_hz, window.bin_count, index)
+    }
 }
 
 pub struct WaterfallBuffer {
@@ -174,6 +278,78 @@ mod min_rows_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fft_bins_keep_n_intervals() {
+        let axis = BinAxis::FftBins;
+        let window = axis.window(100_000_000, 64_000_000.0, 64, 1).unwrap();
+        assert_eq!(axis.interval_count(64), Some(64));
+        assert_eq!(window.first_bin, 0);
+        assert_eq!(window.bin_count, 64);
+        assert_eq!(window.left_hz, 68_000_000.0);
+        assert_eq!(window.span_hz, 64_000_000.0);
+        assert_eq!(
+            axis.frequency_of_bin(window.left_hz, window.span_hz, window.bin_count, 63),
+            Some(131_000_000.0)
+        );
+        for (frequency, index) in [
+            (68_000_000.0, 0),
+            (100_000_000.0, 32),
+            (131_000_000.0, 63),
+            (132_000_000.0, 63),
+        ] {
+            assert_eq!(
+                axis.nearest_bin(window.left_hz, window.span_hz, window.bin_count, frequency),
+                Some(index)
+            );
+        }
+    }
+
+    #[test]
+    fn fft_zoom_preserves_bin_spacing_and_clamps_to_one_bin() {
+        let axis = BinAxis::FftBins;
+        assert_eq!(
+            axis.window(100, 10.0, 10, 3),
+            Some(BinWindow {
+                first_bin: 4,
+                bin_count: 3,
+                left_hz: 99.0,
+                span_hz: 3.0,
+            })
+        );
+        assert_eq!(axis.window(100, 10.0, 10, 0), axis.window(100, 10.0, 10, 1));
+        for count in [1, 10] {
+            let window = axis.window(100, 10.0, count, usize::MAX).unwrap();
+            assert_eq!(window.bin_count, 1);
+            assert_eq!(window.span_hz, 10.0 / count as f64);
+            assert_eq!(
+                axis.nearest_bin(window.left_hz, window.span_hz, 1, window.left_hz),
+                Some(0)
+            );
+        }
+    }
+
+    #[test]
+    fn bin_axis_rejects_invalid_bounds() {
+        let axis = BinAxis::FftBins;
+        assert_eq!(axis.interval_count(0), None);
+        assert!(axis.window(100, 10.0, 0, 1).is_none());
+        assert!(axis.frequency_of_bin(0.0, 10.0, 0, 0).is_none());
+        assert!(axis.frequency_of_bin(0.0, 10.0, 4, 4).is_none());
+        assert!(axis.nearest_bin(0.0, 10.0, 0, 0.0).is_none());
+        for span in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(axis.window(100, span, 32, 1).is_none());
+            assert!(axis.frequency_of_bin(0.0, span, 4, 0).is_none());
+            assert!(axis.nearest_bin(0.0, span, 4, 0.0).is_none());
+        }
+        for left in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(axis.frequency_of_bin(left, 10.0, 4, 0).is_none());
+            assert!(axis.nearest_bin(left, 10.0, 4, 0.0).is_none());
+        }
+        for frequency in [-1.0, 11.0, f64::NAN, f64::INFINITY] {
+            assert!(axis.nearest_bin(0.0, 10.0, 4, frequency).is_none());
+        }
+    }
 
     #[test]
     fn push_adds_newest_row_first() {

--- a/src/ui/panels/core/command_rail/modes.rs
+++ b/src/ui/panels/core/command_rail/modes.rs
@@ -57,24 +57,15 @@ pub(super) fn mode_tabs_line(active: RailMode, iw: usize, theme: &crate::Theme) 
 /// `(freq_hz, dbfs)`, strongest-first. A thin wrapper over the spectrum panel's
 /// [`detect_peaks`] (shared prominence ≥ NF+10 dB + min-separation logic) plus
 /// the bin→Hz map, so HUNT and the MONITOR activity count agree with the markers.
-pub(super) fn rail_peaks(
-    bins: &[f32],
-    noise_floor: f32,
-    center_hz: u64,
-    sample_rate: f64,
-    n: usize,
-) -> Vec<(u64, f32)> {
-    if sample_rate <= 0.0 || bins.is_empty() {
-        return Vec::new();
-    }
+pub(super) fn rail_peaks(frame: &crate::state::FftFrame, n: usize) -> Vec<(u64, f32)> {
+    let bins = &frame.bins_dbfs;
     let len = bins.len();
     let sep = (len / 48).max(2);
-    let left_hz = center_hz as f64 - sample_rate / 2.0;
-    detect_peaks(bins, noise_floor, n, sep)
+    detect_peaks(bins, frame.noise_floor, n, sep)
         .into_iter()
-        .map(|i| {
-            let hz = (left_hz + i as f64 / len as f64 * sample_rate).max(0.0) as u64;
-            (hz, bins[i])
+        .filter_map(|i| {
+            let hz = frame.frequency_of_bin(i)?.max(0.0) as u64;
+            Some((hz, bins[i]))
         })
         .collect()
 }
@@ -140,13 +131,7 @@ pub(super) fn mode_card_lines(
             let Some(fr) = fft else {
                 return vec![dim("scanning…".into())];
             };
-            let peaks = rail_peaks(
-                &fr.bins_dbfs,
-                fr.noise_floor,
-                state.radio.frequency,
-                fr.sample_rate,
-                3,
-            );
+            let peaks = rail_peaks(fr, 3);
             if peaks.is_empty() {
                 return vec![dim("no peaks".into())];
             }
@@ -192,16 +177,7 @@ pub(super) fn mode_card_lines(
                 .last_fft
                 .as_ref()
                 .filter(|_| !stale)
-                .map_or(0, |fr| {
-                    rail_peaks(
-                        &fr.bins_dbfs,
-                        fr.noise_floor,
-                        state.radio.frequency,
-                        fr.sample_rate,
-                        8,
-                    )
-                    .len()
-                });
+                .map_or(0, |fr| rail_peaks(fr, 8).len());
             vec![
                 Line::from(vec![
                     Span::raw(" "),
@@ -278,6 +254,16 @@ pub(super) fn mode_card_lines(
 mod tests {
     use super::*;
 
+    fn frame(bins: &[f32], noise_floor: f32, sample_rate: f64) -> crate::state::FftFrame {
+        let state = SdrMetrics::fixture().with_carrier(0.0, 20.0);
+        let mut frame = state.waterfall.last_fft.unwrap();
+        frame.bins_dbfs = std::sync::Arc::new(bins.to_vec());
+        frame.noise_floor = noise_floor;
+        frame.center_freq_hz = 100_000_000;
+        frame.sample_rate = sample_rate;
+        frame
+    }
+
     #[test]
     fn rail_peaks_maps_bins_to_frequency_strongest_first() {
         // Two lobes above the −80 dB noise floor: a tall one left of centre
@@ -285,7 +271,7 @@ mod tests {
         let bins = [
             -90.0, -40.0, -10.0, -40.0, -80.0, -50.0, -25.0, -50.0, -90.0,
         ];
-        let peaks = rail_peaks(&bins, -80.0, 100_000_000, 10_000_000.0, 3);
+        let peaks = rail_peaks(&frame(&bins, -80.0, 10_000_000.0), 3);
         assert_eq!(peaks.len(), 2, "two distinct lobes above NF+10");
         assert!(peaks[0].1 > peaks[1].1, "strongest first");
         assert!((peaks[0].1 - (-10.0)).abs() < 1e-3);
@@ -296,9 +282,9 @@ mod tests {
     #[test]
     fn rail_peaks_empty_without_signal_or_rate() {
         // All near the floor → nothing clears NF+10 dB.
-        assert!(rail_peaks(&[-90.0, -88.0, -90.0], -90.0, 100_000_000, 6_000_000.0, 3).is_empty());
+        assert!(rail_peaks(&frame(&[-90.0, -88.0, -90.0], -90.0, 6_000_000.0), 3).is_empty());
         // No sample rate → no usable frequency map.
-        assert!(rail_peaks(&[-90.0, -10.0, -90.0], -90.0, 100_000_000, 0.0, 3).is_empty());
+        assert!(rail_peaks(&frame(&[-90.0, -10.0, -90.0], -90.0, 0.0), 3).is_empty());
     }
 
     #[test]

--- a/src/ui/panels/core/command_rail/recall.rs
+++ b/src/ui/panels/core/command_rail/recall.rs
@@ -22,12 +22,14 @@ fn recall_pip(slot_hz: u64, state: &SdrMetrics, stale: bool) -> Option<(&'static
         return None;
     }
     let fr = state.waterfall.last_fft.as_ref()?;
-    let half_sr = (fr.sample_rate / 2.0) as u64;
-    let center = state.radio.frequency;
-    if slot_hz < center.saturating_sub(half_sr) || slot_hz > center + half_sr {
-        return None;
-    }
-    let peaks = rail_peaks(&fr.bins_dbfs, fr.noise_floor, center, fr.sample_rate, 8);
+    let window = fr.window(1)?;
+    fr.bin_axis.nearest_bin(
+        window.left_hz,
+        window.span_hz,
+        window.bin_count,
+        slot_hz as f64,
+    )?;
+    let peaks = rail_peaks(fr, 8);
     let close = peaks.iter().any(|&(f, _)| f.abs_diff(slot_hz) < 250_000);
     let strong = peaks
         .iter()
@@ -101,4 +103,25 @@ pub(super) fn lines(state: &SdrMetrics, stale: bool, theme: &crate::Theme) -> Ve
     // is the same whichever section is being edited.
     out.push(Line::raw(""));
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recall_uses_the_captured_frame_after_retuning() {
+        let mut state = SdrMetrics::fixture();
+        state.radio.frequency = 100_000_000;
+        state.radio.config_sample_rate = 32_000_000.0;
+        let mut state = state.with_carrier(8_000_000.0, 70.0);
+        state.radio.frequency = 200_000_000;
+        assert_eq!(recall_pip(108_000_000, &state, false), Some(("⣿⡇", true)));
+        assert_eq!(recall_pip(208_000_000, &state, false), None);
+        assert_eq!(recall_pip(108_000_000, &state, true), None);
+        assert_eq!(
+            rail_peaks(state.waterfall.last_fft.as_ref().unwrap(), 3),
+            vec![(108_000_000, -30.0)]
+        );
+    }
 }

--- a/src/ui/panels/core/spectrum/mod.rs
+++ b/src/ui/panels/core/spectrum/mod.rs
@@ -166,6 +166,7 @@ fn contents(
         fft.center_freq_hz,
         fft.sample_rate,
         zoom,
+        fft.bin_axis,
     ) else {
         return;
     };

--- a/src/ui/panels/core/spectrum/scale.rs
+++ b/src/ui/panels/core/spectrum/scale.rs
@@ -38,13 +38,14 @@ pub(super) fn freq_to_canvas_x(freq_hz: f64, left_hz: f64, bw: f64, max_x: f64) 
     }
 }
 
-/// Map a canvas x-coordinate to a terminal column inside `width`
+/// Map a canvas x-coordinate to the column painted by the Braille canvas
 pub(super) fn canvas_x_to_col(x: f64, max_x: f64, width: u16) -> u16 {
     if max_x <= 0.0 || width == 0 {
         return 0;
     }
-    let frac = (x / max_x).clamp(0.0, 1.0);
-    ((frac * width as f64).round() as u16).min(width - 1)
+    let x = x.clamp(0.0, max_x);
+    let dot = (x * (2.0 * width as f64 - 1.0) / max_x) as usize;
+    (dot / 2) as u16
 }
 
 /// The occupied-bandwidth window as a symmetric span around `center_hz` - the
@@ -151,6 +152,42 @@ mod tests {
     use super::*;
 
     #[test]
+    fn columns_match_the_rendered_braille_dot() {
+        use ratatui::{
+            buffer::Buffer,
+            layout::Rect,
+            widgets::{
+                canvas::{Canvas, Points},
+                Widget,
+            },
+        };
+        for width in [1, 2, 40, 160] {
+            for x in [0.0, 0.1, 7.9, 8.0, 16.0, 24.0, 31.9, 32.0] {
+                let area = Rect::new(0, 0, width, 1);
+                let mut buffer = Buffer::empty(area);
+                Canvas::default()
+                    .x_bounds([0.0, 32.0])
+                    .y_bounds([0.0, 1.0])
+                    .paint(|ctx| {
+                        ctx.draw(&Points {
+                            coords: &[(x, 0.0)],
+                            color: Color::Red,
+                        })
+                    })
+                    .render(area, &mut buffer);
+                let painted = (0..width)
+                    .find(|col| buffer.get(*col, 0).fg == Color::Red)
+                    .unwrap();
+                assert_eq!(
+                    canvas_x_to_col(x, 32.0, width),
+                    painted,
+                    "width {width} x {x}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn canvas_x_and_column_are_not_interchangeable() {
         let max_x = 2048.0;
         assert_eq!(canvas_x_to_col(0.0, max_x, 160), 0);
@@ -159,7 +196,7 @@ mod tests {
             159,
             "the right edge is the last column"
         );
-        assert_eq!(canvas_x_to_col(max_x * 0.75, max_x, 160), 120);
+        assert_eq!(canvas_x_to_col(max_x * 0.75, max_x, 160), 119);
         assert_eq!(canvas_x_to_col(500.0, 0.0, 160), 0);
         assert_eq!(canvas_x_to_col(500.0, max_x, 0), 0);
     }

--- a/src/ui/panels/core/spectrum/scale.rs
+++ b/src/ui/panels/core/spectrum/scale.rs
@@ -4,7 +4,7 @@
 //! Coordinate mapping and the frequency ruler.
 //!
 //! The spectrum works in three coordinate systems at once and they are easy to
-//! confuse: hertz, canvas x (`0..n-1`, as wide as the FFT has bins) and terminal
+//! confuse: hertz, canvas x (one unit per bin interval) and terminal
 //! columns (bounded by the panel). Everything that converts between them lives
 //! here, alone, with tests.
 
@@ -25,32 +25,25 @@ pub(super) fn dim(c: Color, f: f32) -> Color {
     }
 }
 
-/// Map a frequency to a canvas x-coordinate in `[0, n-1]`, or `None` if out of view.
-pub(super) fn freq_to_canvas_x(freq_hz: f64, left_hz: f64, bw: f64, n: f64) -> Option<f64> {
-    if bw <= 0.0 {
+/// Map a frequency to a canvas x-coordinate, or `None` if out of view
+pub(super) fn freq_to_canvas_x(freq_hz: f64, left_hz: f64, bw: f64, max_x: f64) -> Option<f64> {
+    if bw <= 0.0 || max_x <= 0.0 {
         return None;
     }
     let frac = (freq_hz - left_hz) / bw;
     if (0.0..=1.0).contains(&frac) {
-        Some(frac * (n - 1.0))
+        Some(frac * max_x)
     } else {
         None
     }
 }
 
-/// A canvas x - the units [`freq_to_canvas_x`] returns, spanning `0..n-1` - as a
-/// terminal column inside `width`.
-///
-/// The two coordinate systems cost nothing to mix up silently: the canvas is as
-/// wide as the spectrum has bins, typically 2048, while the column is bounded by
-/// the panel, typically under 200. Using one as the other clamps every position
-/// to the right-hand edge, which is exactly what the OBW label did at every
-/// terminal size it was tried at.
-pub(super) fn canvas_x_to_col(x: f64, n: f64, width: u16) -> u16 {
-    if n <= 1.0 || width == 0 {
+/// Map a canvas x-coordinate to a terminal column inside `width`
+pub(super) fn canvas_x_to_col(x: f64, max_x: f64, width: u16) -> u16 {
+    if max_x <= 0.0 || width == 0 {
         return 0;
     }
-    let frac = (x / (n - 1.0)).clamp(0.0, 1.0);
+    let frac = (x / max_x).clamp(0.0, 1.0);
     ((frac * width as f64).round() as u16).min(width - 1)
 }
 
@@ -159,24 +152,21 @@ mod tests {
 
     #[test]
     fn canvas_x_and_column_are_not_interchangeable() {
-        // The bug this guards: a 2048-bin canvas x used directly as a column.
-        // Three quarters across a 2048-bin canvas is column 120 of 160, not 160.
-        let n = 2048.0;
-        assert_eq!(canvas_x_to_col(0.0, n, 160), 0);
+        let max_x = 2048.0;
+        assert_eq!(canvas_x_to_col(0.0, max_x, 160), 0);
         assert_eq!(
-            canvas_x_to_col(n - 1.0, n, 160),
+            canvas_x_to_col(max_x, max_x, 160),
             159,
-            "the last bin is the last column"
+            "the right edge is the last column"
         );
-        assert_eq!(canvas_x_to_col((n - 1.0) * 0.75, n, 160), 120);
-        // Degenerate geometry answers 0 rather than dividing by zero.
-        assert_eq!(canvas_x_to_col(500.0, 1.0, 160), 0);
-        assert_eq!(canvas_x_to_col(500.0, n, 0), 0);
+        assert_eq!(canvas_x_to_col(max_x * 0.75, max_x, 160), 120);
+        assert_eq!(canvas_x_to_col(500.0, 0.0, 160), 0);
+        assert_eq!(canvas_x_to_col(500.0, max_x, 0), 0);
     }
 
     #[test]
     fn freq_to_canvas_x_rejects_what_is_off_screen() {
-        let (left, bw, n) = (92_000_000.0, 2_000_000.0, 1001.0);
+        let (left, bw, n) = (92_000_000.0, 2_000_000.0, 1000.0);
         assert_eq!(freq_to_canvas_x(92_000_000.0, left, bw, n), Some(0.0));
         assert_eq!(freq_to_canvas_x(94_000_000.0, left, bw, n), Some(1000.0));
         assert_eq!(freq_to_canvas_x(93_000_000.0, left, bw, n), Some(500.0));

--- a/src/ui/panels/core/spectrum/trace.rs
+++ b/src/ui/panels/core/spectrum/trace.rs
@@ -183,7 +183,7 @@ pub(super) fn draw(
 
     f.render_widget(
         Canvas::default()
-            .x_bounds([0.0, (n - 1.0).max(0.0)])
+            .x_bounds([0.0, n.max(0.0)])
             .y_bounds([y_min, y_max])
             .paint(move |ctx| {
                 let bright_at = |level: f32| band_bright[band_of(level, v_min, span, steps)];
@@ -201,7 +201,7 @@ pub(super) fn draw(
                         ctx.draw(&CanvasLine {
                             x1: 0.0,
                             y1: y,
-                            x2: n - 1.0,
+                            x2: n,
                             y2: y,
                             color,
                         });
@@ -223,7 +223,7 @@ pub(super) fn draw(
                 //    so only the parts above the signal show through.
                 for i in 0..=4 {
                     level_line(ctx, y_min + (y_max - y_min) * (i as f64 / 4.0), pal.grid);
-                    rule(ctx, (n - 1.0).max(0.0) * (i as f64 / 4.0), pal.grid);
+                    rule(ctx, n.max(0.0) * (i as f64 / 4.0), pal.grid);
                 }
                 // 1. Hold ghost - the entire frozen spectrum as a soft outline.
                 if let Some(ref h) = held {

--- a/src/ui/panels/core/spectrum/trace.rs
+++ b/src/ui/panels/core/spectrum/trace.rs
@@ -151,6 +151,26 @@ pub(super) struct Layers {
     pub noise_floor: f32,
 }
 
+fn series_segments(
+    values: &[f32],
+    tail_width: f64,
+) -> impl Iterator<Item = (f64, f32, f64, f32)> + '_ {
+    let joined = values
+        .windows(2)
+        .enumerate()
+        .map(|(i, pair)| (i as f64, pair[0], (i + 1) as f64, pair[1]));
+    // Extend the last FFT sample across its final interval
+    let tail = values.last().filter(|_| tail_width > 0.0).map(|&last| {
+        (
+            (values.len() - 1) as f64,
+            last,
+            (values.len() - 1) as f64 + tail_width,
+            last,
+        )
+    });
+    joined.chain(tail)
+}
+
 /// Paint the trace and everything drawn on the canvas itself.
 pub(super) fn draw(
     f: &mut Frame,
@@ -168,6 +188,7 @@ pub(super) fn draw(
     } = layers;
     let pal = Palette::new(theme);
     let n = view.n();
+    let tail_width = view.bin_end(0);
     let (y_min, y_max) = (vert.min as f64, vert.max as f64);
 
     // The closure takes ownership, so everything it needs is moved in.
@@ -208,12 +229,12 @@ pub(super) fn draw(
                     };
                 let series =
                     |ctx: &mut ratatui::widgets::canvas::Context, v: &[f32], color: Color| {
-                        for i in 1..v.len() {
+                        for (x1, y1, x2, y2) in series_segments(v, tail_width) {
                             ctx.draw(&CanvasLine {
-                                x1: (i - 1) as f64,
-                                y1: v[i - 1].clamp(v_min, v_max) as f64,
-                                x2: i as f64,
-                                y2: v[i].clamp(v_min, v_max) as f64,
+                                x1,
+                                y1: y1.clamp(v_min, v_max) as f64,
+                                x2,
+                                y2: y2.clamp(v_min, v_max) as f64,
                                 color,
                             });
                         }
@@ -251,7 +272,7 @@ pub(super) fn draw(
                                 ctx.draw(&CanvasLine {
                                     x1: start as f64,
                                     y1: yb as f64,
-                                    x2: (i - 1) as f64,
+                                    x2: view.bin_end(i - 1),
                                     y2: yb as f64,
                                     color,
                                 });
@@ -265,13 +286,12 @@ pub(super) fn draw(
                 //    height. Only Braille draws it: Fill's bright body is its own
                 //    edge, Scatter has no line.
                 if style == SpectrumStyle::Braille {
-                    for i in 1..bins.len() {
-                        let (y0, y1) =
-                            (bins[i - 1].clamp(v_min, v_max), bins[i].clamp(v_min, v_max));
+                    for (x0, y0, x1, y1) in series_segments(&bins, tail_width) {
+                        let (y0, y1) = (y0.clamp(v_min, v_max), y1.clamp(v_min, v_max));
                         ctx.draw(&CanvasLine {
-                            x1: (i - 1) as f64,
+                            x1: x0,
                             y1: y0 as f64,
-                            x2: i as f64,
+                            x2: x1,
                             y2: y1 as f64,
                             color: bright_at((y0 + y1) * 0.5),
                         });
@@ -335,6 +355,95 @@ pub(super) fn draw(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn series_keep_connected_samples_and_extend_only_the_final_interval() {
+        assert_eq!(
+            series_segments(&[-80.0, -20.0], 1.0).collect::<Vec<_>>(),
+            vec![(0.0, -80.0, 1.0, -20.0), (1.0, -20.0, 2.0, -20.0)]
+        );
+        assert_eq!(
+            series_segments(&[-80.0, -20.0], 0.0).collect::<Vec<_>>(),
+            vec![(0.0, -80.0, 1.0, -20.0)]
+        );
+        assert_eq!(series_segments(&[], 1.0).count(), 0);
+        assert_eq!(
+            series_segments(&[-20.0], 1.0).collect::<Vec<_>>(),
+            vec![(0.0, -20.0, 1.0, -20.0)]
+        );
+    }
+
+    fn render_style(
+        style: SpectrumStyle,
+        bins: Vec<f32>,
+        held: Option<Arc<Vec<f32>>>,
+    ) -> ratatui::buffer::Buffer {
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(40, 10)).unwrap();
+        let theme = crate::theme::Theme::sdr();
+        let bins = Arc::new(bins);
+        let view = SpectrumView::new(
+            &bins,
+            &Arc::new(Vec::new()),
+            held,
+            100_000_000,
+            32_000_000.0,
+            1,
+            crate::state::BinAxis::FftBins,
+        )
+        .unwrap();
+        terminal
+            .draw(|f| {
+                draw(
+                    f,
+                    f.size(),
+                    &view,
+                    &Vertical::new(-100.0, 0.0, 10, &theme),
+                    Layers {
+                        rules: Rules {
+                            markers: vec![],
+                            obw: (None, None),
+                            cursor: None,
+                        },
+                        ghosts: LabGhosts {
+                            trace: None,
+                            ref_dbfs: None,
+                        },
+                        style,
+                        noise_floor: -100.0,
+                    },
+                    &theme,
+                );
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn final_fft_interval_is_filled_without_turning_scatter_into_a_line() {
+        for bins in [vec![-100.0, -20.0], vec![-20.0]] {
+            let braille = render_style(SpectrumStyle::Braille, bins.clone(), None);
+            let fill = render_style(SpectrumStyle::Fill, bins.clone(), None);
+            let scatter = render_style(SpectrumStyle::Scatter, bins.clone(), None);
+            let background = render_style(SpectrumStyle::Scatter, vec![-100.0; bins.len()], None);
+            // Column 35 lies inside the final FFT interval at both bin counts
+            assert_ne!(braille.get(35, 4), background.get(35, 4));
+            assert_ne!(fill.get(35, 4), background.get(35, 4));
+            assert_eq!(scatter.get(35, 4), background.get(35, 4));
+            assert_ne!(braille.get(35, 1), background.get(35, 1));
+        }
+    }
+
+    #[test]
+    fn held_trace_reaches_the_end_of_its_last_interval() {
+        let background = render_style(SpectrumStyle::Scatter, vec![-100.0; 2], None);
+        let held = render_style(
+            SpectrumStyle::Scatter,
+            vec![-100.0; 2],
+            Some(Arc::new(vec![-20.0; 2])),
+        );
+        assert_ne!(held.get(35, 1), background.get(35, 1));
+    }
 
     #[test]
     fn band_of_is_monotone_and_never_indexes_past_the_palette() {

--- a/src/ui/panels/core/spectrum/view.rs
+++ b/src/ui/panels/core/spectrum/view.rs
@@ -89,6 +89,12 @@ impl SpectrumView {
         self.bin_axis.interval_count(self.n_bins).unwrap_or(1) as f64
     }
 
+    pub fn bin_end(&self, index: usize) -> f64 {
+        match self.bin_axis {
+            BinAxis::FftBins => (index + 1) as f64,
+        }
+    }
+
     /// The level at `freq_hz`, or `None` when it falls outside the window.
     pub fn level_at(&self, freq_hz: u64) -> Option<f32> {
         let idx = self
@@ -239,6 +245,27 @@ mod tests {
             super::super::scale::freq_to_canvas_x(108_000_000.0, view.left_hz, view.bw, view.n(),),
             Some(24.0)
         );
+    }
+
+    #[test]
+    fn sub_bin_lookup_stays_in_its_fft_interval_at_high_zoom() {
+        let bins = ramp(256);
+        let view = SpectrumView::new(
+            &bins,
+            &bins,
+            None,
+            100_000_000,
+            32_000_000.0,
+            32,
+            BinAxis::FftBins,
+        )
+        .unwrap();
+        for i in 0..view.n_bins {
+            let hz = view.freq_of_bin(i) as u64;
+            for offset in [0, 62_500, 100_000, 124_999] {
+                assert_eq!(view.level_at(hz + offset), Some(view.bins[i]));
+            }
+        }
     }
 
     #[test]

--- a/src/ui/panels/core/spectrum/view.rs
+++ b/src/ui/panels/core/spectrum/view.rs
@@ -15,6 +15,8 @@
 
 use std::sync::Arc;
 
+use crate::state::BinAxis;
+
 /// The window the panel is actually drawing: the bins in view and the frequency
 /// span they cover.
 pub(super) struct SpectrumView {
@@ -30,16 +32,14 @@ pub(super) struct SpectrumView {
     pub left_hz: f64,
     /// Width of the window in hertz.
     pub bw: f64,
+    bin_axis: BinAxis,
 }
 
 impl SpectrumView {
-    /// Window `full_*` down to the centre `1/zoom` of its bins. A `zoom` of 1
-    /// (or a frame with nothing in it) returns the whole span, sharing the
-    /// frame's `Arc`s rather than copying.
+    /// Select the centre slice of the frame at `zoom`
     ///
-    /// `held` may have been captured at a different bin count than the live
-    /// frame, so it is windowed against its own length. Slicing it blind is a
-    /// panic waiting for the user to change sample rate while holding.
+    /// The full view shares the frame's buffers. Empty frames have no view.
+    /// A held trace may have a different bin count.
     pub fn new(
         bins: &Arc<Vec<f32>>,
         peaks: &Arc<Vec<f32>>,
@@ -47,41 +47,35 @@ impl SpectrumView {
         center_hz: u64,
         sample_rate: f64,
         zoom: usize,
+        bin_axis: BinAxis,
     ) -> Option<Self> {
         let full_n = bins.len();
-        if full_n == 0 || sample_rate <= 0.0 {
-            return None;
-        }
-        let full_left = center_hz as f64 - sample_rate / 2.0;
-        let zoom = zoom.max(1);
+        let window = bin_axis.window(center_hz, sample_rate, full_n, zoom)?;
+        let lo = window.first_bin;
+        let hi = lo + window.bin_count;
 
-        if zoom == 1 {
-            // Arc::clone is O(1) - no data copied.
+        if lo == 0 && hi == full_n {
             return Some(Self {
                 bins: Arc::clone(bins),
                 peaks: Arc::clone(peaks),
                 held,
                 n_bins: full_n,
-                left_hz: full_left,
-                bw: sample_rate,
+                left_hz: window.left_hz,
+                bw: window.span_hz,
+                bin_axis,
             });
         }
 
-        let visible_n = (full_n / zoom).max(1);
-        let lo = (full_n / 2)
-            .saturating_sub(visible_n / 2)
-            .min(full_n - visible_n);
-        let hi = lo + visible_n;
-        let bin_hz = sample_rate / full_n as f64;
         let win = |v: &[f32]| Arc::new(v[lo.min(v.len())..hi.min(v.len())].to_vec());
 
         Some(Self {
             bins: win(bins),
             peaks: win(peaks),
             held: held.map(|h| win(&h)),
-            n_bins: visible_n,
-            left_hz: full_left + lo as f64 * bin_hz,
-            bw: visible_n as f64 * bin_hz,
+            n_bins: window.bin_count,
+            left_hz: window.left_hz,
+            bw: window.span_hz,
+            bin_axis,
         })
     }
 
@@ -90,24 +84,24 @@ impl SpectrumView {
         self.left_hz + self.bw
     }
 
-    /// Canvas width in the units the paint closure works in: `0..n-1`.
+    /// Return the right edge of the canvas in bin-interval units
     pub fn n(&self) -> f64 {
-        self.n_bins as f64
+        self.bin_axis.interval_count(self.n_bins).unwrap_or(1) as f64
     }
 
     /// The level at `freq_hz`, or `None` when it falls outside the window.
     pub fn level_at(&self, freq_hz: u64) -> Option<f32> {
-        let frac = (freq_hz as f64 - self.left_hz) / self.bw;
-        if !(0.0..=1.0).contains(&frac) {
-            return None;
-        }
-        let idx = (frac * (self.n_bins - 1) as f64).round() as usize;
-        self.bins.get(idx.min(self.n_bins - 1)).copied()
+        let idx = self
+            .bin_axis
+            .nearest_bin(self.left_hz, self.bw, self.n_bins, freq_hz as f64)?;
+        self.bins.get(idx).copied()
     }
 
     /// The centre frequency of bin `idx`.
     pub fn freq_of_bin(&self, idx: usize) -> f64 {
-        self.left_hz + self.bw * (idx as f64 / (self.n_bins - 1).max(1) as f64)
+        self.bin_axis
+            .frequency_of_bin(self.left_hz, self.bw, self.n_bins, idx)
+            .unwrap_or(self.left_hz)
     }
 }
 
@@ -123,7 +117,16 @@ mod tests {
     fn zoom_one_shows_the_whole_span_without_copying() {
         let bins = ramp(1024);
         let peaks = ramp(1024);
-        let v = SpectrumView::new(&bins, &peaks, None, 92_800_000, 2_000_000.0, 1).unwrap();
+        let v = SpectrumView::new(
+            &bins,
+            &peaks,
+            None,
+            92_800_000,
+            2_000_000.0,
+            1,
+            BinAxis::FftBins,
+        )
+        .unwrap();
         assert_eq!(v.n_bins, 1024);
         assert_eq!(v.left_hz, 91_800_000.0);
         assert_eq!(v.bw, 2_000_000.0);
@@ -136,7 +139,16 @@ mod tests {
     #[test]
     fn zoom_takes_the_centre_slice_around_the_tuned_frequency() {
         let bins = ramp(1000);
-        let v = SpectrumView::new(&bins, &ramp(1000), None, 92_800_000, 2_000_000.0, 4).unwrap();
+        let v = SpectrumView::new(
+            &bins,
+            &ramp(1000),
+            None,
+            92_800_000,
+            2_000_000.0,
+            4,
+            BinAxis::FftBins,
+        )
+        .unwrap();
         assert_eq!(v.n_bins, 250);
         assert_eq!(v.bins[0], 375.0, "starts a quarter of the way in, not at 0");
         assert_eq!(v.bw, 500_000.0, "a quarter of the span");
@@ -150,15 +162,42 @@ mod tests {
         // than the live frame, so the window has to clamp to its own length.
         let bins = ramp(1024);
         let held = Some(ramp(200));
-        let v = SpectrumView::new(&bins, &ramp(1024), held, 92_800_000, 2_000_000.0, 4).unwrap();
+        let v = SpectrumView::new(
+            &bins,
+            &ramp(1024),
+            held,
+            92_800_000,
+            2_000_000.0,
+            4,
+            BinAxis::FftBins,
+        )
+        .unwrap();
         assert!(v.held.unwrap().len() <= 200);
     }
 
     #[test]
     fn an_empty_frame_yields_no_view() {
-        assert!(SpectrumView::new(&ramp(0), &ramp(0), None, 92_800_000, 2_000_000.0, 1).is_none());
+        assert!(SpectrumView::new(
+            &ramp(0),
+            &ramp(0),
+            None,
+            92_800_000,
+            2_000_000.0,
+            1,
+            BinAxis::FftBins
+        )
+        .is_none());
         assert!(
-            SpectrumView::new(&ramp(64), &ramp(64), None, 92_800_000, 0.0, 1).is_none(),
+            SpectrumView::new(
+                &ramp(64),
+                &ramp(64),
+                None,
+                92_800_000,
+                0.0,
+                1,
+                BinAxis::FftBins
+            )
+            .is_none(),
             "a zero sample rate has no span to draw"
         );
     }
@@ -166,9 +205,73 @@ mod tests {
     #[test]
     fn level_at_reads_the_window_not_the_frame() {
         let bins = ramp(1000);
-        let v = SpectrumView::new(&bins, &ramp(1000), None, 92_800_000, 2_000_000.0, 4).unwrap();
+        let v = SpectrumView::new(
+            &bins,
+            &ramp(1000),
+            None,
+            92_800_000,
+            2_000_000.0,
+            4,
+            BinAxis::FftBins,
+        )
+        .unwrap();
         // Mid-window is bin 125 of the slice, which held the value 500.
         assert_eq!(v.level_at((v.left_hz + v.bw / 2.0) as u64), Some(500.0));
         assert!(v.level_at(90_000_000).is_none(), "outside the window");
+    }
+
+    #[test]
+    fn fft_bin_24_maps_to_canvas_24() {
+        let bins = ramp(32);
+        let view = SpectrumView::new(
+            &bins,
+            &bins,
+            None,
+            100_000_000,
+            32_000_000.0,
+            1,
+            BinAxis::FftBins,
+        )
+        .unwrap();
+        assert_eq!(view.freq_of_bin(24), 108_000_000.0);
+        assert_eq!(view.level_at(108_000_000), Some(24.0));
+        assert_eq!(
+            super::super::scale::freq_to_canvas_x(108_000_000.0, view.left_hz, view.bw, view.n(),),
+            Some(24.0)
+        );
+    }
+
+    #[test]
+    fn bin_frequencies_map_to_their_canvas_positions_across_zoom() {
+        let bins = ramp(32);
+        for zoom in [0, 1, 2, 3, 4, 32, 64] {
+            let view = SpectrumView::new(
+                &bins,
+                &bins,
+                None,
+                100_000_000,
+                32_000_000.0,
+                zoom,
+                BinAxis::FftBins,
+            )
+            .unwrap();
+            for index in 0..view.n_bins {
+                let frequency = 84_000_000.0 + view.bins[index] as f64 * 1_000_000.0;
+                assert_eq!(view.freq_of_bin(index), frequency);
+                assert_eq!(view.level_at(frequency as u64), Some(view.bins[index]));
+                let x = super::super::scale::freq_to_canvas_x(
+                    frequency,
+                    view.left_hz,
+                    view.bw,
+                    view.n(),
+                )
+                .unwrap();
+                assert!((x - index as f64).abs() < 1e-9, "zoom {zoom} bin {index}");
+            }
+            assert_eq!(
+                view.level_at(view.right_hz() as u64),
+                view.bins.last().copied()
+            );
+        }
     }
 }

--- a/src/ui/panels/core/waterfall/axes.rs
+++ b/src/ui/panels/core/waterfall/axes.rs
@@ -82,14 +82,14 @@ pub(super) fn indicator(
     area: Rect,
     state: &SdrMetrics,
     rows: &VecDeque<(Instant, Arc<Vec<f32>>)>,
-    columns: &Columns,
+    columns: Option<&Columns>,
     skip_data: usize,
     cursor_col: Option<usize>,
     stride: usize,
     theme: &crate::Theme,
 ) {
-    let text = match (state.waterfall.cursor_freq, cursor_col) {
-        (Some(cf), Some(col)) => cursor_readout(cf, col, rows, columns, skip_data),
+    let text = match (state.waterfall.cursor_freq, cursor_col.zip(columns)) {
+        (Some(cf), Some((col, columns))) => cursor_readout(cf, col, rows, columns, skip_data),
         // A cursor set outside the current zoom window: name it, but there is
         // nothing on screen to read a level from.
         (Some(cf), None) => format!("  cur: {:.3} MHz  \u{2190} \u{2192}  M", cf as f64 / 1e6),

--- a/src/ui/panels/core/waterfall/cells.rs
+++ b/src/ui/panels/core/waterfall/cells.rs
@@ -22,6 +22,7 @@ use ratatui::{
 };
 
 use crate::palette::{magnitude_to_color_palette, ColorDepth, WaterfallPalette};
+use crate::state::BinAxis;
 
 /// Top of the colour scale. The waterfall is always referenced to full scale;
 /// only the floor (`db_min`) moves, under `↑`/`↓`.
@@ -51,29 +52,39 @@ pub(super) struct Columns {
     visible_n: usize,
     row_bins: usize,
     cols: usize,
+    bin_axis: BinAxis,
 }
 
 impl Columns {
-    pub fn new(row_bins: usize, zoom: u32, cols: usize) -> Self {
-        // A zero-bin row would underflow the `row_bins - 1` clamp below. It should
-        // not happen, but a malformed row must not take the TUI down with it.
+    pub fn new(
+        row_bins: usize,
+        first_bin: usize,
+        visible_n: usize,
+        cols: usize,
+        bin_axis: BinAxis,
+    ) -> Self {
         let row_bins = row_bins.max(1);
-        let visible_n = (row_bins / (zoom as usize).max(1)).max(1);
+        let visible_n = visible_n.max(1).min(row_bins);
         Self {
-            lo_bin: (row_bins / 2).saturating_sub(visible_n / 2),
+            lo_bin: first_bin.min(row_bins - visible_n),
             visible_n,
             row_bins,
             cols: cols.max(1),
+            bin_axis,
         }
     }
 
     /// The `[start, end)` bin span column `col` reads. Always non-empty, so a
     /// wide panel over few bins still gets one bin per column rather than none.
     pub fn range(&self, col: usize) -> (usize, usize) {
-        let start = (self.lo_bin + col * self.visible_n / self.cols).min(self.row_bins - 1);
-        let end = (self.lo_bin + ((col + 1) * self.visible_n) / self.cols)
-            .max(start + 1)
-            .min(self.row_bins);
+        let (start, end) = match self.bin_axis {
+            BinAxis::FftBins => (
+                col * self.visible_n / self.cols,
+                (col + 1) * self.visible_n / self.cols,
+            ),
+        };
+        let start = (self.lo_bin + start).min(self.row_bins - 1);
+        let end = (self.lo_bin + end).max(start + 1).min(self.row_bins);
         (start, end)
     }
 }
@@ -148,7 +159,7 @@ mod tests {
 
     #[test]
     fn unzoomed_columns_cover_every_bin_exactly_once() {
-        let c = Columns::new(1024, 1, 128);
+        let c = Columns::new(1024, 0, 1024, 128, BinAxis::FftBins);
         let (first, _) = c.range(0);
         let (_, last) = c.range(127);
         assert_eq!(first, 0, "the first column starts at the first bin");
@@ -165,7 +176,7 @@ mod tests {
 
     #[test]
     fn zoom_keeps_the_centre_slice() {
-        let c = Columns::new(1024, 4, 128);
+        let c = Columns::new(1024, 384, 256, 128, BinAxis::FftBins);
         let (first, _) = c.range(0);
         let (_, last) = c.range(127);
         assert_eq!(first, 384, "a quarter of the way in");
@@ -173,10 +184,26 @@ mod tests {
     }
 
     #[test]
+    fn columns_follow_the_bin_window_at_uneven_zoom() {
+        let axis = BinAxis::FftBins;
+        let window = axis.window(100, 10.0, 10, 3).unwrap();
+        let columns = Columns::new(10, window.first_bin, window.bin_count, 3, axis);
+        assert_eq!(columns.range(0), (4, 5));
+        assert_eq!(columns.range(1), (5, 6));
+        assert_eq!(columns.range(2), (6, 7));
+        for col in 0..3 {
+            assert_eq!(
+                axis.frequency_of_bin(window.left_hz, window.span_hz, window.bin_count, col),
+                Some(99.0 + col as f64)
+            );
+        }
+    }
+
+    #[test]
     fn a_column_is_never_empty_however_odd_the_geometry() {
         // More columns than bins: every column still reads at least one bin,
         // rather than an empty span that would paint the whole plot at the floor.
-        let c = Columns::new(8, 1, 200);
+        let c = Columns::new(8, 0, 8, 200, BinAxis::FftBins);
         for col in 0..200 {
             let (lo, hi) = c.range(col);
             assert!(hi > lo, "column {col} is empty");
@@ -194,12 +221,12 @@ mod tests {
         let (row_bins, cols) = (1024usize, 128usize);
         let naive = |col: usize| col * row_bins / cols;
 
-        let unzoomed = Columns::new(row_bins, 1, cols);
+        let unzoomed = Columns::new(row_bins, 0, row_bins, cols, BinAxis::FftBins);
         for col in 0..cols {
             assert_eq!(unzoomed.range(col).0, naive(col), "zoom 1 hides the bug");
         }
 
-        let zoomed = Columns::new(row_bins, 4, cols);
+        let zoomed = Columns::new(row_bins, 384, 256, cols, BinAxis::FftBins);
         assert_eq!(zoomed.range(0).0, 384);
         assert_eq!(
             naive(0),
@@ -212,12 +239,10 @@ mod tests {
 
     #[test]
     fn degenerate_input_does_not_underflow() {
-        // A zero-bin row and a zero zoom are both nonsense, and both used to be
-        // one subtraction away from panicking.
-        let c = Columns::new(0, 0, 40);
+        let c = Columns::new(0, 0, 0, 40, BinAxis::FftBins);
         let (lo, hi) = c.range(0);
         assert!(hi > lo);
-        let zero_cols = Columns::new(1024, 4, 0);
+        let zero_cols = Columns::new(1024, 384, 256, 0, BinAxis::FftBins);
         let _ = zero_cols.range(0);
     }
 }

--- a/src/ui/panels/core/waterfall/cells.rs
+++ b/src/ui/panels/core/waterfall/cells.rs
@@ -22,7 +22,7 @@ use ratatui::{
 };
 
 use crate::palette::{magnitude_to_color_palette, ColorDepth, WaterfallPalette};
-use crate::state::BinAxis;
+use crate::state::{BinAxis, BinWindow};
 
 /// Top of the colour scale. The waterfall is always referenced to full scale;
 /// only the floor (`db_min`) moves, under `↑`/`↓`.
@@ -48,27 +48,16 @@ pub(super) fn band_max(row: &[f32], start: usize, end: usize) -> f32 {
 /// Zoom keeps the centre `1/zoom` of the row's bins - the same slice the bonded
 /// spectrum above narrows to, so `+`/`-` zoom both plots as one instrument.
 pub(super) struct Columns {
-    lo_bin: usize,
-    visible_n: usize,
-    row_bins: usize,
+    pub window: BinWindow,
     cols: usize,
     bin_axis: BinAxis,
 }
 
 impl Columns {
-    pub fn new(
-        row_bins: usize,
-        first_bin: usize,
-        visible_n: usize,
-        cols: usize,
-        bin_axis: BinAxis,
-    ) -> Self {
-        let row_bins = row_bins.max(1);
-        let visible_n = visible_n.max(1).min(row_bins);
+    /// Use a window computed from the row being drawn
+    pub fn new(window: BinWindow, cols: usize, bin_axis: BinAxis) -> Self {
         Self {
-            lo_bin: first_bin.min(row_bins - visible_n),
-            visible_n,
-            row_bins,
+            window,
             cols: cols.max(1),
             bin_axis,
         }
@@ -77,15 +66,16 @@ impl Columns {
     /// The `[start, end)` bin span column `col` reads. Always non-empty, so a
     /// wide panel over few bins still gets one bin per column rather than none.
     pub fn range(&self, col: usize) -> (usize, usize) {
+        let visible_n = self.window.bin_count;
         let (start, end) = match self.bin_axis {
             BinAxis::FftBins => (
-                col * self.visible_n / self.cols,
-                (col + 1) * self.visible_n / self.cols,
+                col * visible_n / self.cols,
+                (col + 1) * visible_n / self.cols,
             ),
         };
-        let start = (self.lo_bin + start).min(self.row_bins - 1);
-        let end = (self.lo_bin + end).max(start + 1).min(self.row_bins);
-        (start, end)
+        let start = start.min(visible_n - 1);
+        let end = end.max(start + 1).min(visible_n);
+        (self.window.first_bin + start, self.window.first_bin + end)
     }
 }
 
@@ -95,7 +85,7 @@ pub(super) fn draw(
     f: &mut Frame,
     area: Rect,
     rows: &VecDeque<(Instant, Arc<Vec<f32>>)>,
-    columns: &Columns,
+    columns_for_row: impl Fn(usize) -> Option<Columns>,
     cursor_col: Option<usize>,
     skip_data: usize,
     db_min: f32,
@@ -111,16 +101,25 @@ pub(super) fn draw(
     let mut data = rows.iter().skip(skip_data).take(area.height as usize * 2);
     while let Some((_ts, top_row)) = data.next() {
         let bot_row = data.next().map(|(_ts, r)| r.as_ref());
+        let top_columns = columns_for_row(top_row.len());
+        let bot_columns = bot_row.and_then(|row| columns_for_row(row.len()));
+        let row_color = |row: &[f32], columns: Option<&Columns>, col| {
+            columns.map_or(floor, |columns| {
+                let (lo, hi) = columns.range(col);
+                color(band_max(row, lo, hi))
+            })
+        };
         let spans: Vec<Span> = (0..cols)
             .map(|col| {
-                let (lo, hi) = columns.range(col);
-                let bot_color = bot_row.map(|r| color(band_max(r, lo, hi))).unwrap_or(floor);
+                let bot_color = bot_row
+                    .map(|r| row_color(r, bot_columns.as_ref(), col))
+                    .unwrap_or(floor);
                 // The cursor column keeps the background so the history still reads
                 // through it, but takes a bright foreground as its marker.
                 let top_color = if Some(col) == cursor_col {
                     theme.value_hi
                 } else {
-                    color(band_max(top_row, lo, hi))
+                    row_color(top_row, top_columns.as_ref(), col)
                 };
                 Span::styled("\u{2580}", Style::default().fg(top_color).bg(bot_color))
             })
@@ -134,6 +133,14 @@ pub(super) fn draw(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn columns(row_bins: usize, zoom: usize, cols: usize) -> Columns {
+        let axis = BinAxis::FftBins;
+        let window = axis
+            .window(100_000_000, 32_000_000.0, row_bins, zoom)
+            .unwrap();
+        Columns::new(window, cols, axis)
+    }
 
     #[test]
     fn band_max_reads_in_range() {
@@ -159,7 +166,7 @@ mod tests {
 
     #[test]
     fn unzoomed_columns_cover_every_bin_exactly_once() {
-        let c = Columns::new(1024, 0, 1024, 128, BinAxis::FftBins);
+        let c = columns(1024, 1, 128);
         let (first, _) = c.range(0);
         let (_, last) = c.range(127);
         assert_eq!(first, 0, "the first column starts at the first bin");
@@ -176,7 +183,7 @@ mod tests {
 
     #[test]
     fn zoom_keeps_the_centre_slice() {
-        let c = Columns::new(1024, 384, 256, 128, BinAxis::FftBins);
+        let c = columns(1024, 4, 128);
         let (first, _) = c.range(0);
         let (_, last) = c.range(127);
         assert_eq!(first, 384, "a quarter of the way in");
@@ -187,7 +194,7 @@ mod tests {
     fn columns_follow_the_bin_window_at_uneven_zoom() {
         let axis = BinAxis::FftBins;
         let window = axis.window(100, 10.0, 10, 3).unwrap();
-        let columns = Columns::new(10, window.first_bin, window.bin_count, 3, axis);
+        let columns = Columns::new(window, 3, axis);
         assert_eq!(columns.range(0), (4, 5));
         assert_eq!(columns.range(1), (5, 6));
         assert_eq!(columns.range(2), (6, 7));
@@ -203,7 +210,7 @@ mod tests {
     fn a_column_is_never_empty_however_odd_the_geometry() {
         // More columns than bins: every column still reads at least one bin,
         // rather than an empty span that would paint the whole plot at the floor.
-        let c = Columns::new(8, 0, 8, 200, BinAxis::FftBins);
+        let c = columns(8, 1, 200);
         for col in 0..200 {
             let (lo, hi) = c.range(col);
             assert!(hi > lo, "column {col} is empty");
@@ -221,12 +228,12 @@ mod tests {
         let (row_bins, cols) = (1024usize, 128usize);
         let naive = |col: usize| col * row_bins / cols;
 
-        let unzoomed = Columns::new(row_bins, 0, row_bins, cols, BinAxis::FftBins);
+        let unzoomed = columns(row_bins, 1, cols);
         for col in 0..cols {
             assert_eq!(unzoomed.range(col).0, naive(col), "zoom 1 hides the bug");
         }
 
-        let zoomed = Columns::new(row_bins, 384, 256, cols, BinAxis::FftBins);
+        let zoomed = columns(row_bins, 4, cols);
         assert_eq!(zoomed.range(0).0, 384);
         assert_eq!(
             naive(0),
@@ -238,11 +245,29 @@ mod tests {
     }
 
     #[test]
-    fn degenerate_input_does_not_underflow() {
-        let c = Columns::new(0, 0, 0, 40, BinAxis::FftBins);
+    fn singleton_and_zero_columns_do_not_underflow() {
+        let c = columns(1, 32, 40);
         let (lo, hi) = c.range(0);
         assert!(hi > lo);
-        let zero_cols = Columns::new(1024, 384, 256, 0, BinAxis::FftBins);
+        let zero_cols = columns(1024, 4, 0);
         let _ = zero_cols.range(0);
+    }
+
+    #[test]
+    fn high_zoom_sub_bin_frequencies_use_the_same_interval() {
+        let axis = BinAxis::FftBins;
+        let columns = columns(256, 32, 160);
+        let window = columns.window;
+        for col in 0..160 {
+            let frequency = window.left_hz + col as f64 * window.span_hz / 160.0;
+            let index = axis
+                .nearest_bin(window.left_hz, window.span_hz, window.bin_count, frequency)
+                .unwrap();
+            assert_eq!(
+                columns.range(col).0,
+                window.first_bin + index,
+                "column {col}"
+            );
+        }
     }
 }

--- a/src/ui/panels/core/waterfall/mod.rs
+++ b/src/ui/panels/core/waterfall/mod.rs
@@ -252,15 +252,21 @@ fn contents(
     }
     let cols = plot.width as usize;
 
-    // The frequency window, narrowed by the shared zoom around the tuned centre.
-    let bin_window = wf
-        .last_fft
+    // Two data rows occupy each character row
+    let data_rows = plot.height as usize * 2;
+    let max_scroll = buf.rows.len().saturating_sub(data_rows) / 2;
+    let skip_data = wf.scroll_offset.min(max_scroll) * 2;
+
+    let columns_for_row = |row_bins| columns_for_row(wf, row_bins, cols);
+    let columns = buf
+        .rows
+        .get(skip_data)
+        .and_then(|(_, row)| columns_for_row(row.len()));
+    let window = columns
         .as_ref()
-        .and_then(|frame| frame.window(wf.hz_zoom as usize));
-    let window = bin_window
-        .map(|window| Window {
-            left_hz: window.left_hz,
-            bw: window.span_hz,
+        .map(|columns| Window {
+            left_hz: columns.window.left_hz,
+            bw: columns.window.span_hz,
         })
         .unwrap_or(Window {
             left_hz: 0.0,
@@ -278,30 +284,16 @@ fn contents(
             .then(|| ((frac * cols as f64) as usize).min(cols - 1))
     });
 
-    // Two rows of history per character cell, so every scroll figure exists in
-    // both units: `skip_chars` on screen, `skip_data` into the buffer.
-    let data_rows = plot.height as usize * 2;
-    let max_scroll = buf.rows.len().saturating_sub(data_rows) / 2;
-    let skip_data = wf.scroll_offset.min(max_scroll) * 2;
-
-    let row_bins = buf.rows.front().map(|(_, r)| r.len()).unwrap_or(1);
-    let columns = bin_window
-        .zip(wf.last_fft.as_ref())
-        .map(|(window, frame)| {
-            Columns::new(
-                row_bins,
-                window.first_bin,
-                window.bin_count,
-                cols,
-                frame.bin_axis,
-            )
-        })
-        .unwrap_or_else(|| {
-            Columns::new(row_bins, 0, row_bins, cols, crate::state::BinAxis::FftBins)
-        });
-
     cells::draw(
-        f, plot, &buf.rows, &columns, cursor_col, skip_data, wf.db_min, wf.palette, theme,
+        f,
+        plot,
+        &buf.rows,
+        columns_for_row,
+        cursor_col,
+        skip_data,
+        wf.db_min,
+        wf.palette,
+        theme,
     );
 
     // Bonded, the spectrum above already carries the band plan; twice is noise.
@@ -326,7 +318,7 @@ fn contents(
             area,
             state,
             &buf.rows,
-            &columns,
+            columns.as_ref(),
             skip_data,
             cursor_col,
             status.stride,
@@ -335,9 +327,83 @@ fn contents(
     }
 }
 
+fn columns_for_row(
+    wf: &crate::state::WaterfallState,
+    row_bins: usize,
+    cols: usize,
+) -> Option<Columns> {
+    let (axis, center_hz, span_hz) = wf
+        .last_fft
+        .as_ref()
+        .map_or((crate::state::BinAxis::FftBins, 0, 1.0), |frame| {
+            (frame.bin_axis, frame.center_freq_hz, frame.sample_rate)
+        });
+    let window = axis.window(center_hz, span_hz, row_bins, wf.hz_zoom as usize)?;
+    Some(Columns::new(window, cols, axis))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn paused_history_keeps_its_own_bin_window_after_fft_size_changes() {
+        let mut state = crate::state::SdrMetrics::fixture().with_carrier(0.0, 70.0);
+        state.waterfall.hz_zoom = 4;
+        state.waterfall.buffer.paused = true;
+        let old_row = Arc::clone(&state.waterfall.buffer.rows.front().unwrap().1);
+        let frame = state.waterfall.last_fft.as_mut().unwrap();
+        frame.bins_dbfs = Arc::new(vec![-90.0; 1024]);
+        assert!(!state.waterfall.buffer.push(&frame.bins_dbfs));
+
+        let columns = columns_for_row(&state.waterfall, old_row.len(), 64).unwrap();
+        assert_eq!(columns.window.first_bin, 96);
+        assert_eq!(columns.window.bin_count, 64);
+        assert_eq!(columns.range(0), (96, 97));
+        assert_eq!(columns.range(63), (159, 160));
+        assert!(columns_for_row(&state.waterfall, 0, 64).is_none());
+    }
+
+    #[test]
+    fn mixed_size_history_rows_draw_their_own_centre_slices() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let state = crate::state::SdrMetrics::fixture().with_carrier(0.0, 70.0);
+        let mut wf = state.waterfall;
+        wf.hz_zoom = 4;
+        let mut top = vec![-120.0; 256];
+        let mut bottom = vec![-120.0; 1024];
+        top[96] = -20.0;
+        bottom[384] = -20.0;
+        wf.buffer.rows.clear();
+        wf.buffer
+            .rows
+            .push_back((std::time::Instant::now(), Arc::new(top)));
+        wf.buffer
+            .rows
+            .push_back((std::time::Instant::now(), Arc::new(bottom)));
+        let mut terminal = Terminal::new(TestBackend::new(64, 1)).unwrap();
+        let theme = crate::theme::Theme::sdr();
+        terminal
+            .draw(|f| {
+                cells::draw(
+                    f,
+                    Rect::new(0, 0, 64, 1),
+                    &wf.buffer.rows,
+                    |n| columns_for_row(&wf, n, 64),
+                    None,
+                    0,
+                    wf.db_min,
+                    wf.palette,
+                    &theme,
+                )
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer.get(0, 0).fg, buffer.get(0, 0).bg);
+        assert_ne!(buffer.get(0, 0).fg, buffer.get(1, 0).fg);
+        assert_ne!(buffer.get(0, 0).bg, buffer.get(1, 0).bg);
+    }
 
     #[test]
     fn the_ladders_walk_and_stop_at_their_ends() {

--- a/src/ui/panels/core/waterfall/mod.rs
+++ b/src/ui/panels/core/waterfall/mod.rs
@@ -253,15 +253,14 @@ fn contents(
     let cols = plot.width as usize;
 
     // The frequency window, narrowed by the shared zoom around the tuned centre.
-    let window = wf
+    let bin_window = wf
         .last_fft
         .as_ref()
-        .map(|fr| {
-            let visible = fr.sample_rate / wf.hz_zoom as f64;
-            Window {
-                left_hz: fr.center_freq_hz as f64 - visible / 2.0,
-                bw: visible,
-            }
+        .and_then(|frame| frame.window(wf.hz_zoom as usize));
+    let window = bin_window
+        .map(|window| Window {
+            left_hz: window.left_hz,
+            bw: window.span_hz,
         })
         .unwrap_or(Window {
             left_hz: 0.0,
@@ -286,7 +285,20 @@ fn contents(
     let skip_data = wf.scroll_offset.min(max_scroll) * 2;
 
     let row_bins = buf.rows.front().map(|(_, r)| r.len()).unwrap_or(1);
-    let columns = Columns::new(row_bins, wf.hz_zoom, cols);
+    let columns = bin_window
+        .zip(wf.last_fft.as_ref())
+        .map(|(window, frame)| {
+            Columns::new(
+                row_bins,
+                window.first_bin,
+                window.bin_count,
+                cols,
+                frame.bin_axis,
+            )
+        })
+        .unwrap_or_else(|| {
+            Columns::new(row_bins, 0, row_bins, cols, crate::state::BinAxis::FftBins)
+        });
 
     cells::draw(
         f, plot, &buf.rows, &columns, cursor_col, skip_data, wf.db_min, wf.palette, theme,

--- a/src/ui/panels/lab/bars.rs
+++ b/src/ui/panels/lab/bars.rs
@@ -82,17 +82,14 @@ fn fmt_delta(df_hz: u64, dl_db: Option<f32>) -> String {
 /// is no frame yet or the frequency is outside the captured span.
 fn level_at_freq(state: &SdrMetrics, freq_hz: u64) -> Option<f32> {
     let fr = state.waterfall.last_fft.as_ref()?;
-    let n = fr.bins_dbfs.len();
-    if n == 0 {
-        return None;
-    }
-    let left = fr.center_freq_hz as f64 - fr.sample_rate / 2.0;
-    let frac = (freq_hz as f64 - left) / fr.sample_rate;
-    if !(0.0..=1.0).contains(&frac) {
-        return None;
-    }
-    let idx = (frac * (n - 1) as f64).round() as usize;
-    fr.bins_dbfs.get(idx.min(n - 1)).copied()
+    let window = fr.window(1)?;
+    let idx = fr.bin_axis.nearest_bin(
+        window.left_hz,
+        window.span_hz,
+        window.bin_count,
+        freq_hz as f64,
+    )?;
+    fr.bins_dbfs.get(idx).copied()
 }
 
 /// Display width (columns) of a span run - every glyph we use here is single-width.
@@ -1050,6 +1047,19 @@ mod tests {
     use super::*;
     use crate::hardware::native::{hackrf, rtlsdr};
 
+    #[test]
+    fn marker_level_uses_the_captured_fft_interval() {
+        let mut state = SdrMetrics::fixture();
+        state.radio.frequency = 100_000_000;
+        state.radio.config_sample_rate = 32_000_000.0;
+        let mut state = state.with_carrier(8_000_000.0, 70.0);
+        state.radio.frequency = 200_000_000;
+        assert_eq!(level_at_freq(&state, 108_000_000), Some(-30.0));
+        assert_eq!(level_at_freq(&state, 108_100_000), Some(-30.0));
+        assert_eq!(level_at_freq(&state, 108_125_000), Some(-100.0));
+        assert_eq!(level_at_freq(&state, 116_000_000), Some(-100.0));
+        assert_eq!(level_at_freq(&state, 116_000_001), None);
+    }
     /// A signal state with real numbers in it, as if the FFT had just run.
     fn measured() -> crate::state::SignalState {
         crate::state::SignalState {

--- a/src/ui/panels/lab/signal_characterization/metrics.rs
+++ b/src/ui/panels/lab/signal_characterization/metrics.rs
@@ -139,13 +139,7 @@ fn peak_bin(fr: &FftFrame) -> Option<(f32, u64)> {
     let n = bins.len();
     let radius = crate::signal::fft::centre_radius_bins(n, fr.sample_rate);
     let (idx, best) = crate::signal::fft::strongest_real_bin(bins, Some(radius))?;
-    let left = fr.center_freq_hz as f64 - fr.sample_rate / 2.0;
-    let span_frac = if n > 1 {
-        idx as f64 / (n - 1) as f64
-    } else {
-        0.0
-    };
-    let freq = (left + span_frac * fr.sample_rate).max(0.0).round() as u64;
+    let freq = fr.frequency_of_bin(idx)?.max(0.0).round() as u64;
     Some((best, freq))
 }
 
@@ -206,7 +200,7 @@ mod tests {
     fn peak_bin_maps_index_to_frequency() {
         let (lvl, hz) = peak_bin(&peaked_at(75)).unwrap();
         assert!((lvl + 10.0).abs() < 1e-6, "peak level is the max bin");
-        assert_eq!(hz, 100_100_000, "three quarters across the span");
+        assert_eq!(hz, 100_097_030);
     }
 
     #[test]
@@ -222,7 +216,7 @@ mod tests {
             (lvl + 30.0).abs() < 1e-6,
             "reported a station out of channel: {lvl}"
         );
-        assert_eq!(hz, 100_100_000);
+        assert_eq!(hz, 100_097_030);
     }
 
     #[test]
@@ -235,7 +229,7 @@ mod tests {
         bins[60] = -30.0; // a real, weaker carrier
         let (lvl, hz) = peak_bin(&frame(bins, 100_000_000, 400_000.0)).unwrap();
         assert!((lvl + 30.0).abs() < 1e-6, "reported the artefact: {lvl}");
-        assert_eq!(hz, 100_040_000);
+        assert_eq!(hz, 100_037_624);
     }
 
     #[test]

--- a/src/ui/panels/lab/signal_characterization/metrics.rs
+++ b/src/ui/panels/lab/signal_characterization/metrics.rs
@@ -167,6 +167,7 @@ mod tests {
             channel_power_dbfs: -22.0,
             occupied_bw_hz: 180_000,
             enbw_hz: 1_000.0,
+            bin_axis: crate::state::BinAxis::FftBins,
         }
     }
 


### PR DESCRIPTION
This PR prepares sdrtop for spectrum analyzers that publish measured power bins. It is one of three independent prerequisites for #7.

Spectrum and waterfall views used different bin intervals. A bin could therefore map to a different frequency or canvas position across consumers.

This PR introduces one bin-axis model and routes existing IQ geometry through it. #7 uses the same model for direct power traces.