### PR TITLE
Add numeric entry for device options

### DIFF
--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -4,7 +4,7 @@
 //! The menu's own keys, live only while the menu is open.
 //!
 //! Layer 2 of the dispatch: above panel focus, below text entry. The menu is
-//! modal but it is **not** an `InputMode`: those five variants are all text being
+//! modal but it is **not** an `InputMode`: the input variants are all text being
 //! typed, and this is not text.
 //!
 //! Modal here means modal. Nothing falls through to [`super::global`] except the
@@ -14,7 +14,7 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use crate::event::{DeviceOptionCompletion, DeviceOptionRequest};
-use crate::state::{DeviceOptionUpdate, MenuPane, MenuState, SdrMetrics};
+use crate::state::{DeviceOptionUpdate, InputMode, MenuPane, MenuState, SdrMetrics};
 use crate::ui::menu::{keys, sections};
 
 use super::{global, metrics, InputCtx, KeyAction};
@@ -80,6 +80,23 @@ pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
             }
         }
         KeyCode::Enter if state.pane == MenuPane::Options => {
+            let mut m = metrics(ctx.state);
+            if m.ui.device_option_update.is_pending() {
+                return KeyAction::Continue;
+            }
+            if let Some(option) = m
+                .device_options
+                .get(state.scroll)
+                .filter(|option| option.integer_range.is_some())
+            {
+                m.ui.input_mode = InputMode::DeviceOptionInput {
+                    id: option.id.clone(),
+                    error: None,
+                };
+                m.ui.input_buf.clear();
+                return KeyAction::Continue;
+            }
+            drop(m);
             return request_option_change(ctx, state, 1);
         }
         _ => {}
@@ -230,6 +247,13 @@ fn request_option_change(ctx: &mut InputCtx<'_>, menu: MenuState, step: isize) -
         label: requested.1,
         choice: requested.2,
     };
