### PR TITLE
Share acquisition transitions and spectrum statistics

### DIFF
--- a/src/signal/fft/analysis.rs
+++ b/src/signal/fft/analysis.rs
@@ -52,12 +52,7 @@ pub(super) fn carrier(linear: &[f32], sample_rate: f64, noise_floor_db: f32) -> 
 ///
 /// `scratch` is the worker's reused buffer; nothing is allocated here.
 pub(super) fn noise_floor(smoothed: &[f32], scratch: &mut [f32]) -> f32 {
-    scratch.copy_from_slice(smoothed);
-    let count = (smoothed.len() / NOISE_FLOOR_FRACTION).max(1);
-    scratch.select_nth_unstable_by(count - 1, |a, b| {
-        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-    });
-    scratch[..count].iter().sum::<f32>() / count as f32
+    crate::signal::stats::quietest_mean(smoothed, scratch, NOISE_FLOOR_FRACTION)
 }
 
 /// The SNR the worker publishes: the strongest real bin *near centre*, minus the
@@ -190,6 +185,18 @@ mod tests {
     fn a_single_bin_spectrum_has_a_floor() {
         let mut scratch = vec![0.0; 1];
         assert_eq!(noise_floor(&[-42.0], &mut scratch), -42.0);
+    }
+
+    #[test]
+    fn finite_iq_noise_floor_keeps_the_quietest_tenth_mean() {
+        let mut bins = [-20.0; 29];
+        bins[7] = -100.0;
+        bins[19] = -90.0;
+        bins[25] = -80.0;
+        let mut scratch = [0.0; 29];
+        assert_eq!(noise_floor(&bins, &mut scratch), -95.0);
+        bins.reverse();
+        assert_eq!(noise_floor(&bins, &mut scratch), -95.0);
     }
 
     /// `level_db` is the carrier's **total** power, spread evenly across the bins it

--- a/src/signal/fft/frame.rs
+++ b/src/signal/fft/frame.rs
@@ -125,19 +125,8 @@ pub(super) fn average(
     decay_db: f32,
     initialized: &mut bool,
 ) {
-    if !*initialized {
-        smoothed.copy_from_slice(shifted);
-        peak.copy_from_slice(shifted);
-        *initialized = true;
-        return;
-    }
-    let one_minus = 1.0 - alpha;
-    for (s, &new) in smoothed.iter_mut().zip(shifted.iter()) {
-        *s = alpha * new + one_minus * *s;
-    }
-    for (p, &s) in peak.iter_mut().zip(smoothed.iter()) {
-        *p = (*p - decay_db).max(s);
-    }
+    crate::signal::stats::average_and_peak(shifted, smoothed, peak, alpha, decay_db, *initialized);
+    *initialized = true;
 }
 
 #[cfg(test)]
@@ -298,5 +287,46 @@ mod tests {
             s = alpha * target + (1.0 - alpha) * s;
         }
         assert!(s > 0.99, "EMA should converge to target, got {}", s);
+    }
+
+    #[test]
+    fn finite_iq_sequence_keeps_the_existing_average_and_peak_law() {
+        let mut smoothed = [0.0];
+        let mut peak = [0.0];
+        let mut initialized = false;
+        for sample in [-90.0, -80.0, -100.0] {
+            average(
+                &[sample],
+                &mut smoothed,
+                &mut peak,
+                0.2,
+                0.5,
+                &mut initialized,
+            );
+        }
+
+        assert!((smoothed[0] - -90.4).abs() < 1e-4);
+        assert!((peak[0] - -88.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn finite_iq_first_frame_and_reset_seed_both_traces() {
+        let mut smoothed = [-120.0; 2];
+        let mut peak = [0.0; 2];
+        let mut initialized = false;
+        for samples in [[-90.0, -80.0], [-100.0, -110.0]] {
+            average(
+                &samples,
+                &mut smoothed,
+                &mut peak,
+                0.2,
+                0.5,
+                &mut initialized,
+            );
+            assert!(initialized);
+            assert_eq!(smoothed, samples);
+            assert_eq!(peak, samples);
+            initialized = false;
+        }
     }
 }

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -12,6 +12,7 @@ pub mod net;
 pub mod noise_slope;
 pub mod rds;
 pub mod rds_demod;
+mod stats;
 pub mod stream;
 
 pub use demod::DemodWorker;

--- a/src/signal/stats.rs
+++ b/src/signal/stats.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+pub(crate) fn finite_ema(previous: f32, sample: f32, alpha: f32) -> f32 {
+    match (previous.is_finite(), sample.is_finite()) {
+        (true, true) => alpha * sample + (1.0 - alpha) * previous,
+        (false, true) => sample,
+        (true, false) => previous,
+        (false, false) => f32::NEG_INFINITY,
+    }
+}
+
+pub(crate) fn average_and_peak(
+    samples: &[f32],
+    smoothed: &mut [f32],
+    peak: &mut [f32],
+    alpha: f32,
+    decay_db: f32,
+    has_history: bool,
+) {
+    for ((smoothed, peak), sample) in smoothed
+        .iter_mut()
+        .zip(peak.iter_mut())
+        .zip(samples.iter().copied())
+    {
+        if !has_history {
+            *smoothed = f32::NEG_INFINITY;
+            *peak = f32::NEG_INFINITY;
+        }
+        *smoothed = finite_ema(*smoothed, sample, alpha);
+        let decayed_peak = if peak.is_finite() {
+            *peak - decay_db
+        } else {
+            f32::NEG_INFINITY
+        };
+        *peak = if smoothed.is_finite() {
+            decayed_peak.max(*smoothed)
+        } else {
+            decayed_peak
+        };
+    }
+}
+
+pub(crate) fn quietest_mean(values: &[f32], scratch: &mut [f32], fraction: usize) -> f32 {
+    let mut finite_count = 0;
+    for value in values.iter().copied().filter(|value| value.is_finite()) {
+        scratch[finite_count] = value;
+        finite_count += 1;
+    }
+    if finite_count == 0 {
+        return f32::NEG_INFINITY;
+    }
+
+    let count = (finite_count / fraction.max(1)).max(1);
+    scratch[..finite_count].select_nth_unstable_by(count - 1, f32::total_cmp);
+    scratch[..count].iter().sum::<f32>() / count as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finite_ema_keeps_the_available_value() {
+        assert_eq!(finite_ema(-90.0, -80.0, 0.2), -88.0);
+        assert_eq!(finite_ema(f32::NAN, -80.0, 0.2), -80.0);
+        assert_eq!(finite_ema(-90.0, f32::NAN, 0.2), -90.0);
+        assert_eq!(finite_ema(f32::NAN, f32::INFINITY, 0.2), f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn average_and_peak_handles_missing_samples() {
+        let mut smoothed = [0.0, 0.0];
+        let mut peak = [0.0, 0.0];
+        average_and_peak(
+            &[f32::NAN, -90.0],
+            &mut smoothed,
+            &mut peak,
+            0.2,
+            0.5,
+            false,
+        );
+        average_and_peak(&[-70.0, f32::NAN], &mut smoothed, &mut peak, 0.2, 0.5, true);
+        assert_eq!(smoothed, [-70.0, -90.0]);
+        assert_eq!(peak, [-70.0, -90.0]);
+    }
+
+    #[test]
+    fn quietest_mean_ignores_non_finite_values() {
+        let values = [-100.0, f32::NAN, -90.0, f32::INFINITY, -80.0];
+        let mut scratch = vec![0.0; values.len()];
+        assert_eq!(quietest_mean(&values, &mut scratch, 10), -100.0);
+    }
+}

--- a/src/signal/stats.rs
+++ b/src/signal/stats.rs
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
+//! These statistics operate on finite spectrum measurements in a common dB unit.
+//! Non-finite inputs represent unavailable measurements.
+//! `NEG_INFINITY` represents an unavailable output.
+//! A finite floor such as the FFT's `DB_FLOOR` remains a measurement.
+
+/// Compute an EMA from the available values.
+///
+/// A finite sample seeds unavailable history regardless of `alpha`.
+/// An unavailable sample preserves finite history.
+/// Two unavailable values produce `NEG_INFINITY`.
+/// The caller must supply a finite `alpha` in `0..=1`.
+/// With two finite values, zero retains history and one selects the sample.
 pub(crate) fn finite_ema(previous: f32, sample: f32, alpha: f32) -> f32 {
     match (previous.is_finite(), sample.is_finite()) {
         (true, true) => alpha * sample + (1.0 - alpha) * previous,
@@ -10,6 +22,20 @@ pub(crate) fn finite_ema(previous: f32, sample: f32, alpha: f32) -> f32 {
     }
 }
 
+/// Smooth each bin and decay its peak toward the smoothed value.
+///
+/// `has_history = false` discards both traces before seeding from the samples.
+/// With history, each bin follows [`finite_ema`]'s availability rules.
+/// Non-finite previous peaks are unavailable.
+/// The caller must supply a finite `alpha` in `0..=1`.
+/// `decay_db` must be finite and nonnegative.
+/// It sets the peak reduction in dB per call, including calls with unavailable samples.
+/// Zero holds the peak.
+///
+/// # Panics
+///
+/// All three slices must have equal lengths.
+/// A mismatch panics before either output is mutated.
 pub(crate) fn average_and_peak(
     samples: &[f32],
     smoothed: &mut [f32],
@@ -18,6 +44,12 @@ pub(crate) fn average_and_peak(
     decay_db: f32,
     has_history: bool,
 ) {
+    assert_eq!(
+        samples.len(),
+        smoothed.len(),
+        "samples/smoothed length mismatch"
+    );
+    assert_eq!(samples.len(), peak.len(), "samples/peak length mismatch");
     for ((smoothed, peak), sample) in smoothed
         .iter_mut()
         .zip(peak.iter_mut())
@@ -41,7 +73,23 @@ pub(crate) fn average_and_peak(
     }
 }
 
+/// Average the quietest fraction of the finite dB measurements.
+///
+/// The selected count is the finite count divided by `fraction`, rounded down.
+/// At least one measurement is selected from nonempty finite input.
+/// A zero fraction selects all finite measurements.
+/// Empty or all-non-finite input produces `NEG_INFINITY`.
+/// `scratch` is reusable workspace with unspecified contents after the call.
+///
+/// # Panics
+///
+/// `scratch` must hold at least `values.len()` entries, including unavailable values.
+/// Insufficient capacity panics before `scratch` is mutated.
 pub(crate) fn quietest_mean(values: &[f32], scratch: &mut [f32], fraction: usize) -> f32 {
+    assert!(
+        scratch.len() >= values.len(),
+        "scratch is shorter than values"
+    );
     let mut finite_count = 0;
     for value in values.iter().copied().filter(|value| value.is_finite()) {
         scratch[finite_count] = value;
@@ -59,6 +107,7 @@ pub(crate) fn quietest_mean(values: &[f32], scratch: &mut [f32], fraction: usize
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     #[test]
     fn finite_ema_keeps_the_available_value() {
@@ -90,5 +139,155 @@ mod tests {
         let values = [-100.0, f32::NAN, -90.0, f32::INFINITY, -80.0];
         let mut scratch = vec![0.0; values.len()];
         assert_eq!(quietest_mean(&values, &mut scratch, 10), -100.0);
+    }
+
+    #[test]
+    fn finite_ema_handles_all_unavailable_values_and_recovers() {
+        for unavailable in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(finite_ema(unavailable, -80.0, 0.2), -80.0);
+            assert_eq!(finite_ema(-90.0, unavailable, 0.2), -90.0);
+            for other in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                let absent = finite_ema(unavailable, other, 0.2);
+                assert_eq!(absent, f32::NEG_INFINITY);
+                assert_eq!(finite_ema(absent, -80.0, 0.2), -80.0);
+            }
+        }
+    }
+
+    #[test]
+    fn finite_ema_alpha_boundaries_preserve_seeding() {
+        assert_eq!(finite_ema(-90.0, -80.0, 0.0), -90.0);
+        assert_eq!(finite_ema(-90.0, -80.0, 1.0), -80.0);
+        for alpha in [0.0, 1.0] {
+            assert_eq!(finite_ema(f32::NEG_INFINITY, -80.0, alpha), -80.0);
+            assert_eq!(finite_ema(-90.0, f32::NAN, alpha), -90.0);
+        }
+    }
+
+    #[test]
+    fn average_and_peak_accepts_empty_traces() {
+        for has_history in [false, true] {
+            average_and_peak(&[], &mut [], &mut [], 0.2, 0.5, has_history);
+        }
+    }
+
+    #[test]
+    fn average_and_peak_recovers_from_all_unavailable_samples() {
+        let unavailable = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+        let mut smoothed = [-90.0; 3];
+        let mut peak = [-80.0; 3];
+        average_and_peak(&unavailable, &mut smoothed, &mut peak, 0.2, 0.5, false);
+        assert_eq!(smoothed, [f32::NEG_INFINITY; 3]);
+        assert_eq!(peak, [f32::NEG_INFINITY; 3]);
+        average_and_peak(&unavailable, &mut smoothed, &mut peak, 0.2, 0.5, true);
+        assert_eq!(smoothed, [f32::NEG_INFINITY; 3]);
+        assert_eq!(peak, [f32::NEG_INFINITY; 3]);
+        average_and_peak(&[-70.0; 3], &mut smoothed, &mut peak, 0.2, 0.5, true);
+        assert_eq!(smoothed, [-70.0; 3]);
+        assert_eq!(peak, [-70.0; 3]);
+    }
+
+    #[test]
+    fn average_and_peak_discards_non_finite_previous_peaks() {
+        for previous_peak in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            for previous in [-90.0, f32::NEG_INFINITY] {
+                let mut smoothed = [previous];
+                let mut peak = [previous_peak];
+                average_and_peak(&[f32::NAN], &mut smoothed, &mut peak, 0.2, 0.5, true);
+                assert_eq!(smoothed, [previous]);
+                assert_eq!(peak, [previous]);
+                average_and_peak(&[-70.0], &mut smoothed, &mut peak, 1.0, 0.5, true);
+                assert_eq!(smoothed, [-70.0]);
+                assert_eq!(peak, [-70.0]);
+            }
+        }
+    }
+
+    #[test]
+    fn average_and_peak_alpha_and_decay_boundaries() {
+        for (alpha, expected) in [(0.0, -90.0), (1.0, -80.0)] {
+            for decay in [0.0, 1.0] {
+                let mut smoothed = [-90.0];
+                let mut peak = [-70.0];
+                average_and_peak(&[-80.0], &mut smoothed, &mut peak, alpha, decay, true);
+                assert_eq!(smoothed, [expected]);
+                assert_eq!(peak, [-70.0 - decay]);
+                average_and_peak(&[f32::NAN], &mut smoothed, &mut peak, alpha, decay, true);
+                assert_eq!(smoothed, [expected]);
+                assert_eq!(peak, [-70.0 - 2.0 * decay]);
+            }
+        }
+        let mut smoothed = [-90.0];
+        let mut peak = [-89.5];
+        average_and_peak(&[-90.0], &mut smoothed, &mut peak, 1.0, 1.0, true);
+        assert_eq!(peak, smoothed);
+    }
+
+    #[test]
+    fn average_and_peak_rejects_mismatches_before_mutating() {
+        for (samples_len, smoothed_len, peak_len) in
+            [(1, 2, 2), (2, 1, 2), (2, 2, 1), (2, 2, 3), (0, 1, 1)]
+        {
+            for sample in [-80.0, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                for has_history in [false, true] {
+                    let samples = vec![sample; samples_len];
+                    let mut smoothed = vec![-90.0; smoothed_len];
+                    let mut peak = vec![-70.0; peak_len];
+                    let result = catch_unwind(AssertUnwindSafe(|| {
+                        average_and_peak(&samples, &mut smoothed, &mut peak, 0.2, 0.5, has_history);
+                    }));
+                    assert!(result.is_err());
+                    assert_eq!(smoothed, vec![-90.0; smoothed_len]);
+                    assert_eq!(peak, vec![-70.0; peak_len]);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn quietest_mean_empty_and_unavailable_inputs_have_no_measurement() {
+        assert_eq!(quietest_mean(&[], &mut [], 10), f32::NEG_INFINITY);
+        let mut scratch = [42.0; 3];
+        assert_eq!(
+            quietest_mean(
+                &[f32::NAN, f32::INFINITY, f32::NEG_INFINITY],
+                &mut scratch,
+                10,
+            ),
+            f32::NEG_INFINITY
+        );
+        assert_eq!(
+            quietest_mean(&[-90.0, -80.0, -70.0], &mut scratch, 10),
+            -90.0
+        );
+    }
+
+    #[test]
+    fn quietest_mean_zero_and_one_select_all_finite_values() {
+        let values = [-90.0, f32::NAN, -70.0, f32::INFINITY, f32::NEG_INFINITY];
+        let mut scratch = [0.0; 8];
+        for fraction in [0, 1] {
+            assert_eq!(quietest_mean(&values, &mut scratch, fraction), -80.0);
+        }
+        assert_eq!(quietest_mean(&values, &mut scratch, usize::MAX), -90.0);
+    }
+
+    #[test]
+    fn quietest_mean_rejects_short_scratch_before_mutating() {
+        for values in [
+            [-90.0, -80.0],
+            [-90.0, f32::NAN],
+            [f32::NAN, f32::INFINITY],
+            [f32::NEG_INFINITY, f32::NEG_INFINITY],
+        ] {
+            for fraction in [0, 1, 10] {
+                let mut scratch = [42.0];
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    quietest_mean(&values, &mut scratch, fraction);
+                }));
+                assert!(result.is_err());
+                assert_eq!(scratch, [42.0]);
+            }
+        }
     }
 }

--- a/src/tasks/rx/control.rs
+++ b/src/tasks/rx/control.rs
@@ -23,6 +23,37 @@ use crate::state::{SdrMetrics, ADC_COMFORT_DBFS as AUTOGAIN_COMFORT_DBFS};
 use super::metrics::RateTracker;
 use super::publish::Throughput;
 
+pub(super) enum RxRequestTransition {
+    Unchanged(bool),
+    Started,
+    StartFailed(anyhow::Error),
+    Stopped(anyhow::Result<()>),
+}
+
+pub(super) fn request_transition(
+    rx_enabled: bool,
+    hw_rx_active: bool,
+    start: impl FnOnce() -> anyhow::Result<()>,
+    stop: impl FnOnce() -> anyhow::Result<()>,
+) -> RxRequestTransition {
+    match (rx_enabled, hw_rx_active) {
+        (true, false) => match start() {
+            Ok(()) => RxRequestTransition::Started,
+            Err(error) => RxRequestTransition::StartFailed(error),
+        },
+        (false, true) => RxRequestTransition::Stopped(stop()),
+        (_, active) => RxRequestTransition::Unchanged(active),
+    }
+}
+
+pub(super) fn unexpected_stop(
+    hw_rx_active: bool,
+    hw_streaming: bool,
+    cleanup: impl FnOnce() -> anyhow::Result<()>,
+) -> Option<anyhow::Result<()>> {
+    (hw_rx_active && !hw_streaming).then(cleanup)
+}
+
 /// Notice that the radio stopped streaming without being asked, and say so.
 ///
 /// Returns the new `hw_rx_active`. The device is told to stop as well: it has
@@ -34,10 +65,9 @@ pub(super) fn note_unexpected_stop(
     hw_rx_active: bool,
     hw_streaming: bool,
 ) -> bool {
-    if !hw_rx_active || hw_streaming {
+    let Some(_) = unexpected_stop(hw_rx_active, hw_streaming, || device.stop_rx()) else {
         return hw_rx_active;
-    }
-    let _ = device.stop_rx();
+    };
     let mut m = state.lock().unwrap_or_else(|e| e.into_inner());
     m.radio.rx_enabled = false;
     m.radio.hw_streaming = false;
@@ -57,30 +87,29 @@ pub(super) fn apply_rx_request(
     rx_enabled: bool,
     hw_rx_active: bool,
 ) -> bool {
-    match (rx_enabled, hw_rx_active) {
-        (true, false) => match device.start_rx(Arc::clone(rx_ctx)) {
-            Ok(()) => {
-                // Fresh per-session throughput statistics, and a rate baseline
-                // that does not span the stop. Averaging across one would mix a
-                // silent stretch into the sample-rate offset.
-                tp.reset();
-                rate.reset();
-                let mut m = state.lock().unwrap_or_else(|e| e.into_inner());
-                m.radio.rx_start_time = Some(Instant::now());
-                m.timing.jitter_session_max_us = 0;
-                m.push_log("RX streaming started");
-                true
-            }
-            Err(e) => {
-                let msg = format!("Error starting RX: {}", e);
-                let mut m = state.lock().unwrap_or_else(|e| e.into_inner());
-                m.radio.rx_enabled = false;
-                m.push_log(msg);
-                false
-            }
-        },
-        (false, true) => {
-            let result = device.stop_rx();
+    match request_transition(
+        rx_enabled,
+        hw_rx_active,
+        || device.start_rx(Arc::clone(rx_ctx)),
+        || device.stop_rx(),
+    ) {
+        RxRequestTransition::Started => {
+            // Keep the sample-rate baseline within one RX session
+            tp.reset();
+            rate.reset();
+            let mut m = state.lock().unwrap_or_else(|e| e.into_inner());
+            m.radio.rx_start_time = Some(Instant::now());
+            m.timing.jitter_session_max_us = 0;
+            m.push_log("RX streaming started");
+            true
+        }
+        RxRequestTransition::StartFailed(error) => {
+            let mut m = state.lock().unwrap_or_else(|e| e.into_inner());
+            m.radio.rx_enabled = false;
+            m.push_log(format!("Error starting RX: {error}"));
+            false
+        }
+        RxRequestTransition::Stopped(result) => {
             rate.reset();
             let mut m = state.lock().unwrap_or_else(|e| e.into_inner());
             m.radio.rx_start_time = None;
@@ -90,7 +119,7 @@ pub(super) fn apply_rx_request(
             }
             false
         }
-        (_, active) => active,
+        RxRequestTransition::Unchanged(active) => active,
     }
 }
 
@@ -252,6 +281,7 @@ pub(super) fn advance_noise_sweep(state: &Arc<Mutex<SdrMetrics>>, device: &Arc<d
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     #[test]
     fn the_comfort_window_is_closed_at_both_ends() {
@@ -270,5 +300,94 @@ mod tests {
             AUTOGAIN_COMFORT_DBFS.contains(&opt),
             "the optimum {opt} dBFS must be inside the comfort window"
         );
+    }
+
+    #[test]
+    fn request_transitions_call_only_the_needed_device_action() {
+        let starts = Cell::new(0);
+        let stops = Cell::new(0);
+        let started = request_transition(
+            true,
+            false,
+            || {
+                starts.set(starts.get() + 1);
+                Ok(())
+            },
+            || {
+                stops.set(stops.get() + 1);
+                Ok(())
+            },
+        );
+        assert!(matches!(started, RxRequestTransition::Started));
+        assert_eq!((starts.get(), stops.get()), (1, 0));
+
+        let stopped = request_transition(
+            false,
+            true,
+            || {
+                starts.set(starts.get() + 1);
+                Ok(())
+            },
+            || {
+                stops.set(stops.get() + 1);
+                Ok(())
+            },
+        );
+        assert!(matches!(stopped, RxRequestTransition::Stopped(Ok(()))));
+        assert_eq!((starts.get(), stops.get()), (1, 1));
+    }
+
+    #[test]
+    fn unchanged_requests_do_not_call_the_device() {
+        for active in [false, true] {
+            let transition = request_transition(
+                active,
+                active,
+                || panic!("unexpected start"),
+                || panic!("unexpected stop"),
+            );
+            assert!(matches!(transition, RxRequestTransition::Unchanged(value) if value == active));
+        }
+    }
+
+    #[test]
+    fn request_transitions_preserve_device_errors() {
+        let started = request_transition(
+            true,
+            false,
+            || anyhow::bail!("start failed"),
+            || panic!("unexpected stop"),
+        );
+        assert!(
+            matches!(started, RxRequestTransition::StartFailed(error) if error.to_string() == "start failed")
+        );
+
+        let stopped = request_transition(
+            false,
+            true,
+            || panic!("unexpected start"),
+            || anyhow::bail!("stop failed"),
+        );
+        assert!(
+            matches!(stopped, RxRequestTransition::Stopped(Err(error)) if error.to_string() == "stop failed")
+        );
+    }
+
+    #[test]
+    fn unexpected_stop_runs_cleanup_once() {
+        let cleanups = Cell::new(0);
+        let result = unexpected_stop(true, false, || {
+            cleanups.set(cleanups.get() + 1);
+            anyhow::bail!("cleanup failed")
+        });
+        assert!(matches!(result, Some(Err(_))));
+        assert_eq!(cleanups.get(), 1);
+        for (active, streaming) in [(false, false), (false, true), (true, true)] {
+            assert!(unexpected_stop(active, streaming, || panic!("unexpected cleanup")).is_none());
+        }
+        assert!(matches!(
+            unexpected_stop(true, false, || Ok(())),
+            Some(Ok(()))
+        ));
     }
 }


### PR DESCRIPTION
This PR prepares sdrtop to support IQ receivers and power-trace analyzers through shared acquisition behavior. It is one of three independent prerequisites for #7.

RX transitions and spectrum statistics were tied to the IQ path. A direct power path would otherwise duplicate that logic and risk different behavior.

This PR extracts backend-neutral transition and statistics helpers while preserving existing IQ results. #7 reuses them for power traces.