+    submit_option_request(&mut m, request)
+}
+
+pub(super) fn submit_option_request(m: &mut SdrMetrics, request: DeviceOptionRequest) -> KeyAction {
+    if m.ui.device_option_update.is_pending() {
+        return KeyAction::Continue;
+    }
     m.ui.device_option_update = DeviceOptionUpdate::Pending {
         request: request.clone(),
         quit_requested: false,
@@ -340,14 +364,20 @@ mod tests {
         }
 
         fn key(&mut self, code: KeyCode) -> KeyAction {
-            let mut ctx = InputCtx {
-                state: &self.state,
-                device: None,
-                engine: &mut self.engine,
-                show_footer: &mut self.show_footer,
-                focus_keys: &self.focus_keys,
-            };
-            handle(KeyEvent::from(code), &mut ctx)
+            super::super::handle_key(
+                KeyEvent::from(code),
+                &self.state,
+                None,
+                &mut self.engine,
+                &mut self.show_footer,
+                &self.focus_keys,
+            )
+        }
+
+        fn type_number(&mut self, value: &str) {
+            for c in value.chars() {
+                assert_eq!(self.key(KeyCode::Char(c)), KeyAction::Continue);
+            }
         }
 
         fn menu(&self) -> MenuState {
@@ -374,6 +404,325 @@ mod tests {
             label: label.into(),
             choices: choices.iter().map(|choice| (*choice).into()).collect(),
             selected_choice: selected.into(),
+            integer_range: None,
+        }
+    }
+
+    fn integer_option(selected: &str) -> DeviceOption {
+        DeviceOption {
+            id: "gain".into(),
+            label: "Gain".into(),
+            choices: (-100..=100).map(|value| value.to_string()).collect(),
+            selected_choice: selected.into(),
+            integer_range: Some(-100..=100),
+        }
+    }
+
+    #[test]
+    fn numeric_entry_begins_without_writing_and_cancel_keeps_the_value() {
+        let mut h = Harness::new();
+        h.show_options(vec![integer_option("0")]);
+        assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+        h.type_number("-12");
+        h.key(KeyCode::Backspace);
+        {
+            let m = metrics(&h.state);
+            assert_eq!(m.ui.input_buf, "-1");
+            assert!(matches!(
+                &m.ui.input_mode,
+                InputMode::DeviceOptionInput { id, error: None } if id == "gain"
+            ));
+            assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+            assert_eq!(m.device_options[0].selected_choice, "0");
+        }
+        assert_eq!(h.key(KeyCode::Esc), KeyAction::Continue);
+        let m = metrics(&h.state);
+        assert!(matches!(m.ui.input_mode, InputMode::Normal));
+        assert!(m.ui.input_buf.is_empty());
+        assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+        assert_eq!(m.device_options[0].selected_choice, "0");
+        assert_eq!(m.ui.menu.unwrap().pane, MenuPane::Options);
+    }
+
+    #[test]
+    fn numeric_submission_emits_one_request_and_waits_for_authoritative_refresh() {
+        let mut h = Harness::new();
+        h.show_options(vec![integer_option("0"), option("mode", "Mode", "Narrow")]);
+        h.key(KeyCode::Enter);
+        h.type_number("-12");
+        let request = DeviceOptionRequest {
+            id: "gain".into(),
+            label: "Gain".into(),
+            choice: "-12".into(),
+        };
+        assert_eq!(
+            h.key(KeyCode::Enter),
+            KeyAction::ApplyDeviceOption(request.clone())
+        );
+        for code in [KeyCode::Enter, KeyCode::Left, KeyCode::Right] {
+            assert_eq!(h.key(code), KeyAction::Continue);
+        }
+        {
+            let m = metrics(&h.state);
+            assert_eq!(m.device_options[0].selected_choice, "0");
+            assert!(matches!(m.ui.input_mode, InputMode::Normal));
+            assert!(m.ui.input_buf.is_empty());
+            assert_eq!(
+                m.ui.device_option_update,
+                DeviceOptionUpdate::Pending {
+                    request,
+                    quit_requested: false,
+                }
+            );
+        }
+        h.key(KeyCode::Down);
+        assert!(!complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                result: Ok(vec![option("mode", "Mode", "Wide"), integer_option("-10")]),
+            }
+        ));
+        assert_eq!(h.menu().scroll, 0);
+        let m = metrics(&h.state);
+        assert_eq!(m.device_options[1].selected_choice, "-10");
+        assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+        assert!(m.ui.log.back().unwrap().text.contains("Gain set to -10"));
+    }
+
+    #[test]
+    fn numeric_input_rejects_invalid_out_of_range_and_unadvertised_values() {
+        for value in [
+            "",
+            "-",
+            "101",
+            "-101",
+            "2147483648",
+            "1.5",
+            "+1",
+            " 1",
+            "1 ",
+            "1e1",
+            "auto",
+            "12",
+        ] {
+            let mut h = Harness::new();
+            let mut option = integer_option("0");
+            option.choices.retain(|choice| choice != "12");
+            h.show_options(vec![option]);
+            h.key(KeyCode::Enter);
+            metrics(&h.state).ui.input_buf = value.into();
+            assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue, "{value}");
+            let m = metrics(&h.state);
+            assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+            assert_eq!(m.device_options[0].selected_choice, "0");
+            assert_eq!(m.ui.input_buf, value);
+            assert!(
+                matches!(
+                    &m.ui.input_mode,
+                    InputMode::DeviceOptionInput { error: Some(message), .. }
+                        if message.contains("advertised integer from -100 to 100")
+                ),
+                "{value}"
+            );
+        }
+    }
+
+    #[test]
+    fn editing_an_invalid_number_clears_the_error_and_allows_resubmission() {
+        let mut h = Harness::new();
+        h.show_options(vec![integer_option("0")]);
+        h.key(KeyCode::Enter);
+        h.type_number("-");
+        h.key(KeyCode::Enter);
+        h.key(KeyCode::Backspace);
+        assert!(matches!(
+            metrics(&h.state).ui.input_mode,
+            InputMode::DeviceOptionInput { error: None, .. }
+        ));
+        h.type_number("-100");
+        assert!(
+            matches!(h.key(KeyCode::Enter), KeyAction::ApplyDeviceOption(request)
+            if request.choice == "-100")
+        );
+    }
+
+    #[test]
+    fn numeric_entry_keeps_auto_available_through_choice_arrows() {
+        let mut h = Harness::new();
+        let mut option = DeviceOption {
+            id: "level".into(),
+            label: "Level".into(),
+            choices: std::iter::once("auto".to_string())
+                .chain((0..=31).map(|value| value.to_string()))
+                .collect(),
+            selected_choice: "auto".into(),
+            integer_range: Some(0..=31),
+        };
+        h.show_options(vec![option.clone()]);
+        h.key(KeyCode::Enter);
+        assert!(metrics(&h.state).ui.input_buf.is_empty());
+        h.type_number("-1");
+        assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+        h.key(KeyCode::Esc);
+        h.key(KeyCode::Enter);
+        h.type_number("31");
+        assert!(
+            matches!(h.key(KeyCode::Enter), KeyAction::ApplyDeviceOption(request)
+            if request.choice == "31")
+        );
+        option.selected_choice = "31".into();
+        complete_device_option(
+            &h.state,
+            DeviceOptionCompletion {
+                result: Ok(vec![option]),
+            },
+        );
+        assert!(
+            matches!(h.key(KeyCode::Right), KeyAction::ApplyDeviceOption(request)
+            if request.choice == "auto")
+        );
+    }
+
+    #[test]
+    fn unchanged_numeric_values_skip_writes_after_normalization() {
+        for input in ["0", "-0", "000"] {
+            let mut h = Harness::new();
+            h.show_options(vec![integer_option("0")]);
+            h.key(KeyCode::Enter);
+            h.type_number(input);
+            assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+            let m = metrics(&h.state);
+            assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+            assert!(matches!(m.ui.input_mode, InputMode::Normal));
+        }
+    }
+
+    #[test]
+    fn numeric_submission_uses_the_canonical_advertised_string() {
+        for (input, expected) in [("100", "100"), ("-0012", "-12")] {
+            let mut h = Harness::new();
+            h.show_options(vec![integer_option("0")]);
+            h.key(KeyCode::Enter);
+            h.type_number(input);
+            assert!(matches!(
+                h.key(KeyCode::Enter),
+                KeyAction::ApplyDeviceOption(request) if request.choice == expected
+            ));
+        }
+        let mut h = Harness::new();
+        let mut option = integer_option("0");
+        option.choices.retain(|choice| choice != "12");
+        option.choices.push("012".into());
+        h.show_options(vec![option]);
+        h.key(KeyCode::Enter);
+        h.type_number("12");
+        assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+        assert_eq!(
+            metrics(&h.state).ui.device_option_update,
+            DeviceOptionUpdate::Idle
+        );
+    }
+
+    #[test]
+    fn numeric_entry_cannot_start_during_another_option_update() {
+        let mut h = Harness::new();
+        h.show_options(vec![option("mode", "Mode", "Narrow"), integer_option("0")]);
+        let KeyAction::ApplyDeviceOption(request) = h.key(KeyCode::Enter) else {
+            panic!("discrete change did not create a request");
+        };
+        h.key(KeyCode::Down);
+        assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+        let m = metrics(&h.state);
+        assert!(matches!(m.ui.input_mode, InputMode::Normal));
+        assert_eq!(
+            m.ui.device_option_update,
+            DeviceOptionUpdate::Pending {
+                request,
+                quit_requested: false,
+            }
+        );
+    }
+
+    #[test]
+    fn integer_choices_require_explicit_numeric_metadata() {
+        let mut h = Harness::new();
+        let mut option = integer_option("0");
+        option.integer_range = None;
+        h.show_options(vec![option]);
+        assert!(
+            matches!(h.key(KeyCode::Enter), KeyAction::ApplyDeviceOption(request)
+            if request.choice == "1")
+        );
+        assert!(matches!(metrics(&h.state).ui.input_mode, InputMode::Normal));
+    }
+
+    #[test]
+    fn numeric_editor_resolves_its_option_by_id_and_rechecks_current_metadata() {
+        let mut h = Harness::new();
+        h.show_options(vec![integer_option("0"), option("mode", "Mode", "Narrow")]);
+        h.key(KeyCode::Enter);
+        h.type_number("12");
+        Arc::make_mut(&mut metrics(&h.state).device_options).swap(0, 1);
+        assert!(
+            matches!(h.key(KeyCode::Enter), KeyAction::ApplyDeviceOption(request)
+            if request.id == "gain" && request.choice == "12")
+        );
+
+        for removed in [false, true] {
+            let mut h = Harness::new();
+            h.show_options(vec![integer_option("0")]);
+            h.key(KeyCode::Enter);
+            h.type_number("12");
+            if removed {
+                metrics(&h.state).device_options = Arc::new(Vec::new());
+            } else {
+                Arc::make_mut(&mut metrics(&h.state).device_options)[0].integer_range = None;
+            }
+            assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+            assert!(matches!(
+                metrics(&h.state).ui.input_mode,
+                InputMode::DeviceOptionInput { error: Some(_), .. }
+            ));
+            assert_eq!(
+                metrics(&h.state).ui.device_option_update,
+                DeviceOptionUpdate::Idle
+            );
+        }
+    }
+
+    #[test]
+    fn numeric_completion_preserves_quit_request_on_success_and_failure() {
+        for failed in [false, true] {
+            let mut h = Harness::new();
+            h.show_options(vec![integer_option("0")]);
+            h.key(KeyCode::Enter);
+            h.type_number("1");
+            assert!(matches!(
+                h.key(KeyCode::Enter),
+                KeyAction::ApplyDeviceOption(_)
+            ));
+            assert_eq!(h.key(KeyCode::Char('q')), KeyAction::Quit);
+            assert!(!metrics(&h.state).ui.device_option_update.request_quit());
+            let result = if failed {
+                Err("device rejected choice".into())
+            } else {
+                Ok(vec![integer_option("1")])
+            };
+            assert!(complete_device_option(
+                &h.state,
+                DeviceOptionCompletion { result }
+            ));
+            let m = metrics(&h.state);
+            if failed {
+                assert_eq!(m.device_options[0].selected_choice, "0");
+                assert_eq!(
+                    m.ui.device_option_update,
+                    DeviceOptionUpdate::Failed { id: "gain".into() }
+                );
+            } else {
+                assert_eq!(m.device_options[0].selected_choice, "1");
+                assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+            }
         }
     }
 

--- a/src/app/input/menu.rs
+++ b/src/app/input/menu.rs
@@ -96,6 +96,7 @@ pub(super) fn handle(key: KeyEvent, ctx: &mut InputCtx<'_>) -> KeyAction {
                 m.ui.input_buf.clear();
                 return KeyAction::Continue;
             }
+            // Release the metrics lock before the cycling handler acquires it
             drop(m);
             return request_option_change(ctx, state, 1);
         }
@@ -516,15 +517,67 @@ mod tests {
             assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
             assert_eq!(m.device_options[0].selected_choice, "0");
             assert_eq!(m.ui.input_buf, value);
+            let expected = match value {
+                "101" | "-101" => "Out of range: -100 to 100",
+                "12" => "Not advertised. Closest choice: 11",
+                _ => "Enter a signed 32-bit integer",
+            };
             assert!(
                 matches!(
                     &m.ui.input_mode,
                     InputMode::DeviceOptionInput { error: Some(message), .. }
-                        if message.contains("advertised integer from -100 to 100")
+                        if message == expected
                 ),
                 "{value}"
             );
         }
+    }
+
+    #[test]
+    fn numeric_keystrokes_ignore_an_embedded_minus() {
+        let mut h = Harness::new();
+        h.show_options(vec![integer_option("0")]);
+        h.key(KeyCode::Enter);
+        h.type_number("1-2");
+        assert_eq!(metrics(&h.state).ui.input_buf, "12");
+    }
+
+    #[test]
+    fn overflowing_numeric_input_is_preserved_and_never_submitted() {
+        let mut h = Harness::new();
+        h.show_options(vec![integer_option("0")]);
+        h.key(KeyCode::Enter);
+        let input = "9".repeat(100);
+        h.type_number(&input);
+        assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+        let m = metrics(&h.state);
+        assert_eq!(m.ui.input_buf, input);
+        assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+        assert!(matches!(&m.ui.input_mode,
+            InputMode::DeviceOptionInput { error: Some(error), .. }
+            if error == "Enter a signed 32-bit integer"));
+    }
+
+    #[test]
+    fn repeated_invalid_submissions_stay_inline_without_writes_or_logs() {
+        let mut h = Harness::new();
+        let mut option = integer_option("0");
+        option.choices = ["0", "10"].map(String::from).to_vec();
+        h.show_options(vec![option]);
+        h.key(KeyCode::Enter);
+        h.type_number("9");
+        let log_count = metrics(&h.state).ui.log.len();
+        for _ in 0..3 {
+            assert_eq!(h.key(KeyCode::Enter), KeyAction::Continue);
+        }
+        let m = metrics(&h.state);
+        assert_eq!(m.ui.log.len(), log_count);
+        assert_eq!(m.ui.input_buf, "9");
+        assert_eq!(m.device_options[0].selected_choice, "0");
+        assert_eq!(m.ui.device_option_update, DeviceOptionUpdate::Idle);
+        assert!(matches!(&m.ui.input_mode,
+            InputMode::DeviceOptionInput { error: Some(error), .. }
+            if error == "Not advertised. Closest choice: 10"));
     }
 
     #[test]

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -10,7 +10,7 @@
 //!    keyboard belongs to [`text`] and nothing else sees it.
 //! 2. **The menu.** While it is open it is modal and owns the keyboard, so a
 //!    focus handler cannot act on a deck that is currently behind it. It is not
-//!    an `InputMode` because those five variants are all text being typed.
+//!    an `InputMode` because input modes represent text being typed.
 //! 3. **Panel focus.** [`handle_normal`] asks the layout engine which panel holds
 //!    focus and hands the key to that panel's own handler - [`core`], [`bench`],
 //!    [`signal`], [`sweep`] or [`rail`].
@@ -113,6 +113,7 @@ pub fn handle_key(
             text::frequency(key, state, device);
             KeyAction::Continue
         }
+        InputMode::DeviceOptionInput { id, .. } => text::device_option(key, state, &id),
         InputMode::SampleRateInput => {
             text::sample_rate(key, state, device);
             KeyAction::Continue

--- a/src/app/input/text.rs
+++ b/src/app/input/text.rs
@@ -43,17 +43,9 @@ pub(super) fn device_option(key: KeyEvent, state: &Arc<Mutex<SdrMetrics>>, id: &
                 .find(|option| option.id == id)
                 .ok_or_else(|| "Option is no longer available".to_string())
                 .and_then(|option| {
-                    let choice =
-                        option.integer_choice(&m.ui.input_buf).ok_or_else(|| {
-                            match &option.integer_range {
-                                Some(range) => format!(
-                                    "Enter an advertised integer from {} to {}",
-                                    range.start(),
-                                    range.end()
-                                ),
-                                None => "Numeric entry is no longer available".to_string(),
-                            }
-                        })?;
+                    let choice = option
+                        .integer_choice(&m.ui.input_buf)
+                        .map_err(|error| error.to_string())?;
                     Ok((
                         crate::event::DeviceOptionRequest {
                             id: option.id.clone(),
@@ -72,7 +64,6 @@ pub(super) fn device_option(key: KeyEvent, state: &Arc<Mutex<SdrMetrics>>, id: &
                     }
                 }
                 Err(message) => {
-                    m.push_log(format!("Device option input error: {message}"));
                     if let InputMode::DeviceOptionInput { error, .. } = &mut m.ui.input_mode {
                         *error = Some(message);
                     }

--- a/src/app/input/text.rs
+++ b/src/app/input/text.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
-//! The text-entry modes: frequency, sample rate, the two sweep-range fields and
-//! a marker's label.
+//! The text-entry modes include device options, frequency, sample rate, sweep
+//! bounds, and marker labels.
 //!
 //! These are reached through [`InputMode`] rather than through panel focus, and
 //! they are the one place a key is **not** case-folded - a marker label is typed,
@@ -15,7 +15,80 @@ use crossterm::event::{KeyCode, KeyEvent};
 use crate::hardware;
 use crate::state::{InputMode, RailMode, SdrMetrics, SpectrumMarker};
 
-use super::metrics;
+use super::{menu, metrics, KeyAction};
+
+pub(super) fn device_option(key: KeyEvent, state: &Arc<Mutex<SdrMetrics>>, id: &str) -> KeyAction {
+    let mut m = metrics(state);
+    if m.ui.device_option_update.is_pending() {
+        return KeyAction::Continue;
+    }
+    match key.code {
+        KeyCode::Esc => {
+            m.ui.input_mode = InputMode::Normal;
+            m.ui.input_buf.clear();
+            m.push_log("Device option input cancelled");
+        }
+        KeyCode::Backspace => {
+            m.ui.input_buf.pop();
+            clear_option_error(&mut m);
+        }
+        KeyCode::Char(c) if c.is_ascii_digit() || (c == '-' && m.ui.input_buf.is_empty()) => {
+            m.ui.input_buf.push(c);
+            clear_option_error(&mut m);
+        }
+        KeyCode::Enter => {
+            let result = m
+                .device_options
+                .iter()
+                .find(|option| option.id == id)
+                .ok_or_else(|| "Option is no longer available".to_string())
+                .and_then(|option| {
+                    let choice =
+                        option.integer_choice(&m.ui.input_buf).ok_or_else(|| {
+                            match &option.integer_range {
+                                Some(range) => format!(
+                                    "Enter an advertised integer from {} to {}",
+                                    range.start(),
+                                    range.end()
+                                ),
+                                None => "Numeric entry is no longer available".to_string(),
+                            }
+                        })?;
+                    Ok((
+                        crate::event::DeviceOptionRequest {
+                            id: option.id.clone(),
+                            label: option.label.clone(),
+                            choice: choice.to_string(),
+                        },
+                        choice == option.selected_choice,
+                    ))
+                });
+            match result {
+                Ok((request, unchanged)) => {
+                    m.ui.input_mode = InputMode::Normal;
+                    m.ui.input_buf.clear();
+                    if !unchanged {
+                        return menu::submit_option_request(&mut m, request);
+                    }
+                }
+                Err(message) => {
+                    m.push_log(format!("Device option input error: {message}"));
+                    if let InputMode::DeviceOptionInput { error, .. } = &mut m.ui.input_mode {
+                        *error = Some(message);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    KeyAction::Continue
+}
+
+fn clear_option_error(m: &mut SdrMetrics) {
+    if let InputMode::DeviceOptionInput { error, .. } = &mut m.ui.input_mode {
+        *error = None;
+    }
+}
 
 pub(super) fn frequency(
     key: KeyEvent,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -581,6 +581,7 @@ mod tests {
                 label: "Bandwidth".into(),
                 choices: vec!["Narrow".into(), "Wide".into()],
                 selected_choice: "Wide".into(),
+                integer_range: None,
             }]),
         }))
         .unwrap();
@@ -716,12 +717,14 @@ mod tests {
                             label: "Bandwidth".into(),
                             choices: vec!["Narrow".into(), "Wide".into()],
                             selected_choice: "Wide".into(),
+                            integer_range: None,
                         },
                         hardware::DeviceOption {
                             id: "attenuation".into(),
                             label: "Attenuation".into(),
                             choices: vec!["0 dB".into(), "10 dB".into()],
                             selected_choice: "0 dB".into(),
+                            integer_range: None,
                         },
                     ]
                 },

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -235,7 +235,11 @@ impl App {
                     .collect()
             })
             .unwrap_or_default();
-        let hide_footer = !self.show_footer && m.ui.input_mode == crate::state::InputMode::Normal;
+        let hide_footer = !self.show_footer
+            && matches!(
+                m.ui.input_mode,
+                crate::state::InputMode::Normal | crate::state::InputMode::DeviceOptionInput { .. }
+            );
         self.engine.set_panel_hidden("footer", hide_footer);
         // Copied out before the closure borrows `self` for the engine.
         let deck_shown = self.deck_shown;
@@ -608,6 +612,47 @@ mod tests {
             .is_some_and(|entry| entry.text.contains("Bandwidth set to Wide")));
         drop(m);
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn numeric_menu_entry_preserves_the_deck_footer_setting() {
+        use crate::state::{InputMode, MenuPane, MenuState};
+        let (mut app, _, _, _) = quit_test_app();
+        app.engine.set_preset("command_rail");
+        {
+            let mut m = app.state.lock().unwrap();
+            m.ui.device_option_update = DeviceOptionUpdate::Idle;
+            m.ui.menu = Some(MenuState {
+                pane: MenuPane::Options,
+                ..Default::default()
+            });
+        }
+        let mut terminal = Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+        for show_footer in [false, true] {
+            app.show_footer = show_footer;
+            for mode in [
+                InputMode::Normal,
+                InputMode::DeviceOptionInput {
+                    id: "level".into(),
+                    error: None,
+                },
+                InputMode::FrequencyInput,
+                InputMode::SampleRateInput,
+                InputMode::SweepStartInput,
+                InputMode::SweepStopInput,
+                InputMode::MarkerNameInput,
+            ] {
+                let expected = show_footer
+                    || !matches!(
+                        mode,
+                        InputMode::Normal | InputMode::DeviceOptionInput { .. }
+                    );
+                app.state.lock().unwrap().ui.input_mode = mode;
+                app.draw(&mut terminal).unwrap();
+                assert_eq!(app.engine.is_panel_visible("footer"), expected);
+                assert_eq!(app.show_footer, show_footer);
+            }
+        }
     }
 
     #[test]

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -55,6 +55,14 @@ pub(crate) fn debug_assert_device_options(options: &[DeviceOption]) {
                 ids.insert(option.id.as_str()),
                 "device option IDs must be unique within a snapshot"
             );
+            debug_assert!(
+                option.integer_range.is_none()
+                    || option.choices.iter().any(|choice| {
+                        option.integer_choice(choice).ok() == Some(choice.as_str())
+                    }),
+                "numeric device option '{}' must advertise a canonical integer within its bounds",
+                option.id
+            );
         }
     }
     #[cfg(not(debug_assertions))]
@@ -94,5 +102,36 @@ mod tests {
             option("bandwidth", &["Narrow"], "Narrow"),
             option("bandwidth", &["Wide"], "Wide"),
         ]);
+    }
+
+    #[test]
+    fn numeric_contract_accepts_sparse_choices_and_auto() {
+        let mut numeric = option("level", &["auto", "0", "10"], "auto");
+        numeric.integer_range = Some(0..=31);
+        debug_assert_device_options(&[numeric]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must advertise a canonical integer within its bounds")]
+    fn numeric_contract_rejects_choices_outside_bounds() {
+        let mut numeric = option("level", &["auto", "32"], "auto");
+        numeric.integer_range = Some(0..=31);
+        debug_assert_device_options(&[numeric]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must advertise a canonical integer within its bounds")]
+    fn numeric_contract_rejects_noncanonical_integers() {
+        let mut numeric = option("level", &["auto", "+1", "01", "-0", "1.0"], "auto");
+        numeric.integer_range = Some(0..=31);
+        debug_assert_device_options(&[numeric]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must advertise a canonical integer within its bounds")]
+    fn numeric_contract_rejects_reversed_bounds() {
+        let mut numeric = option("level", &["0"], "0");
+        numeric.integer_range = Some(std::ops::RangeInclusive::new(31, 0));
+        debug_assert_device_options(&[numeric]);
     }
 }

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -71,6 +71,7 @@ mod tests {
             label: "Bandwidth".into(),
             choices: choices.iter().map(|choice| (*choice).into()).collect(),
             selected_choice: selected.into(),
+            integer_range: None,
         }
     }
 

--- a/src/hardware/traits.rs
+++ b/src/hardware/traits.rs
@@ -76,6 +76,26 @@ pub struct DeviceOption {
     pub label: String,
     pub choices: Vec<String>,
     pub selected_choice: String,
+    /// Numeric entry submits an advertised decimal integer choice within this range
+    pub integer_range: Option<std::ops::RangeInclusive<i32>>,
+}
+
+impl DeviceOption {
+    pub fn integer_choice(&self, input: &str) -> Option<&str> {
+        let digits = input.strip_prefix('-').unwrap_or(input);
+        if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+        let value = input.parse::<i32>().ok()?;
+        if !self.integer_range.as_ref()?.contains(&value) {
+            return None;
+        }
+        let choice = value.to_string();
+        self.choices
+            .iter()
+            .find(|advertised| **advertised == choice)
+            .map(String::as_str)
+    }
 }
 
 /// How raw USB bytes encode each I/Q component.

--- a/src/hardware/traits.rs
+++ b/src/hardware/traits.rs
@@ -76,25 +76,151 @@ pub struct DeviceOption {
     pub label: String,
     pub choices: Vec<String>,
     pub selected_choice: String,
-    /// Numeric entry submits an advertised decimal integer choice within this range
+    /// Editor bounds may contain gaps in the advertised canonical integer choices
     pub integer_range: Option<std::ops::RangeInclusive<i32>>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IntegerChoiceError {
+    InvalidInteger,
+    OutOfRange { min: i32, max: i32 },
+    Unadvertised { closest: Option<i32> },
+    Unavailable,
+}
+
+impl std::fmt::Display for IntegerChoiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidInteger => write!(f, "Enter a signed 32-bit integer"),
+            Self::OutOfRange { min, max } => write!(f, "Out of range: {min} to {max}"),
+            Self::Unadvertised {
+                closest: Some(value),
+            } => {
+                write!(f, "Not advertised. Closest choice: {value}")
+            }
+            Self::Unadvertised { closest: None } => write!(f, "No advertised integer in range"),
+            Self::Unavailable => write!(f, "Numeric entry is no longer available"),
+        }
+    }
+}
+
 impl DeviceOption {
-    pub fn integer_choice(&self, input: &str) -> Option<&str> {
+    pub fn integer_choice(&self, input: &str) -> Result<&str, IntegerChoiceError> {
+        let range = self
+            .integer_range
+            .as_ref()
+            .ok_or(IntegerChoiceError::Unavailable)?;
         let digits = input.strip_prefix('-').unwrap_or(input);
         if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
-            return None;
+            return Err(IntegerChoiceError::InvalidInteger);
         }
-        let value = input.parse::<i32>().ok()?;
-        if !self.integer_range.as_ref()?.contains(&value) {
-            return None;
+        let value = input
+            .parse::<i32>()
+            .map_err(|_| IntegerChoiceError::InvalidInteger)?;
+        if !range.contains(&value) {
+            return Err(IntegerChoiceError::OutOfRange {
+                min: *range.start(),
+                max: *range.end(),
+            });
         }
         let choice = value.to_string();
         self.choices
             .iter()
             .find(|advertised| **advertised == choice)
             .map(String::as_str)
+            .ok_or_else(|| IntegerChoiceError::Unadvertised {
+                closest: self
+                    .choices
+                    .iter()
+                    .filter_map(|choice| {
+                        let number = choice.parse::<i32>().ok()?;
+                        (range.contains(&number) && number.to_string() == *choice).then_some(number)
+                    })
+                    .min_by_key(|number| (i64::from(*number) - i64::from(value)).abs()),
+            })
+    }
+}
+
+#[cfg(test)]
+mod integer_choice_tests {
+    use super::*;
+
+    fn option() -> DeviceOption {
+        DeviceOption {
+            id: "level".into(),
+            label: "Level".into(),
+            choices: ["auto", "-100", "0", "10", "100"]
+                .map(String::from)
+                .to_vec(),
+            selected_choice: "auto".into(),
+            integer_range: Some(-100..=100),
+        }
+    }
+
+    #[test]
+    fn integer_validation_distinguishes_failure_reasons() {
+        let mut option = option();
+        for input in ["", "-", "+1", "1.0", "2147483648", "-2147483649"] {
+            assert_eq!(
+                option.integer_choice(input),
+                Err(IntegerChoiceError::InvalidInteger)
+            );
+        }
+        assert_eq!(
+            option.integer_choice("101"),
+            Err(IntegerChoiceError::OutOfRange {
+                min: -100,
+                max: 100
+            })
+        );
+        assert_eq!(
+            option.integer_choice("12"),
+            Err(IntegerChoiceError::Unadvertised { closest: Some(10) })
+        );
+        assert_eq!(option.integer_choice("-00100"), Ok("-100"));
+        assert_eq!(option.integer_choice("-0"), Ok("0"));
+        option.integer_range = None;
+        assert_eq!(
+            option.integer_choice("12"),
+            Err(IntegerChoiceError::Unavailable)
+        );
+    }
+
+    #[test]
+    fn closest_choice_excludes_noncanonical_and_out_of_range_values() {
+        let mut option = option();
+        option.choices = ["auto", "012", "+12", "12.0", "11", "31"]
+            .map(String::from)
+            .to_vec();
+        option.integer_range = Some(12..=31);
+        assert_eq!(
+            option.integer_choice("12"),
+            Err(IntegerChoiceError::Unadvertised { closest: Some(31) })
+        );
+        option.choices.pop();
+        assert_eq!(
+            option.integer_choice("12"),
+            Err(IntegerChoiceError::Unadvertised { closest: None })
+        );
+    }
+
+    #[test]
+    fn closest_choice_distance_handles_i32_extremes() {
+        let mut option = option();
+        option.integer_range = Some(i32::MIN..=i32::MAX);
+        option.choices = vec![i32::MIN.to_string(), i32::MAX.to_string()];
+        assert_eq!(
+            option.integer_choice("1"),
+            Err(IntegerChoiceError::Unadvertised {
+                closest: Some(i32::MAX)
+            })
+        );
+        assert_eq!(
+            option.integer_choice("-1"),
+            Err(IntegerChoiceError::Unadvertised {
+                closest: Some(i32::MIN)
+            })
+        );
     }
 }
 

--- a/src/state/ui.rs
+++ b/src/state/ui.rs
@@ -170,6 +170,7 @@ impl DeviceOptionUpdate {
 #[derive(Clone, PartialEq)]
 pub enum InputMode {
     Normal,
+    DeviceOptionInput { id: String, error: Option<String> },
     FrequencyInput,
     SampleRateInput,
     MarkerNameInput,

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -34,7 +34,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::state::{MenuPane, MenuState, SdrMetrics};
+use crate::state::{InputMode, MenuPane, MenuState, SdrMetrics};
 use crate::ui::chrome;
 
 use model::Menu;
@@ -84,7 +84,7 @@ pub fn render(
         .split(inner);
 
     header(f, rows[0], m, theme);
-    footer(f, rows[2], state.pane, !m.device_options.is_empty(), theme);
+    footer(f, rows[2], state, m, theme);
 
     // The cursor is cloned into the frame snapshot and arrives here without the
     // engine, so it is clamped rather than trusted. An out of range index would
@@ -183,27 +183,42 @@ fn header(f: &mut Frame, area: Rect, m: &SdrMetrics, theme: &crate::Theme) {
 }
 
 /// The keys, in the order the design's "Moving around" table lists them.
-fn footer(f: &mut Frame, area: Rect, pane: MenuPane, has_options: bool, theme: &crate::Theme) {
+fn footer(f: &mut Frame, area: Rect, state: &MenuState, m: &SdrMetrics, theme: &crate::Theme) {
     let key = Style::default().fg(theme.border_accent);
     let what = Style::default().fg(theme.label);
     let mut spans = Vec::new();
-    let bindings: &[(&str, &str)] = if pane == MenuPane::Options && has_options {
-        &[
-            ("Tab", "section"),
-            ("\u{2191}\u{2193}", "option"),
-            ("\u{2190}\u{2192}", "value"),
-            ("Enter", "next"),
-            ("Esc", "close"),
-        ]
-    } else {
-        &[
-            ("Tab", "section"),
-            ("\u{2191}\u{2193}", "move"),
-            ("1-9", "open"),
-            ("Enter", "open"),
-            ("Esc", "close"),
-        ]
-    };
+    let numeric = m
+        .device_options
+        .get(state.scroll)
+        .is_some_and(|option| option.integer_range.is_some());
+    let bindings: &[(&str, &str)] =
+        if matches!(m.ui.input_mode, InputMode::DeviceOptionInput { .. }) {
+            &[("Enter", "apply"), ("Esc", "cancel")]
+        } else if state.pane == MenuPane::Options && numeric {
+            &[
+                ("Enter", "number"),
+                ("\u{2190}\u{2192}", "all choices"),
+                ("Esc", "close"),
+                ("Tab", "section"),
+                ("\u{2191}\u{2193}", "option"),
+            ]
+        } else if state.pane == MenuPane::Options && !m.device_options.is_empty() {
+            &[
+                ("Tab", "section"),
+                ("\u{2191}\u{2193}", "option"),
+                ("\u{2190}\u{2192}", "value"),
+                ("Enter", "next"),
+                ("Esc", "close"),
+            ]
+        } else {
+            &[
+                ("Tab", "section"),
+                ("\u{2191}\u{2193}", "move"),
+                ("1-9", "open"),
+                ("Enter", "open"),
+                ("Esc", "close"),
+            ]
+        };
     for (k, w) in bindings {
         spans.push(Span::styled(format!(" {k} "), key));
         spans.push(Span::styled(*w, what));
@@ -419,11 +434,51 @@ mod tests {
                 label: format!("Option {index}"),
                 choices: vec!["Off".into(), "On".into()],
                 selected_choice: "On".into(),
+                integer_range: None,
             });
         }
 
         let all = draw_with_metrics(40, 10, &state, &metrics).join("\n");
         assert!(all.contains("Option 5"), "{all}");
+    }
+
+    #[test]
+    fn numeric_options_show_entry_hints_and_keep_the_accepted_value_in_the_editor() {
+        let state = MenuState {
+            pane: MenuPane::Options,
+            ..MenuState::default()
+        };
+        let mut m = SdrMetrics::fixture();
+        m.device_options = Arc::new(vec![crate::hardware::DeviceOption {
+            id: "gain".into(),
+            label: "Gain".into(),
+            choices: vec!["0".into(), "-12".into()],
+            selected_choice: "0".into(),
+            integer_range: Some(-100..=100),
+        }]);
+        for (w, h) in [(40, 10), (90, 24)] {
+            let all = draw_with_metrics(w, h, &state, &m).join("\n");
+            assert!(all.contains("Enter number"), "{all}");
+            assert!(all.contains("all choices"), "{all}");
+        }
+        m.ui.input_mode = InputMode::DeviceOptionInput {
+            id: "gain".into(),
+            error: None,
+        };
+        m.ui.input_buf = "-12".into();
+        for (w, h) in [(40, 10), (90, 24)] {
+            let all = draw_with_metrics(w, h, &state, &m).join("\n");
+            for text in [
+                "Gain: 0",
+                "Value: -12_",
+                "Integer -100 to 100",
+                "Enter apply",
+                "Esc cancel",
+            ] {
+                assert!(all.contains(text), "'{text}' missing:\n{all}");
+            }
+            assert!(!all.contains("Enter number"), "{all}");
+        }
     }
 
     /// Small enough that nothing sensible fits. The requirement is only that it

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -182,7 +182,7 @@ fn header(f: &mut Frame, area: Rect, m: &SdrMetrics, theme: &crate::Theme) {
     f.render_widget(Paragraph::new(line), area);
 }
 
-/// The keys, in the order the design's "Moving around" table lists them.
+/// Show the keys for the active menu pane or editor
 fn footer(f: &mut Frame, area: Rect, state: &MenuState, m: &SdrMetrics, theme: &crate::Theme) {
     let key = Style::default().fg(theme.border_accent);
     let what = Style::default().fg(theme.label);
@@ -470,7 +470,7 @@ mod tests {
             let all = draw_with_metrics(w, h, &state, &m).join("\n");
             for text in [
                 "Gain: 0",
-                "Value: -12_",
+                "Value: -12\u{258c}",
                 "Integer -100 to 100",
                 "Enter apply",
                 "Esc cancel",
@@ -478,6 +478,19 @@ mod tests {
                 assert!(all.contains(text), "'{text}' missing:\n{all}");
             }
             assert!(!all.contains("Enter number"), "{all}");
+        }
+        m.ui.input_mode = InputMode::DeviceOptionInput {
+            id: "gain".into(),
+            error: Some("Out of range: -100 to 100".into()),
+        };
+        for (w, h) in [(40, 6), (40, 7), (40, 8), (90, 5), (90, 6), (90, 7)] {
+            let all = draw_with_metrics(w, h, &state, &m).join("\n");
+            for text in ["Value: -12\u{258c}", "Enter apply", "Esc cancel"] {
+                assert!(all.contains(text), "'{text}' missing:\n{all}");
+            }
+            if (w == 40 && h >= 7) || (w == 90 && h >= 6) {
+                assert!(all.contains("Out of range:"), "{all}");
+            }
         }
     }
 

--- a/src/ui/menu/options.rs
+++ b/src/ui/menu/options.rs
@@ -65,7 +65,7 @@ fn lines(
     theme: &crate::Theme,
 ) -> Vec<Line<'static>> {
     if let InputMode::DeviceOptionInput { id, error } = &m.ui.input_mode {
-        return editor_lines(m, id, error.as_deref(), iw, theme);
+        return editor_lines(m, id, error.as_deref(), iw, height, theme);
     }
     if m.device_options.is_empty() {
         return empty_lines(iw, theme);
@@ -98,41 +98,51 @@ fn editor_lines(
     id: &str,
     error: Option<&str>,
     iw: usize,
+    height: usize,
     theme: &crate::Theme,
 ) -> Vec<Line<'static>> {
+    if iw == 0 || height == 0 {
+        return Vec::new();
+    }
+    let option = m.device_options.iter().find(|option| option.id == id);
     let mut out = Vec::new();
-    if let Some(option) = m.device_options.iter().find(|option| option.id == id) {
-        out.push(Line::from(Span::styled(
-            fit_text(&format!("{}: {}", option.label, option.selected_choice), iw),
-            Style::default().fg(theme.label),
-        )));
-        out.push(Line::from(Span::styled(
-            fit_text(&format!("Value: {}_", m.ui.input_buf), iw),
-            Style::default().fg(theme.value_hi),
-        )));
+    let input = format!("Value: {}\u{258c}", m.ui.input_buf);
+    let tail: String = input.chars().rev().take(iw).collect();
+    out.push(Line::from(Span::styled(
+        tail.chars().rev().collect::<String>(),
+        Style::default().fg(theme.value_hi),
+    )));
+    let error = error.or_else(|| {
+        option
+            .is_none()
+            .then_some("Option is no longer available. Esc cancels.")
+    });
+    if let Some(error) = error {
+        for row in chrome::wrap(error, iw, height.saturating_sub(out.len())) {
+            out.push(Line::from(Span::styled(
+                row,
+                Style::default().fg(theme.status_warn),
+            )));
+        }
+    }
+    if let Some(option) = option {
+        if out.len() < height {
+            out.push(Line::from(Span::styled(
+                fit_text(&format!("{}: {}", option.label, option.selected_choice), iw),
+                Style::default().fg(theme.label),
+            )));
+        }
         if let Some(range) = &option.integer_range {
             for row in chrome::wrap(
                 &format!("Integer {} to {}", range.start(), range.end()),
                 iw,
-                3,
+                height.saturating_sub(out.len()),
             ) {
                 out.push(Line::from(Span::styled(
                     row,
                     Style::default().fg(theme.label),
                 )));
             }
-        }
-    }
-    let error = error.or_else(|| {
-        (!m.device_options.iter().any(|option| option.id == id))
-            .then_some("Option is no longer available. Esc cancels.")
-    });
-    if let Some(error) = error {
-        for row in chrome::wrap(error, iw, 4) {
-            out.push(Line::from(Span::styled(
-                row,
-                Style::default().fg(theme.status_warn),
-            )));
         }
     }
     out
@@ -442,7 +452,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         assert!(text.contains("Gain: 0"), "{text}");
-        assert!(text.contains("Value: 101_"), "{text}");
+        assert!(text.contains("Value: 101\u{258c}"), "{text}");
         assert!(text.contains("Enter an advertised integer"), "{text}");
 
         m.device_options = Arc::new(Vec::new());
@@ -458,5 +468,73 @@ mod tests {
             text.contains("Option is no longer available. Esc cancels."),
             "{text}"
         );
+    }
+
+    #[test]
+    fn short_numeric_panes_prioritize_input_tail_then_error() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options = Arc::new(vec![crate::hardware::DeviceOption {
+            id: "gain".into(),
+            label: "Gain".into(),
+            choices: vec!["0".into()],
+            selected_choice: "0".into(),
+            integer_range: Some(-100..=100),
+        }]);
+        m.ui.input_buf = "12345678901234567890".into();
+        for error in [None, Some("Out of range: -100 to 100".to_string())] {
+            m.ui.input_mode = InputMode::DeviceOptionInput {
+                id: "gain".into(),
+                error: error.clone(),
+            };
+            for width in [1_u16, 4, 12, 40] {
+                for height in [1_u16, 2, 3] {
+                    let mut terminal =
+                        ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height))
+                            .unwrap();
+                    terminal
+                        .draw(|f| render(f, f.size(), &m, 0, &crate::Theme::sdr()))
+                        .unwrap();
+                    let buffer = terminal.backend().buffer();
+                    let rows: Vec<String> = (0..height)
+                        .map(|y| {
+                            (0..width)
+                                .map(|x| buffer.get(x, y).symbol())
+                                .collect::<String>()
+                                .trim_end()
+                                .to_string()
+                        })
+                        .collect();
+                    assert!(rows[0].ends_with('\u{258c}'), "{rows:?}");
+                    if width >= 4 {
+                        assert!(rows[0].ends_with("890\u{258c}"), "{rows:?}");
+                    }
+                    if height >= 2 {
+                        let expected = if error.is_some() {
+                            "Out of range:"
+                        } else {
+                            "Gain: 0"
+                        };
+                        assert_eq!(
+                            rows[1],
+                            fit_text(
+                                if width == 40 && error.is_some() {
+                                    "Out of range: -100 to 100"
+                                } else {
+                                    expected
+                                },
+                                width as usize
+                            )
+                            .trim_end(),
+                            "{rows:?}"
+                        );
+                    }
+                    assert_eq!(m.ui.input_buf, "12345678901234567890");
+                    assert!(
+                        lines(&m, 0, width as usize, height as usize, &crate::Theme::sdr()).len()
+                            <= height as usize
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/ui/menu/options.rs
+++ b/src/ui/menu/options.rs
@@ -12,7 +12,7 @@ use ratatui::{
 };
 
 use crate::{
-    state::{DeviceOptionUpdate, SdrMetrics},
+    state::{DeviceOptionUpdate, InputMode, SdrMetrics},
     ui::chrome,
 };
 
@@ -64,6 +64,9 @@ fn lines(
     height: usize,
     theme: &crate::Theme,
 ) -> Vec<Line<'static>> {
+    if let InputMode::DeviceOptionInput { id, error } = &m.ui.input_mode {
+        return editor_lines(m, id, error.as_deref(), iw, theme);
+    }
     if m.device_options.is_empty() {
         return empty_lines(iw, theme);
     }
@@ -86,6 +89,51 @@ fn lines(
             iw,
             theme,
         ));
+    }
+    out
+}
+
+fn editor_lines(
+    m: &SdrMetrics,
+    id: &str,
+    error: Option<&str>,
+    iw: usize,
+    theme: &crate::Theme,
+) -> Vec<Line<'static>> {
+    let mut out = Vec::new();
+    if let Some(option) = m.device_options.iter().find(|option| option.id == id) {
+        out.push(Line::from(Span::styled(
+            fit_text(&format!("{}: {}", option.label, option.selected_choice), iw),
+            Style::default().fg(theme.label),
+        )));
+        out.push(Line::from(Span::styled(
+            fit_text(&format!("Value: {}_", m.ui.input_buf), iw),
+            Style::default().fg(theme.value_hi),
+        )));
+        if let Some(range) = &option.integer_range {
+            for row in chrome::wrap(
+                &format!("Integer {} to {}", range.start(), range.end()),
+                iw,
+                3,
+            ) {
+                out.push(Line::from(Span::styled(
+                    row,
+                    Style::default().fg(theme.label),
+                )));
+            }
+        }
+    }
+    let error = error.or_else(|| {
+        (!m.device_options.iter().any(|option| option.id == id))
+            .then_some("Option is no longer available. Esc cancels.")
+    });
+    if let Some(error) = error {
+        for row in chrome::wrap(error, iw, 4) {
+            out.push(Line::from(Span::styled(
+                row,
+                Style::default().fg(theme.status_warn),
+            )));
+        }
     }
     out
 }
@@ -243,6 +291,7 @@ mod tests {
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
             selected_choice: "Wide".into(),
+            integer_range: None,
         });
         let text = lines(&m, 0, 60, 20, &crate::Theme::sdr())
             .iter()
@@ -262,6 +311,7 @@ mod tests {
                 label: format!("Option {index}"),
                 choices: vec!["Off".into(), "On".into()],
                 selected_choice: "Off".into(),
+                integer_range: None,
             });
         }
 
@@ -282,6 +332,7 @@ mod tests {
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
             selected_choice: "Wide".into(),
+            integer_range: None,
         });
 
         let text = lines(&m, 0, 60, 1, &crate::Theme::sdr())
@@ -301,6 +352,7 @@ mod tests {
             label: "A device-provided label that is much too long".into(),
             choices: vec!["A device-provided choice that is much too long".into()],
             selected_choice: "A device-provided choice that is much too long".into(),
+            integer_range: None,
         });
 
         for width in [1, 4, 7, 8, 12, 20, 28] {
@@ -322,6 +374,7 @@ mod tests {
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
             selected_choice: "Narrow".into(),
+            integer_range: None,
         });
         m.ui.device_option_update = DeviceOptionUpdate::Pending {
             request: crate::event::DeviceOptionRequest {
@@ -348,6 +401,7 @@ mod tests {
             label: "Bandwidth".into(),
             choices: vec!["Narrow".into(), "Wide".into()],
             selected_choice: "Narrow".into(),
+            integer_range: None,
         });
         m.ui.device_option_update = DeviceOptionUpdate::Failed {
             id: "bandwidth".into(),
@@ -360,5 +414,49 @@ mod tests {
             .join("\n");
         assert!(text.contains("Narrow (failed)"), "{text}");
         assert!(!text.contains("Wide"), "{text}");
+    }
+
+    #[test]
+    fn numeric_editor_shows_validation_errors_and_fits_narrow_panes() {
+        let mut m = SdrMetrics::fixture();
+        m.device_options = Arc::new(vec![crate::hardware::DeviceOption {
+            id: "gain".into(),
+            label: "Gain".into(),
+            choices: vec!["0".into(), "12".into()],
+            selected_choice: "0".into(),
+            integer_range: Some(-100..=100),
+        }]);
+        m.ui.input_mode = InputMode::DeviceOptionInput {
+            id: "gain".into(),
+            error: Some("Enter an advertised integer from -100 to 100".into()),
+        };
+        m.ui.input_buf = "101".into();
+        for width in [0, 1, 4, 7, 12, 28, 60] {
+            for line in lines(&m, 0, width, 20, &crate::Theme::sdr()) {
+                assert!(line.width() <= width, "{line:?}");
+            }
+        }
+        let text = lines(&m, 0, 60, 20, &crate::Theme::sdr())
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Gain: 0"), "{text}");
+        assert!(text.contains("Value: 101_"), "{text}");
+        assert!(text.contains("Enter an advertised integer"), "{text}");
+
+        m.device_options = Arc::new(Vec::new());
+        m.ui.input_mode = InputMode::DeviceOptionInput {
+            id: "gain".into(),
+            error: None,
+        };
+        let text = lines(&m, 0, 60, 20, &crate::Theme::sdr())
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<String>();
+        assert!(
+            text.contains("Option is no longer available. Esc cancels."),
+            "{text}"
+        );
     }
 }

--- a/src/ui/panels/core/footer.rs
+++ b/src/ui/panels/core/footer.rs
@@ -408,6 +408,10 @@ impl Panel for FooterPanel {
             )
         } else {
             match m.ui.input_mode {
+                InputMode::DeviceOptionInput { .. } => prompt(format!(
+                    " Value: [{}]  [Enter] Apply  [Esc] Cancel",
+                    m.ui.input_buf
+                )),
                 InputMode::FrequencyInput => prompt(format!(
                     " Frequency (MHz): [{}▌]  [Enter] Confirm  [Esc] Cancel",
                     m.ui.input_buf

--- a/src/ui/panels/core/footer.rs
+++ b/src/ui/panels/core/footer.rs
@@ -328,7 +328,11 @@ fn count_lines<S: AsRef<str>>(items: &[S], sep: &str, inner_w: usize) -> usize {
 
 /// Public free function - called directly from the engine (bypasses dyn dispatch).
 pub fn compute_footer_height(available_width: u16, state: &SdrMetrics) -> u16 {
-    if !matches!(state.ui.input_mode, InputMode::Normal) || state.observer.active {
+    if !matches!(
+        state.ui.input_mode,
+        InputMode::Normal | InputMode::DeviceOptionInput { .. }
+    ) || state.observer.active
+    {
         return 3;
     }
     let inner_w = available_width.saturating_sub(2) as usize;
@@ -408,10 +412,6 @@ impl Panel for FooterPanel {
             )
         } else {
             match m.ui.input_mode {
-                InputMode::DeviceOptionInput { .. } => prompt(format!(
-                    " Value: [{}]  [Enter] Apply  [Esc] Cancel",
-                    m.ui.input_buf
-                )),
                 InputMode::FrequencyInput => prompt(format!(
                     " Frequency (MHz): [{}▌]  [Enter] Confirm  [Esc] Cancel",
                     m.ui.input_buf
@@ -446,7 +446,7 @@ impl Panel for FooterPanel {
                         freq_str, m.ui.input_buf
                     ))
                 }
-                InputMode::Normal => {
+                InputMode::Normal | InputMode::DeviceOptionInput { .. } => {
                     if let Some(panel_name) = &m.ui.focused_panel {
                         let items = focus_items(m);
                         let groups = wrap_items_grouped(&items, FOCUS_SEP, inner_w);
@@ -503,8 +503,10 @@ fn tone_for(observer: bool, mode: &InputMode, panel_focused: bool) -> FrameTone 
     match mode {
         // Normal: lit while a panel is focused, because the keys along the
         // footer are that panel's, not the global set.
-        InputMode::Normal if panel_focused => FrameTone::Focused,
-        InputMode::Normal => FrameTone::Dim,
+        InputMode::Normal | InputMode::DeviceOptionInput { .. } if panel_focused => {
+            FrameTone::Focused
+        }
+        InputMode::Normal | InputMode::DeviceOptionInput { .. } => FrameTone::Dim,
         // Anything else is a half-typed value waiting on Enter.
         _ => FrameTone::Warn,
     }
@@ -561,6 +563,29 @@ mod tests {
             FrameTone::Focused
         );
         assert_eq!(tone_for(false, &InputMode::Normal, false), FrameTone::Dim);
+    }
+
+    #[test]
+    fn numeric_entry_keeps_the_normal_deck_footer() {
+        let mut m = SdrMetrics::fixture();
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 5)).unwrap();
+        let normal_height = compute_footer_height(80, &m);
+        let mut draw = |m: &SdrMetrics| {
+            terminal
+                .draw(|f| FooterPanel.render(f, f.size(), m, &crate::Theme::sdr(), false))
+                .unwrap();
+            terminal.backend().buffer().clone()
+        };
+        let normal = draw(&m);
+        m.ui.input_mode = InputMode::DeviceOptionInput {
+            id: "level".into(),
+            error: None,
+        };
+        m.ui.input_buf = "123456".into();
+        assert_eq!(draw(&m), normal);
+        assert_eq!(compute_footer_height(80, &m), normal_height);
+        assert_eq!(tone_for(false, &m.ui.input_mode, false), FrameTone::Dim);
     }
 
     #[test]

--- a/user_docs/keys.md
+++ b/user_docs/keys.md
@@ -41,6 +41,8 @@ In **Options**, `Up` / `Down` selects a device setting.
 `Left` / `Right` cycles all advertised choices, including `auto` when available.
 `Enter` cycles discrete settings or opens number entry when the footer shows `Enter number`.
 Type an integer within the displayed range.
+Some devices advertise only specific integers within that range.
+An unavailable value shows the closest advertised integer without applying it.
 `Backspace` removes a character.
 `Enter` applies an advertised value.
 `Esc` cancels entry without changing the device.

--- a/user_docs/keys.md
+++ b/user_docs/keys.md
@@ -37,6 +37,15 @@ The menu opens with the cursor already on the layout you are using, so `Enter`
 puts you straight back. That is also how the first screen of a session works:
 sdrtop remembers the layout you quit from, and the menu opens on it.
 
+In **Options**, `Up` / `Down` selects a device setting.
+`Left` / `Right` cycles all advertised choices, including `auto` when available.
+`Enter` cycles discrete settings or opens number entry when the footer shows `Enter number`.
+Type an integer within the displayed range.
+`Backspace` removes a character.
+`Enter` applies an advertised value.
+`Esc` cancels entry without changing the device.
+The accepted value stays visible until the device finishes applying the change.
+
 **Numbers belong to a section.** `2` is the RF bench inside Lab and the spectrum
 inside Command Rail, and each section starts again at `1`. This is what keeps the
 keyboard small: four families of layout, nine keys, instead of one long row of


### PR DESCRIPTION
This PR prepares the device-options UI for numeric tinySA controls in #11.

Options currently require stepping through choices one at a time. Setting external gain can take hundreds of keypresses.

This PR adds direct integer entry for options that support it. It retains discrete choices such as auto and uses the existing asynchronous update flow.