### PR TITLE
Load native SDR libraries at runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-      - name: Install system dependencies
+      - name: Install native runtimes
         # Keep coverage with both native runtime libraries installed
-        run: sudo apt-get update && sudo apt-get install -y libhackrf-dev librtlsdr-dev pkg-config libusb-1.0-0-dev
+        run: sudo apt-get update && sudo apt-get install -y libhackrf0 librtlsdr2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -73,6 +75,9 @@ jobs:
       # morning.
       - name: Test
         run: cargo test --all --locked
+
+      - name: Resolve installed native libraries
+        run: cargo test --locked hardware::native::tests::installed_native_libraries_resolve -- --ignored --exact
 
       # sdrtop is published to crates.io, and a publish cannot be undone: a
       # version that fails to package can only be fixed by burning the version
@@ -94,6 +99,7 @@ jobs:
       contents: read
     container:
       image: debian:12@sha256:6ebd97fa83deb272194a2cf015b3d26a4d538e9ad3a7a79d544c8af5b0a01443
+      # Hide host radios so discovery cannot enter the TUI
       options: --tmpfs /sys:ro
     steps:
       - name: Install build tools
@@ -118,9 +124,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libhackrf-dev librtlsdr-dev pkg-config libusb-1.0-0-dev
 
       - name: Install Rust 1.88
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        # librtlsdr-dev matters as much as libhackrf-dev: build.rs falls back to a
-        # bare `-lrtlsdr` link directive when it finds no .pc file, so a missing
-        # librtlsdr passes the build script and fails at link time instead.
+        # Keep coverage with both native runtime libraries installed
         run: sudo apt-get update && sudo apt-get install -y libhackrf-dev librtlsdr-dev pkg-config libusb-1.0-0-dev
 
       - name: Install Rust
@@ -89,6 +87,25 @@ jobs:
       # toolchain, C libraries and warm registry cache.
       - name: The crate still packages
         run: cargo package --locked
+
+  no-native-libraries:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: debian:12@sha256:6ebd97fa83deb272194a2cf015b3d26a4d538e9ad3a7a79d544c8af5b0a01443
+      options: --tmpfs /sys:ro
+    steps:
+      - name: Install build tools
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends build-essential ca-certificates curl git
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and start without native libraries
+        run: sh packaging/check-no-native.sh
 
   # rust-version = "1.88" in Cargo.toml is a promise to everyone installing from
   # crates.io, where the user's own toolchain does the compiling. Without this

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,13 +101,9 @@ jobs:
             | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p' | sort | tr '\n' ' ')
           actual=${actual% }
           echo "needs: $actual"
-          case "$actual" in
-            *libhackrf.so*|*librtlsdr.so*)
-              echo "::error::native SDR libraries must remain optional runtime loads"
-              exit 1 ;;
-          esac
           test "$actual" = "$expected" || {
             echo "::error::the set of shared libraries changed"
+            echo "::error::libhackrf and librtlsdr must remain optional runtime loads; remove native link directives"
             echo "::error::expected: $expected"
             echo "::error::actual:   $actual"
             exit 1; }
@@ -231,6 +227,7 @@ jobs:
             echo "sdrtop $version is already on crates.io; nothing to do"
             exit 0
           fi
+          # Verify the packaged source builds before publishing an immutable version
           cargo publish --locked
 
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,14 +75,7 @@ jobs:
       - name: Build the tarball
         run: packaging/build-tarball.sh
 
-      # build-tarball.sh has already proved the binary *runs* and reports the
-      # version the archive is named after, inside the Debian 12 container,
-      # which is the only place it can be run: this runner is Ubuntu and has
-      # librtlsdr.so.2 where the binary wants .so.0, the exact mismatch
-      # install.sh exists to handle. So none of the checks below execute it.
-      #
-      # What is left is what the binary *is* and what it asks of a machine,
-      # which the ELF headers answer without running anything.
+      # build-tarball.sh checks startup at the glibc floor without SDR libraries
       - name: Check what came out
         run: |
           out="$RUNNER_TEMP/unpacked"
@@ -103,11 +96,16 @@ jobs:
           #
           # Changing this list is a deliberate act, and the edit belongs in the
           # same commit as the dependency that caused it.
-          expected="libc.so.6 libgcc_s.so.1 libhackrf.so.0 libm.so.6 librtlsdr.so.0"
+          expected="libc.so.6 libgcc_s.so.1 libm.so.6"
           actual=$(readelf -d "$bin" \
             | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p' | sort | tr '\n' ' ')
           actual=${actual% }
           echo "needs: $actual"
+          case "$actual" in
+            *libhackrf.so*|*librtlsdr.so*)
+              echo "::error::native SDR libraries must remain optional runtime loads"
+              exit 1 ;;
+          esac
           test "$actual" = "$expected" || {
             echo "::error::the set of shared libraries changed"
             echo "::error::expected: $expected"
@@ -204,13 +202,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-
-      # `cargo publish` runs a verification build, so the C libraries have to be
-      # present. Publishing with --no-verify to dodge that would mean uploading
-      # a version nobody proved compiles, which is the one thing here that
-      # cannot be taken back.
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libhackrf-dev librtlsdr-dev pkg-config libusb-1.0-0-dev
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,12 +493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +598,6 @@ dependencies = [
  "libc",
  "libloading",
  "num-complex",
- "pkg-config",
  "ratatui",
  "rustfft",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ clap = { version = "4", features = ["derive"] }
 crossbeam-channel = "0.5"
 rustfft = "6"
 num-complex = "0.4"
+# HackRF, RTL-SDR and SoapySDR runtimes are optional
 libloading = "0.8"
 serialport = { version = "4", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,10 @@ clap = { version = "4", features = ["derive"] }
 crossbeam-channel = "0.5"
 rustfft = "6"
 num-complex = "0.4"
-# SoapySDR is opened at runtime rather than linked, so a machine without it runs
-# exactly the binary it runs today and simply sees no Soapy devices. See
-# dev_docs/soapy-design.md, decision 1.
 libloading = "0.8"
 serialport = { version = "4", default-features = false }
 
 [build-dependencies]
-pkg-config = "0.3"
 # The man page is generated from the same `Parser` derive `main.rs` parses with,
 # so it cannot describe a flag the binary does not have. See `src/cli.rs`.
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ sh install.sh --help                # this list, from the script itself
 
 Piped straight into a shell they go after `sh -s --`. `--no-verify` turns off the checksum check on a download, which is the one thing standing between you and a tarball that isn't the one I published, so have a reason. The rest are explained in [Getting started](user_docs/getting-started.md#every-flag-it-takes).
 
-`--deps-only` without a runtime flag does nothing. It never installs build tools.
+`--deps-only` requires a runtime flag. It never installs build tools.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Measured the awkward way rather than the easy way. Bandwidth about the carrier, 
 
 ## 📦 Install
 
-**Requirements:** Linux · a HackRF One, an RTL-SDR, a tinySA, or anything SoapySDR speaks to
+**Requirements:** Linux · a HackRF One, an RTL-SDR, or anything SoapySDR speaks to
 
 ### The one-liner
 
@@ -141,7 +141,7 @@ curl -fsSL https://raw.githubusercontent.com/musithang/sdrtop/main/packaging/ins
 
 The installer tries the prebuilt binary on your machine. It compiles from source if the binary cannot run there. Native SDR libraries are optional runtime dependencies.
 
-Add `--hackrf` or `--rtlsdr` to install the runtime for your radio. `--soapy` adds SoapySDR and its driver modules. A plain install adds none of these libraries. tinySA needs none of them.
+Add `--hackrf` or `--rtlsdr` to install the runtime for your radio. `--soapy` adds SoapySDR and its driver modules. A plain install adds none of these libraries.
 
 <details>
 <summary>Every flag it takes, and installing without root</summary>
@@ -182,7 +182,9 @@ sudo dnf install gcc               # Fedora
 cargo install sdrtop --locked
 ```
 
-Building needs Rust 1.88+ and a C compiler/linker. Install Rust with [rustup](https://rustup.rs). No SDR libraries, development headers or pkg-config are required. At runtime, HackRF needs libhackrf 2023.01.1+ and RTL-SDR needs librtlsdr. A missing or incompatible library disables only its backend. tinySA can build and run with neither library.
+Building needs Rust 1.88+ and a C compiler/linker. Install Rust with [rustup](https://rustup.rs). No SDR libraries, development headers or pkg-config are required. At runtime, HackRF needs libhackrf 2023.01.1+ and RTL-SDR needs librtlsdr. A missing or incompatible library disables only its backend.
+
+Runtime loading is independent preparation for the tinySA support proposed in [musithang/sdrtop#7](https://github.com/musithang/sdrtop/pull/7) and [musithang/sdrtop#8](https://github.com/musithang/sdrtop/pull/8). The tinySA backend is provided by that companion work.
 
 Then go make coffee: a few minutes on a laptop, considerably more on a Raspberry Pi. It's not frozen, it's just Rust.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Measured the awkward way rather than the easy way. Bandwidth about the carrier, 
 
 ## 📦 Install
 
-**Requirements:** Linux · a HackRF One, an RTL-SDR, or anything SoapySDR speaks to
+**Requirements:** Linux · a HackRF One, an RTL-SDR, a tinySA, or anything SoapySDR speaks to
 
 ### The one-liner
 
@@ -139,9 +139,9 @@ Measured the awkward way rather than the easy way. Bandwidth about the carrier, 
 curl -fsSL https://raw.githubusercontent.com/musithang/sdrtop/main/packaging/install.sh | sh
 ```
 
-It works out your distribution, installs the libraries under whatever names that distribution gives them (apt, dnf, pacman, zypper, apk, xbps, emerge and nix are all handled), grabs the prebuilt binary if it can actually run on your box, and quietly falls back to compiling if it can't. The nice bit: it decides by **running the thing**, not by reading your distro's name off a list and hoping.
+The installer tries the prebuilt binary on your machine. It compiles from source if the binary cannot run there. Native SDR libraries are optional runtime dependencies.
 
-Add `--soapy` if you want the SoapySDR library and driver modules too; without it the installer leaves them alone and just tells you at the end what you're missing out on.
+Add `--hackrf` or `--rtlsdr` to install the runtime for your radio. `--soapy` adds SoapySDR and its driver modules. A plain install adds none of these libraries. tinySA needs none of them.
 
 <details>
 <summary>Every flag it takes, and installing without root</summary>
@@ -154,13 +154,17 @@ sh install.sh --version v0.4.1      # a specific release instead of the latest
 sh install.sh --from-source         # skip the prebuilt binary, always compile
 sh install.sh --git                 # compile the main branch, live dangerously
 sh install.sh --no-verify           # skip the checksum check (say why first)
+sh install.sh --hackrf              # Install the HackRF runtime
+sh install.sh --rtlsdr              # Install the RTL-SDR runtime
 sh install.sh --soapy               # add SoapySDR and its driver modules
-sh install.sh --deps-only           # the libraries and nothing else
+sh install.sh --deps-only --hackrf   # Install only the selected runtime
 sh install.sh --uninstall           # remove what a previous run installed
 sh install.sh --help                # this list, from the script itself
 ```
 
 Piped straight into a shell they go after `sh -s --`. `--no-verify` turns off the checksum check on a download, which is the one thing standing between you and a tarball that isn't the one I published, so have a reason. The rest are explained in [Getting started](user_docs/getting-started.md#every-flag-it-takes).
+
+`--deps-only` without a runtime flag does nothing. It never installs build tools.
 
 </details>
 
@@ -168,17 +172,17 @@ Piping a script into `sh` means running code you haven't read. You should read i
 
 ### Or cargo, the boring one that always works
 
-sdrtop is on [crates.io](https://crates.io/crates/sdrtop). Cargo compiles it *on your machine*, so it links what your machine actually has and doesn't care about your architecture or distribution.
+sdrtop is on [crates.io](https://crates.io/crates/sdrtop). Cargo compiles it for your machine.
 
 ```sh
-sudo apt install libhackrf-dev librtlsdr-dev pkg-config          # Debian / Ubuntu / Mint
-sudo pacman -S hackrf rtl-sdr pkgconf                            # Arch / Manjaro
-sudo dnf install hackrf-devel rtl-sdr-devel pkgconf-pkg-config   # Fedora
+sudo apt install build-essential    # Debian / Ubuntu / Mint
+sudo pacman -S base-devel           # Arch / Manjaro
+sudo dnf install gcc               # Fedora
 
 cargo install sdrtop --locked
 ```
 
-You need both libraries at build time even if you only own one radio. Sorry. Wants **Rust 1.88+**, and your distro's Rust is quite possibly ancient (Debian 12 ships 1.63, bless it), which [rustup](https://rustup.rs) fixes in one line.
+Building needs Rust 1.88+ and a C compiler/linker. Install Rust with [rustup](https://rustup.rs). No SDR libraries, development headers or pkg-config are required. At runtime, HackRF needs libhackrf 2023.01.1+ and RTL-SDR needs librtlsdr. A missing or incompatible library disables only its backend. tinySA can build and run with neither library.
 
 Then go make coffee: a few minutes on a laptop, considerably more on a Raspberry Pi. It's not frozen, it's just Rust.
 
@@ -193,7 +197,7 @@ SoapySDRUtil --find     # if this can't see your radio, sdrtop can't either
 
 That last command is the whole diagnostic. If your radio isn't in that list, the missing piece is a driver module, and no amount of shouting at sdrtop will conjure one up.
 
-<sub>Prefer a prebuilt binary, or on something unusual? <b><a href="user_docs/getting-started.md#the-prebuilt-tarball-by-hand">Getting started</a></b> has the release tarball, the checksum and the provenance attestation to check it against, plus the distro-by-distro package names. Short version on the tarball: it's x86_64 and it wants Debian's <code>librtlsdr.so.0</code>, so it won't start on Ubuntu or Mint, who package the identical library as <code>.so.2</code> because of course they do.</sub>
+<sub><a href="user_docs/getting-started.md#the-prebuilt-tarball-by-hand">Getting started</a> covers the release tarball, checksums and provenance attestation. The tarball needs x86_64 Linux with glibc 2.36+. Runtime loading supports both Debian's <code>librtlsdr.so.0</code> and Ubuntu's <code>librtlsdr.so.2</code>.</sub>
 
 **First run:** sdrtop opens on its menu. `Enter` takes a layout, `Space` starts receiving, `Esc` brings the menu back, `q` quits and saves.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ cargo install sdrtop --locked
 
 Building needs Rust 1.88+ and a C compiler/linker. Install Rust with [rustup](https://rustup.rs). No SDR libraries, development headers or pkg-config are required. At runtime, HackRF needs libhackrf 2023.01.1+ and RTL-SDR needs librtlsdr. A missing or incompatible library disables only its backend.
 
-Runtime loading is independent preparation for the tinySA support proposed in [musithang/sdrtop#7](https://github.com/musithang/sdrtop/pull/7) and [musithang/sdrtop#8](https://github.com/musithang/sdrtop/pull/8). The tinySA backend is provided by that companion work.
+tinySA builds and runs without libhackrf or librtlsdr. Install native SDR runtimes only for the backends you use.
 
 Then go make coffee: a few minutes on a laptop, considerably more on a Raspberry Pi. It's not frozen, it's just Rust.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -338,8 +338,11 @@ The release workflow requires exactly `libc.so.6`, `libgcc_s.so.1` and
 `install.sh` installs native runtimes only with `--hackrf` or `--rtlsdr`.
 `--soapy` selects SoapySDR and its driver modules. `--deps-only` installs only
 selected runtimes. With no runtime flags it does nothing. Source-build packages
-contain compiler/linker tools. Older releases selected by `--version` may still
-need SDR development packages installed by hand.
+contain compiler/linker tools. Older releases selected by `--version` or the
+latest-release URL may still need SDR development packages installed by hand.
+Failed source builds report that requirement. A built binary must pass its startup
+check before it replaces an existing installation. `--git` selects `main` before
+the next release.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -320,19 +320,26 @@ and it will happily eat yours.
 
 ## 🔵 The Ubuntu One: "it works on my machine, but not on my other machine"
 
-Debian ships the rtl-sdr runtime as **`librtlsdr0`**. Ubuntu packages the
-*identical upstream source* as **`librtlsdr2`**, soname `.so.2`. Kali and
-Raspberry Pi OS follow Debian. Mint follows Ubuntu. Nobody is wrong. Everybody
-is incompatible.
+The prebuilt tarball needs x86_64 Linux with glibc 2.36+. The installer runs
+the binary to check compatibility. Other architectures, musl and older glibc
+systems use the source-build fallback.
 
-This is why exactly one prebuilt tarball is published, why `install.sh` decides
-whether to use it by **running the binary** instead of reading your distribution
-off a list, and why the fallback to `cargo install` is the design rather than an
-error path.
+Native SDR libraries are optional runtime loads. Linux candidates are
+`libhackrf.so.0` / `libhackrf.so` and
+`librtlsdr.so.0` / `librtlsdr.so.2` / `librtlsdr.so`.
+Debian's `librtlsdr0` and Ubuntu's `librtlsdr2` are both supported.
+HackRF requires libhackrf 2023.01.1+ with all required symbols.
 
-It was also got wrong once, from memory, in a comment. The fix was to go and
-read `packages.debian.org` and `packages.ubuntu.com` like an adult. Do that
-before editing any package name in `install.sh`.
+The release container builds without native SDR libraries or development headers.
+The release workflow requires exactly `libc.so.6`, `libgcc_s.so.1` and
+`libm.so.6` in `DT_NEEDED`. It explicitly rejects libhackrf and librtlsdr links.
+`cargo publish` retains its verification build without installing SDR libraries.
+
+`install.sh` installs native runtimes only with `--hackrf` or `--rtlsdr`.
+`--soapy` selects SoapySDR and its driver modules. `--deps-only` installs only
+selected runtimes. With no runtime flags it does nothing. Source-build packages
+contain compiler/linker tools. Older releases selected by `--version` may still
+need SDR development packages installed by hand.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -335,14 +335,16 @@ The release workflow requires exactly `libc.so.6`, `libgcc_s.so.1` and
 `libm.so.6` in `DT_NEEDED`. It explicitly rejects libhackrf and librtlsdr links.
 `cargo publish` retains its verification build without installing SDR libraries.
 
-`install.sh` installs native runtimes only with `--hackrf` or `--rtlsdr`.
+`install.sh` installs native runtimes for current releases only with `--hackrf` or `--rtlsdr`.
 `--soapy` selects SoapySDR and its driver modules. `--deps-only` installs only
-selected runtimes. With no runtime flags it does nothing. Source-build packages
-contain compiler/linker tools. Older releases selected by `--version` or the
-latest-release URL may still need SDR development packages installed by hand.
-Failed source builds report that requirement. A built binary must pass its startup
-check before it replaces an existing installation. `--git` selects `main` before
-the next release.
+selected runtimes. With no runtime flags it exits with a usage error.
+Source-build packages contain compiler/linker tools.
+Older releases can still need SDR development packages.
+The installer recognizes sdrtop's missing-libhackrf build-script panic and
+linker errors for missing `-lhackrf` or `-lrtlsdr`.
+Only these failures trigger development package installation and one retry.
+The retry pins the same release version. `--git` receives no legacy retry.
+A built binary must pass its startup check before it replaces an existing installation.
 
 ---
 

--- a/build.rs
+++ b/build.rs
@@ -11,41 +11,6 @@ const MAN_DIR: &str = "target/man";
 fn main() {
     emit_version();
     generate_man_page();
-
-    // docs.rs builds every published crate and cannot install system packages,
-    // so the probe below would panic there and leave a red build badge on the
-    // crates.io page of a binary-only crate whose docs nobody reads. docs.rs
-    // announces itself with DOCS_RS=1. Skipping the link directives costs
-    // nothing there: `cargo doc` documents the crate, it never links the
-    // binary.
-    println!("cargo:rerun-if-env-changed=DOCS_RS");
-    if std::env::var_os("DOCS_RS").is_some() {
-        return;
-    }
-
-    // Requires libhackrf >= 2023.01.1 (hackrf_board_rev_read,
-    // hackrf_usb_api_version_read). Many .pc files omit the version field so
-    // atleast_version() fails even on a correct install; just probe and let
-    // the linker error on missing symbols if the library is too old.
-    //
-    // Install: apt install libhackrf-dev  (Bookworm / Ubuntu 24.04+)
-    // Older distros: build from source at
-    // https://github.com/greatscottgadgets/hackrf
-    if let Err(e) = pkg_config::probe_library("libhackrf") {
-        panic!(
-            "libhackrf not found ({}). \
-             Install: apt install libhackrf-dev  \
-             (requires Raspberry Pi OS Bookworm or Ubuntu 24.04+)",
-            e
-        );
-    }
-
-    // librtlsdr powers the RTL-SDR backend. Some distros ship the library
-    // without a .pc file, so fall back to a bare link directive (and let the
-    // linker error if it is genuinely missing) rather than failing the probe.
-    if pkg_config::probe_library("librtlsdr").is_err() {
-        println!("cargo:rustc-link-lib=rtlsdr");
-    }
 }
 
 /// Render `sdrtop.1` from the CLI definition.
@@ -54,9 +19,6 @@ fn main() {
 /// `src/cli.rs` is not importable from a build script any other way. It is why
 /// that file has to stay self-contained.
 fn generate_man_page() {
-    // pkg-config emits `rerun-if-env-changed`, which switches off cargo's default
-    // "re-run when any file changes" - so the man page's own input has to be
-    // declared, or an edit to the flags would not regenerate it.
     println!("cargo:rerun-if-changed=src/cli.rs");
 
     use clap::CommandFactory;

--- a/dev_docs/native-abi.md
+++ b/dev_docs/native-abi.md
@@ -1,0 +1,105 @@
+# Native SDR ABI checks
+
+All 15 RTL-SDR functions loaded by `src/hardware/native/rtlsdr/ffi.rs` have identical declarations in the three checked development packages.
+Each runtime exports all 15 names.
+Their argument widths, return widths, tuner values, and callback ABI match the Rust declarations.
+
+## Package evidence
+
+Checked on 2026-09-11 using the `amd64` packages below.
+Downloads were extracted with `dpkg-deb -x` into session artifacts.
+No packages were installed.
+
+| Distribution | Version | Runtime download | Development download | Runtime SONAME |
+| --- | --- | --- | --- | --- |
+| Debian 12 Bookworm | `0.6.0-4` | [librtlsdr0](https://deb.debian.org/debian/pool/main/r/rtl-sdr/librtlsdr0_0.6.0-4_amd64.deb) | [librtlsdr-dev](https://deb.debian.org/debian/pool/main/r/rtl-sdr/librtlsdr-dev_0.6.0-4_amd64.deb) | `librtlsdr.so.0` |
+| Debian 13 Trixie | `2.0.2-2+b1` | [librtlsdr0](https://deb.debian.org/debian/pool/main/r/rtl-sdr/librtlsdr0_2.0.2-2+b1_amd64.deb) | [librtlsdr-dev](https://deb.debian.org/debian/pool/main/r/rtl-sdr/librtlsdr-dev_2.0.2-2+b1_amd64.deb) | `librtlsdr.so.0` |
+| Ubuntu 24.04 Noble | `2.0.1-2build1` | [librtlsdr2](https://archive.ubuntu.com/ubuntu/pool/universe/r/rtl-sdr/librtlsdr2_2.0.1-2build1_amd64.deb) | [librtlsdr-dev](https://archive.ubuntu.com/ubuntu/pool/universe/r/rtl-sdr/librtlsdr-dev_2.0.1-2build1_amd64.deb) | `librtlsdr.so.2` |
+| Debian 13 Trixie | `2024.02.1-3` | [libhackrf0](https://deb.debian.org/debian/pool/main/h/hackrf/libhackrf0_2024.02.1-3_amd64.deb) | [libhackrf-dev](https://deb.debian.org/debian/pool/main/h/hackrf/libhackrf-dev_2024.02.1-3_amd64.deb) | `libhackrf.so.0` |
+
+The checks used `usr/include/rtl-sdr.h` and `usr/include/libhackrf/hackrf.h`.
+`readelf -d` verified SONAMEs.
+`readelf --dyn-syms --wide` verified defined global function exports.
+GCC 15.2 compiled C11 `_Static_assert` probes with `-Wall -Wextra -Werror`.
+The probes checked function-pointer types, callback types, scalar widths, enum values, and HackRF structure layouts.
+Rust signature comparisons and a compiled Rust layout probe also passed.
+All checks passed.
+
+## RTL-SDR signatures
+
+Names below have the `rtlsdr_` prefix.
+`dev*` means the opaque `rtlsdr_dev_t*`.
+`I32` is C `int` / Rust `c_int`.
+`U32` is C `uint32_t` / Rust `u32`.
+Characters occupy 8 bits.
+Pointers occupy 64 bits on the checked `amd64` target.
+All functions and callbacks use the C calling convention.
+
+| Function | Arguments in order | Return |
+| --- | --- | --- |
+| `get_device_count` | none | U32 |
+| `get_device_name` | U32 index | `const char*` |
+| `get_device_usb_strings` | U32 index, `char*` manufacturer, `char*` product, `char*` serial | I32 |
+| `open` | `dev**`, U32 index | I32 |
+| `close` | `dev*` | I32 |
+| `set_center_freq` | `dev*`, U32 frequency | I32 |
+| `set_sample_rate` | `dev*`, U32 rate | I32 |
+| `get_sample_rate` | `dev*` | U32 |
+| `get_tuner_type` | `dev*` | 32-bit `enum rtlsdr_tuner` |
+| `get_tuner_gains` | `dev*`, `int*` gains | I32 |
+| `set_tuner_gain_mode` | `dev*`, I32 manual | I32 |
+| `set_tuner_gain` | `dev*`, I32 gain | I32 |
+| `reset_buffer` | `dev*` | I32 |
+| `read_async` | `dev*`, callback, `void*` context, U32 buffer count, U32 buffer length | I32 |
+| `cancel_async` | `dev*` | I32 |
+
+`rtlsdr_read_async_cb_t` is `void (*)(unsigned char*, uint32_t, void*)`.
+Its buffer contains unsigned 8-bit samples.
+Its length is unsigned 32-bit.
+Rust's `RtlSdrReadAsyncCb` has the same signature.
+
+`enum rtlsdr_tuner` contains `UNKNOWN=0`, `E4000=1`, `FC0012=2`, `FC0013=3`, `FC2580=4`, `R820T=5`, and `R828D=6`.
+Every name has the `RTLSDR_TUNER_` prefix.
+The enum occupies four bytes in all three probes.
+GCC selects `unsigned int` as its compatible integer type.
+Rust's `c_int` has the same return ABI for these values.
+
+## HackRF enum and callback checks
+
+The checked runtime exports all 22 functions loaded by `src/hardware/native/hackrf/ffi.rs`.
+Their header signatures match the current Rust ABI.
+`hackrf_board_id_name` takes `enum hackrf_board_id` and returns `const char*`.
+Its enum argument occupies four bytes.
+The runtime disassembly compares the full `%edi` register.
+A Rust `u8` argument has the wrong declared width.
+`hackrf_board_id_read` separately writes through a `uint8_t*`.
+
+`hackrf_board_id` values are `0` through `4`, `254`, and `255`.
+`hackrf_usb_board_id` values are `0x604B`, `0x6089`, `0xCC15`, and `0xFFFF`.
+Both enums have the 32-bit call/storage ABI used by Rust's `c_int`.
+GCC chooses `unsigned int` for both.
+`hackrf_error` is compatible with signed 32-bit `int`.
+
+`hackrf_sample_block_cb_fn` is `int (*)(hackrf_transfer*)`.
+`hackrf_transfer` fields are device pointer, `uint8_t*` buffer, two C `int` lengths, RX context pointer, and TX context pointer.
+Their `amd64` offsets are `0, 8, 16, 20, 24, 32`.
+Size is 40 bytes with alignment 8.
+`hackrf_device_list_t` field offsets are `0, 8, 16, 24, 32, 40`.
+Size is 48 bytes with alignment 8.
+Its USB board array stores four-byte enum elements.
+`read_partid_serialno_t` contains `uint32_t[2]` followed by `uint32_t[4]`.
+Size is 24 bytes with alignment 4.
+These layouts match the Rust `repr(C)` definitions.
+
+## Compatibility boundary
+
+These results cover the listed package builds on `amd64`.
+They support loading both RTL-SDR SONAMEs for this symbol subset.
+Other architectures and future library builds need their own ABI evidence.
+
+The native APIs have no Soapy-style ABI version gate.
+The loader requires every symbol in its declared subset.
+Symbol availability alone cannot validate a handwritten function signature.
+The former pkg-config checks supplied compiler/linker flags.
+The linker resolved names.
+Neither checked the manual Rust argument types, return types, callbacks, or struct layouts against C headers.

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -10,6 +10,7 @@
 # demand glibc 2.39 and lose the older half for nothing.
 #
 # SDR libraries are loaded at runtime. This image needs only the build tools
+#
 # Pinned by digest, not by the `debian:12` tag. A tag is a moving pointer: it
 # advances on every Debian point release, so the same commit built two months
 # apart would come out of two different base images and produce two different

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -5,16 +5,11 @@
 # The only reason this is a container and not the CI runner: glibc is forward
 # compatible only, so a binary is usable on every distribution at least as new
 # as the one that built it and on none that are older. Debian 12 puts the floor
-# at glibc 2.36, which reaches Debian 12 and 13, Ubuntu 22.04 and up, Mint,
+# at glibc 2.36, which reaches Debian 12 and 13, Ubuntu 24.04 and up, Mint 22+,
 # Kali and Raspberry Pi OS Bookworm. Built on the runner's Ubuntu 24.04 it would
 # demand glibc 2.39 and lose the older half for nothing.
 #
-# glibc is not the only floor, and packaging/install.sh is what handles the
-# other one. The binary also needs librtlsdr.so.0, which Debian ships (through
-# trixie, as `librtlsdr0`) but Ubuntu does not (it packages the same upstream as
-# `librtlsdr2`, soname .so.2). install.sh runs `ldd` over the downloaded binary
-# and builds from source when that check fails, so the tarball never has to be
-# the answer everywhere. See dev_docs/release-packaging-plan.md.
+# SDR libraries are loaded at runtime. This image needs only the build tools
 # Pinned by digest, not by the `debian:12` tag. A tag is a moving pointer: it
 # advances on every Debian point release, so the same commit built two months
 # apart would come out of two different base images and produce two different
@@ -35,8 +30,7 @@ ENV CARGO_TERM_COLOR=never
 
 RUN apt-get update -qq \
  && apt-get install -y -qq --no-install-recommends \
-        curl ca-certificates build-essential pkg-config \
-        libhackrf-dev librtlsdr-dev \
+        curl ca-certificates build-essential \
  && rm -rf /var/lib/apt/lists/*
 
 # Debian ships rustc 1.63; sdrtop needs 1.88 (`slice::as_chunks`). The distro

--- a/packaging/build-tarball.sh
+++ b/packaging/build-tarball.sh
@@ -11,9 +11,7 @@
 # the oldest glibc floor worth supporting instead of whatever the build machine
 # happens to have. See packaging/Containerfile.
 #
-# x86_64 only, on purpose. Every other architecture, and every distribution
-# whose librtlsdr soname does not match, is served by packaging/install.sh
-# building from source, which links what the target machine actually has.
+# packaging/install.sh builds from source for other architectures or libcs
 set -eu
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
@@ -99,10 +97,7 @@ exec "$CONTAINER" run --rm --platform linux/amd64 $CONTAINER_USER \
     # gets exercised is the exact one that goes into the archive rather than the
     # one it was copied from.
     #
-    # It has to happen inside the container: Debian 12 is the only place this
-    # binary is expected to start, and on the Ubuntu CI runner it fails for the
-    # librtlsdr soname reason that install.sh exists to handle. Both flags
-    # return before any device is opened, so neither needs a radio.
+    # Test startup at the supported glibc floor without native SDR libraries
     reported=$("$OUT/sdrtop" --version)
     echo "$reported"
     "$OUT/sdrtop" --help >/dev/null

--- a/packaging/check-no-native.sh
+++ b/packaging/check-no-native.sh
@@ -20,17 +20,18 @@ if find /usr/lib /usr/local/lib /lib /usr/include /usr/local/include \
 fi
 
 cargo build --locked
+cargo test --locked
 bin="${CARGO_TARGET_DIR:-target}/debug/sdrtop"
 needed=$(readelf -d "$bin")
 if printf '%s\n' "$needed" | grep -Eq 'NEEDED.*lib(hackrf|rtlsdr)'; then
     die "The binary requires a native SDR library"
 fi
-"$bin" --help >/dev/null
-"$bin" --version
-
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT HUP INT TERM
-export XDG_CONFIG_HOME="$work"
+# The CLI reads HOME/.config. Cargo and rustup must use the original HOME
+export HOME="$work"
+"$bin" --help >/dev/null
+"$bin" --version
 
 expect_failure() {
     if "$bin" "$@" >"$work/output" 2>&1; then
@@ -47,6 +48,7 @@ expect_text() {
     }
 }
 
+# These package and version assertions keep installation advice actionable
 expect_failure --device hackrf
 expect_text "libhackrf backend unavailable"
 expect_text "2023.01.1"

--- a/packaging/check-no-native.sh
+++ b/packaging/check-no-native.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -eu
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+
+[ -z "${DOCS_RS+x}" ] || die "DOCS_RS must be unset"
+[ -z "${LD_LIBRARY_PATH+x}" ] || die "LD_LIBRARY_PATH must be unset"
+[ -z "${LIBRARY_PATH+x}" ] || die "LIBRARY_PATH must be unset"
+[ -z "${RUSTFLAGS+x}" ] || die "RUSTFLAGS must be unset"
+[ -z "${CARGO_ENCODED_RUSTFLAGS+x}" ] || die "CARGO_ENCODED_RUSTFLAGS must be unset"
+
+if ldconfig -p | grep -Eq 'lib(hackrf|rtlsdr|SoapySDR)\.so'; then
+    die "The smoke environment must have no SDR runtime libraries"
+fi
+if find /usr/lib /usr/local/lib /lib /usr/include /usr/local/include \
+    \( -name 'libhackrf.so*' -o -name 'librtlsdr.so*' -o -name 'libSoapySDR.so*' \
+       -o -name hackrf.h -o -name rtl-sdr.h \) -print | grep -q .; then
+    die "The smoke environment must have no SDR libraries or headers"
+fi
+
+cargo build --locked
+bin="${CARGO_TARGET_DIR:-target}/debug/sdrtop"
+needed=$(readelf -d "$bin")
+if printf '%s\n' "$needed" | grep -Eq 'NEEDED.*lib(hackrf|rtlsdr)'; then
+    die "The binary requires a native SDR library"
+fi
+"$bin" --help >/dev/null
+"$bin" --version
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+export XDG_CONFIG_HOME="$work"
+
+expect_failure() {
+    if "$bin" "$@" >"$work/output" 2>&1; then
+        die "Unexpected startup success: $*"
+    else
+        status=$?
+    fi
+    [ "$status" -eq 1 ] || die "Unexpected startup exit $status: $*"
+}
+expect_text() {
+    grep -Fq "$1" "$work/output" || {
+        cat "$work/output" >&2
+        die "Missing startup diagnostic: $1"
+    }
+}
+
+expect_failure --device hackrf
+expect_text "libhackrf backend unavailable"
+expect_text "2023.01.1"
+expect_text "libhackrf0"
+expect_failure --device rtlsdr
+expect_text "librtlsdr backend unavailable"
+expect_text "librtlsdr0"
+expect_text "librtlsdr2"
+expect_failure
+expect_text "No device found"
+expect_text "libhackrf backend unavailable"
+expect_text "librtlsdr backend unavailable"
+for backend in tinysa soapy; do
+    expect_failure --device "$backend"
+    expect_text "No device found"
+    if grep -Eq 'libhackrf|librtlsdr' "$work/output"; then
+        die "Irrelevant native diagnostic for $backend"
+    fi
+done
+printf '%s\n' "No-native-library startup checks passed"

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -64,10 +64,11 @@ sdrtop installer
   --uninstall     remove what a previous run installed
   --help          this
 
-No SDR libraries are installed by default. tinySA needs none of them.
+No SDR libraries are installed by default.
 --deps-only without a runtime flag does nothing. It never installs build tools.
 Source builds need Rust 1.88+ and a C compiler/linker.
-SDR headers are unnecessary for current releases.
+SDR headers are unnecessary for runtime-loading builds.
+Older releases may require SDR development packages. --git builds main.
 EOF
 }
 
@@ -502,10 +503,18 @@ if [ -z "$BINARY" ]; then
     # shellcheck disable=SC2086 # deliberate: $src_args is an argument list
     PATH="$WORK/cargo/bin:$PATH" \
         cargo install "$CRATE" --locked --root "$WORK/cargo" $src_args \
-        || die "the build failed; see the output above"
+        || {
+            if [ "$FROM_GIT" -eq 0 ]; then
+                warn "older releases require native SDR development packages"
+                warn "use --git to build main with runtime loading"
+            fi
+            die "the build failed; see the output above"
+        }
 
     BINARY="$WORK/cargo/bin/sdrtop"
     [ -x "$BINARY" ] || die "cargo reported success but produced no binary"
+    "$BINARY" --version >/dev/null 2>&1 \
+        || die "the built binary does not run; the existing installation was left unchanged"
     # No SRC_DIR: `cargo install` delivers a binary and nothing else, so this
     # path installs no README, man page or user_docs. That is what the command
     # means, and the documentation lives at github.com/musithang/sdrtop.

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -21,11 +21,8 @@
 # It decides by asking rather than by guessing: it unpacks the binary, tries to
 # run it, and falls through to cargo if that fails for any reason at all.
 #
-# That fallback is the whole design. sdrtop links `librtlsdr`, and Debian ships
-# it as `librtlsdr.so.0` while Ubuntu ships the same upstream as `.so.2`, so no
-# single prebuilt binary can serve both. Running the binary catches that, and
-# also catches musl, aarch64, a missing loader and every future soname bump,
-# none of which a list of distribution names would have covered.
+# Running the binary checks the host's loader and glibc compatibility
+# Native SDR libraries are loaded at runtime during discovery or selection
 #
 # What this script does NOT do, deliberately: build sdrtop itself. It used to
 # carry its own download-and-compile pipeline, which was a second unmaintained
@@ -35,6 +32,8 @@ set -eu
 
 REPO=musithang/sdrtop
 CRATE=sdrtop
+WANT_HACKRF=0
+WANT_RTLSDR=0
 WANT_SOAPY=0
 RAW_DEPS_ONLY=0
 FROM_SOURCE=0
@@ -58,10 +57,17 @@ sdrtop installer
   --from-source   compile with cargo even on x86_64, skipping the prebuilt binary
   --git           compile the main branch instead of a release (unversioned)
   --no-verify     install a download without checking its checksum (say why first)
+  --hackrf        also install the optional libhackrf runtime
+  --rtlsdr        also install the optional librtlsdr runtime
   --soapy         also install libSoapySDR and its driver modules (optional)
-  --deps-only     install the library dependencies and stop
+  --deps-only     install only runtimes selected by --hackrf, --rtlsdr, --soapy
   --uninstall     remove what a previous run installed
   --help          this
+
+No SDR libraries are installed by default. tinySA needs none of them.
+--deps-only without a runtime flag does nothing. It never installs build tools.
+Source builds need Rust 1.88+ and a C compiler/linker.
+SDR headers are unnecessary for current releases.
 EOF
 }
 
@@ -72,6 +78,8 @@ while [ $# -gt 0 ]; do
         --from-source) FROM_SOURCE=1; shift ;;
         --git)         FROM_GIT=1; FROM_SOURCE=1; shift ;;
         --no-verify)   NO_VERIFY=1; shift ;;
+        --hackrf)      WANT_HACKRF=1; shift ;;
+        --rtlsdr)      WANT_RTLSDR=1; shift ;;
         --soapy)       WANT_SOAPY=1; shift ;;
         --deps-only)   RAW_DEPS_ONLY=1; shift ;;
         --uninstall)   UNINSTALL=1; shift ;;
@@ -140,7 +148,8 @@ done
 # upstream as `librtlsdr2` with soname .so.2. Kali and Raspberry Pi OS follow
 # Debian, Mint follows Ubuntu. Both names are in the list, so neither family
 # needs to be detected.
-UDEV_PKGS=""
+HACKRF_UDEV=""
+RTLSDR_UDEV=""
 # SoapySDR is optional: sdrtop opens it at runtime and works without it, so
 # these are only used by --soapy. Two lists, because the library alone finds no
 # devices: SOAPY_LIB is what sdrtop loads, SOAPY_MODULES is what actually talks
@@ -161,25 +170,25 @@ case "$PM" in
         LIB_RTLSDR="librtlsdr0 librtlsdr2 librtlsdr-dev"
         SOAPY_LIB="libsoapysdr0.8 libsoapysdr0.7 libsoapysdr-dev"
         SOAPY_MODULES="soapysdr-module-all"
-        DEV_PKGS="libhackrf-dev librtlsdr-dev pkg-config build-essential" ;;
+        DEV_PKGS="build-essential" ;;
     dnf|yum)
         LIB_HACKRF="hackrf hackrf-devel"
         LIB_RTLSDR="rtl-sdr rtl-sdr-devel"
         SOAPY_LIB="SoapySDR"
         SOAPY_MODULES="SoapySDR-hackrf SoapySDR-rtlsdr SoapySDR-airspy SoapySDR-plutosdr"
-        DEV_PKGS="hackrf-devel rtl-sdr-devel pkgconf-pkg-config gcc" ;;
+        DEV_PKGS="gcc" ;;
     pacman)
         LIB_HACKRF="hackrf"
         LIB_RTLSDR="rtl-sdr"
         SOAPY_LIB="soapysdr"
         SOAPY_MODULES="soapyhackrf soapyrtlsdr soapyairspy soapyplutosdr"
-        DEV_PKGS="hackrf rtl-sdr pkgconf base-devel" ;;
+        DEV_PKGS="base-devel" ;;
     zypper)
         LIB_HACKRF="libhackrf0 hackrf libhackrf-devel"
         LIB_RTLSDR="librtlsdr0 rtl-sdr rtl-sdr-devel"
         SOAPY_LIB="libSoapySDR0_8 SoapySDR SoapySDR-devel"
         SOAPY_MODULES="SoapySDR-module-hackrf SoapySDR-module-rtlsdr"
-        DEV_PKGS="libhackrf-devel rtl-sdr-devel pkg-config gcc" ;;
+        DEV_PKGS="gcc" ;;
     apk)
         # Alpine splits further than anyone else: the library, the headers and
         # the udev rules are three packages.
@@ -187,26 +196,27 @@ case "$PM" in
         LIB_RTLSDR="librtlsdr librtlsdr-dev"
         SOAPY_LIB="soapysdr soapysdr-dev"
         SOAPY_MODULES="soapysdr-hackrf soapysdr-rtlsdr"
-        UDEV_PKGS="hackrf-udev librtlsdr-udev"
-        DEV_PKGS="hackrf-dev librtlsdr-dev pkgconf build-base" ;;
+        HACKRF_UDEV="hackrf-udev"
+        RTLSDR_UDEV="librtlsdr-udev"
+        DEV_PKGS="build-base" ;;
     xbps-install)
         LIB_HACKRF="hackrf hackrf-devel"
         LIB_RTLSDR="rtl-sdr rtl-sdr-devel"
         SOAPY_LIB="SoapySDR SoapySDR-devel"
         SOAPY_MODULES="SoapyHackRF SoapyRTLSDR"
-        DEV_PKGS="hackrf-devel rtl-sdr-devel pkg-config base-devel" ;;
+        DEV_PKGS="base-devel" ;;
     emerge)
         LIB_HACKRF="net-wireless/hackrf"
         LIB_RTLSDR="net-wireless/rtl-sdr"
         SOAPY_LIB="net-wireless/soapysdr"
         SOAPY_MODULES="net-wireless/soapyhackrf net-wireless/soapyrtlsdr"
-        DEV_PKGS="net-wireless/hackrf net-wireless/rtl-sdr" ;;
+        DEV_PKGS="sys-devel/gcc" ;;
     nix-env)
         LIB_HACKRF="hackrf"
         LIB_RTLSDR="rtl-sdr"
         SOAPY_LIB="soapysdr-with-plugins soapysdr"
         SOAPY_MODULES=""
-        DEV_PKGS="hackrf rtl-sdr pkg-config" ;;
+        DEV_PKGS="gcc" ;;
     "")
         LIB_HACKRF=""; LIB_RTLSDR=""; DEV_PKGS="" ;;
 esac
@@ -236,9 +246,8 @@ install_first() {
     return 1
 }
 
-have_libs() {
-    ldconfig -p 2>/dev/null | grep -q 'libhackrf\.so' \
-        && ldconfig -p 2>/dev/null | grep -q 'librtlsdr\.so'
+have_native_lib() {
+    ldconfig -p 2>/dev/null | grep -Fq "$1.so"
 }
 
 # SoapySDR is not a dependency. sdrtop opens it at runtime if it is there and
@@ -268,34 +277,47 @@ install_soapy() {
 }
 
 install_runtime_deps() {
-    if have_libs; then
-        say "libhackrf and librtlsdr are already present"
+    if [ "$WANT_HACKRF" -eq 0 ] && [ "$WANT_RTLSDR" -eq 0 ]; then
+        return 0
+    fi
+    if { [ "$WANT_HACKRF" -eq 0 ] || have_native_lib libhackrf; } \
+       && { [ "$WANT_RTLSDR" -eq 0 ] || have_native_lib librtlsdr; }; then
+        say "the selected native SDR libraries are already present"
         return 0
     fi
     if [ -z "$PM" ]; then
-        warn "no known package manager; install libhackrf and librtlsdr yourself"
+        warn "no known package manager; install the selected SDR libraries yourself"
         return 0
     fi
-    step "Installing libhackrf and librtlsdr with $PM"
-    say "(this can take a moment, and is the only step that needs root)"
+    step "Installing selected native SDR libraries with $PM"
+    say "(this may ask for your password)"
     # Not fatal. A stale or unreachable mirror must not end the installation
     # before the libraries have even been tried, and they may be cached already.
     if [ "$PM" = apt-get ]; then
         as_root apt-get update -qq || warn "apt-get update failed, trying anyway"
     fi
-    install_first "$LIB_HACKRF" || warn "could not install libhackrf automatically"
-    install_first "$LIB_RTLSDR" || warn "could not install librtlsdr automatically"
-    # Where a distribution ships the udev rules as their own package, take them.
-    # This is the only udev handling here, and it is a package install like any
-    # other. See "Device access" at the bottom for why nothing is hand-written.
-    for p in $UDEV_PKGS; do
+    udev_pkgs=""
+    if [ "$WANT_HACKRF" -eq 1 ]; then
+        install_first "$LIB_HACKRF" || warn "could not install libhackrf automatically"
+        udev_pkgs="$udev_pkgs $HACKRF_UDEV"
+    fi
+    if [ "$WANT_RTLSDR" -eq 1 ]; then
+        install_first "$LIB_RTLSDR" || warn "could not install librtlsdr automatically"
+        udev_pkgs="$udev_pkgs $RTLSDR_UDEV"
+    fi
+    for p in $udev_pkgs; do
         if pm_install "$p" >/dev/null 2>&1; then say "  $p"; fi
     done
 }
 
 install_runtime_deps
 [ "$WANT_SOAPY" -eq 1 ] && install_soapy
-[ "$RAW_DEPS_ONLY" -eq 1 ] && exit 0
+if [ "$RAW_DEPS_ONLY" -eq 1 ]; then
+    if [ "$WANT_HACKRF" -eq 0 ] && [ "$WANT_RTLSDR" -eq 0 ] && [ "$WANT_SOAPY" -eq 0 ]; then
+        say "no runtimes selected; use --hackrf, --rtlsdr or --soapy with --deps-only"
+    fi
+    exit 0
+fi
 
 BINARY=""
 SRC_DIR=""
@@ -406,7 +428,7 @@ if [ -z "$BINARY" ] && [ "$FROM_SOURCE" -eq 0 ]; then
                 say "the prebuilt binary does not run on this system:"
                 ldd "$WORK/$NAME/sdrtop" 2>&1 | grep -E 'not found|Error|error' \
                     | sed 's/^/    /' || say "    (it failed to start)"
-                say "compiling instead, which links what you do have"
+                say "compiling for this system"
             fi
         fi
     fi
@@ -416,22 +438,15 @@ fi
 if [ -z "$BINARY" ]; then
     step "Compiling with cargo"
 
-    # Only if they are not already there. Someone who has built sdrtop before,
-    # or who has any SDR development environment, should not be asked for a root
-    # password to install packages they have. pkg-config is asked first, but
-    # librtlsdr ships no .pc file on some distributions, so the header is the
-    # fallback question.
-    have_dev() {
-        { pkg-config --exists libhackrf 2>/dev/null \
-            || [ -e /usr/include/libhackrf/hackrf.h ] || [ -e /usr/include/hackrf.h ]; } \
-        && { pkg-config --exists librtlsdr 2>/dev/null \
-            || [ -e /usr/include/rtl-sdr.h ]; }
-    }
-    if have_dev; then
-        say "the build dependencies are already installed"
+    if command -v cc >/dev/null 2>&1; then
+        say "a C compiler/linker is already installed"
     elif [ -n "$PM" ]; then
-        say "installing the build dependencies (this will ask for your password)"
-        for p in $DEV_PKGS; do pm_install "$p" >/dev/null 2>&1 || true; done
+        say "installing C build tools (this may ask for your password)"
+        for p in $DEV_PKGS; do
+            pm_install "$p" >/dev/null 2>&1 || warn "could not install build tool package $p"
+        done
+    else
+        warn "no known package manager; install a C compiler/linker yourself"
     fi
 
     # Distribution Rust is usually too old: sdrtop needs 1.88 for
@@ -538,32 +553,28 @@ else
 fi
 
 # ── The radio has to be openable ────────────────────────────────────────────
-# Reported, never written. The libhackrf and rtl-sdr packages ship their own
-# udev rules, so a machine with the libraries has the permissions, and a second
-# set of rules written here would be a second answer to one question that agrees
-# with the first only until someone edits one of them.
-#
-# On Alpine the rules are separate packages, and those were installed above with
-# the libraries, which is the same mechanism rather than an exception to it.
-step "Device access"
-if grep -rqs -e 'idVendor.*1d50' -e 'idVendor.*0bda' \
-     /usr/lib/udev/rules.d /lib/udev/rules.d /etc/udev/rules.d; then
-    say "udev rules for SDR hardware are installed"
-else
-    warn "no udev rules for SDR hardware were found on this system"
-    say "  sdrtop will need root to open the radio until they exist. They come"
-    say "  with the libhackrf and rtl-sdr packages on most distributions; see"
-    say "  user_docs/troubleshooting.md if installing those did not supply any."
-fi
+# Distribution packages supply native SDR udev rules
+if [ "$WANT_HACKRF" -eq 1 ] || [ "$WANT_RTLSDR" -eq 1 ]; then
+    step "Device access"
+    if grep -rqs -e 'idVendor.*1d50' -e 'idVendor.*0bda' \
+         /usr/lib/udev/rules.d /lib/udev/rules.d /etc/udev/rules.d; then
+        say "udev rules for SDR hardware are installed"
+    else
+        warn "no udev rules for SDR hardware were found on this system"
+        say "  HackRF/RTL-SDR access may need udev rules. They come"
+        say "  with the libhackrf and rtl-sdr packages on most distributions; see"
+        say "  user_docs/troubleshooting.md if installing those did not supply any."
+    fi
 
-if ! id -nG 2>/dev/null | tr ' ' '\n' | grep -qx plugdev; then
-    if getent group plugdev >/dev/null 2>&1; then
-        say ""
-        say "You are not in the plugdev group, which those rules usually grant"
-        say "access through. To join it:"
-        say "    sudo usermod -aG plugdev $(id -un)"
-        say "then log out and back in, because group membership only applies to"
-        say "new sessions."
+    if ! id -nG 2>/dev/null | tr ' ' '\n' | grep -qx plugdev; then
+        if getent group plugdev >/dev/null 2>&1; then
+            say ""
+            say "You are not in the plugdev group, which those rules usually grant"
+            say "access through. To join it:"
+            say "    sudo usermod -aG plugdev $(id -un)"
+            say "then log out and back in, because group membership only applies to"
+            say "new sessions."
+        fi
     fi
 fi
 

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -64,11 +64,12 @@ sdrtop installer
   --uninstall     remove what a previous run installed
   --help          this
 
-No SDR libraries are installed by default.
---deps-only without a runtime flag does nothing. It never installs build tools.
+Runtime libraries are opt-in for current releases.
+--deps-only requires a runtime flag. It never installs build tools.
 Source builds need Rust 1.88+ and a C compiler/linker.
 SDR headers are unnecessary for runtime-loading builds.
-Older releases may require SDR development packages. --git builds main.
+Recognized native-link failures in older releases install SDR development
+packages and retry the same version once. --git builds main.
 EOF
 }
 
@@ -88,6 +89,12 @@ while [ $# -gt 0 ]; do
         *) die "unknown option: $1 (try --help)" ;;
     esac
 done
+
+if [ "$RAW_DEPS_ONLY" -eq 1 ] && [ "$WANT_HACKRF" -eq 0 ] \
+   && [ "$WANT_RTLSDR" -eq 0 ] && [ "$WANT_SOAPY" -eq 0 ]; then
+    usage >&2
+    die "--deps-only requires --hackrf, --rtlsdr or --soapy"
+fi
 
 [ "$(uname -s)" = Linux ] || die "sdrtop is Linux only; this is $(uname -s)"
 
@@ -165,30 +172,35 @@ RTLSDR_UDEV=""
 # and correct the list, not to add another guess.
 SOAPY_LIB=""
 SOAPY_MODULES=""
+LEGACY_DEV_PKGS=""
 case "$PM" in
     apt-get)
         LIB_HACKRF="libhackrf0 libhackrf-dev"
         LIB_RTLSDR="librtlsdr0 librtlsdr2 librtlsdr-dev"
         SOAPY_LIB="libsoapysdr0.8 libsoapysdr0.7 libsoapysdr-dev"
         SOAPY_MODULES="soapysdr-module-all"
+        LEGACY_DEV_PKGS="libhackrf-dev librtlsdr-dev pkg-config"
         DEV_PKGS="build-essential" ;;
     dnf|yum)
         LIB_HACKRF="hackrf hackrf-devel"
         LIB_RTLSDR="rtl-sdr rtl-sdr-devel"
         SOAPY_LIB="SoapySDR"
         SOAPY_MODULES="SoapySDR-hackrf SoapySDR-rtlsdr SoapySDR-airspy SoapySDR-plutosdr"
+        LEGACY_DEV_PKGS="hackrf-devel rtl-sdr-devel pkgconf-pkg-config"
         DEV_PKGS="gcc" ;;
     pacman)
         LIB_HACKRF="hackrf"
         LIB_RTLSDR="rtl-sdr"
         SOAPY_LIB="soapysdr"
         SOAPY_MODULES="soapyhackrf soapyrtlsdr soapyairspy soapyplutosdr"
+        LEGACY_DEV_PKGS="hackrf rtl-sdr pkgconf"
         DEV_PKGS="base-devel" ;;
     zypper)
         LIB_HACKRF="libhackrf0 hackrf libhackrf-devel"
         LIB_RTLSDR="librtlsdr0 rtl-sdr rtl-sdr-devel"
         SOAPY_LIB="libSoapySDR0_8 SoapySDR SoapySDR-devel"
         SOAPY_MODULES="SoapySDR-module-hackrf SoapySDR-module-rtlsdr"
+        LEGACY_DEV_PKGS="libhackrf-devel rtl-sdr-devel pkg-config"
         DEV_PKGS="gcc" ;;
     apk)
         # Alpine splits further than anyone else: the library, the headers and
@@ -199,24 +211,28 @@ case "$PM" in
         SOAPY_MODULES="soapysdr-hackrf soapysdr-rtlsdr"
         HACKRF_UDEV="hackrf-udev"
         RTLSDR_UDEV="librtlsdr-udev"
+        LEGACY_DEV_PKGS="hackrf-dev librtlsdr-dev pkgconf"
         DEV_PKGS="build-base" ;;
     xbps-install)
         LIB_HACKRF="hackrf hackrf-devel"
         LIB_RTLSDR="rtl-sdr rtl-sdr-devel"
         SOAPY_LIB="SoapySDR SoapySDR-devel"
         SOAPY_MODULES="SoapyHackRF SoapyRTLSDR"
+        LEGACY_DEV_PKGS="hackrf-devel rtl-sdr-devel pkg-config"
         DEV_PKGS="base-devel" ;;
     emerge)
         LIB_HACKRF="net-wireless/hackrf"
         LIB_RTLSDR="net-wireless/rtl-sdr"
         SOAPY_LIB="net-wireless/soapysdr"
         SOAPY_MODULES="net-wireless/soapyhackrf net-wireless/soapyrtlsdr"
+        LEGACY_DEV_PKGS="net-wireless/hackrf net-wireless/rtl-sdr"
         DEV_PKGS="sys-devel/gcc" ;;
     nix-env)
         LIB_HACKRF="hackrf"
         LIB_RTLSDR="rtl-sdr"
         SOAPY_LIB="soapysdr-with-plugins soapysdr"
         SOAPY_MODULES=""
+        LEGACY_DEV_PKGS="hackrf rtl-sdr pkg-config"
         DEV_PKGS="gcc" ;;
     "")
         LIB_HACKRF=""; LIB_RTLSDR=""; DEV_PKGS="" ;;
@@ -314,9 +330,6 @@ install_runtime_deps() {
 install_runtime_deps
 [ "$WANT_SOAPY" -eq 1 ] && install_soapy
 if [ "$RAW_DEPS_ONLY" -eq 1 ]; then
-    if [ "$WANT_HACKRF" -eq 0 ] && [ "$WANT_RTLSDR" -eq 0 ] && [ "$WANT_SOAPY" -eq 0 ]; then
-        say "no runtimes selected; use --hackrf, --rtlsdr or --soapy with --deps-only"
-    fi
     exit 0
 fi
 
@@ -491,7 +504,7 @@ if [ -z "$BINARY" ]; then
         src_args="--git https://github.com/$REPO"
         src_label="the main branch from git"
     elif [ -n "$TAG" ]; then
-        src_args="--version ${TAG#v}"
+        src_args="--version =${TAG#v}"
         src_label="$CRATE ${TAG#v} from crates.io"
     fi
     say "building $src_label"
@@ -500,16 +513,56 @@ if [ -z "$BINARY" ]; then
     # temporary directory, which stops existing seconds later, and this script
     # prints the correct PATH line about $BIN_DIR at the end anyway. Two pieces
     # of contradictory advice is worse than one.
-    # shellcheck disable=SC2086 # deliberate: $src_args is an argument list
-    PATH="$WORK/cargo/bin:$PATH" \
-        cargo install "$CRATE" --locked --root "$WORK/cargo" $src_args \
-        || {
-            if [ "$FROM_GIT" -eq 0 ]; then
-                warn "older releases require native SDR development packages"
-                warn "use --git to build main with runtime loading"
+    run_cargo_install() {
+        (
+            # The status file preserves Cargo's result across the tee pipeline
+            # shellcheck disable=SC2086 # deliberate: $src_args is an argument list
+            if PATH="$WORK/cargo/bin:$PATH" CARGO_TERM_COLOR=never \
+                cargo install "$CRATE" --locked --root "$WORK/cargo" $src_args; then
+                echo 0 > "$WORK/cargo.status"
+            else
+                echo "$?" > "$WORK/cargo.status"
             fi
+        ) 2>&1 | tee "$WORK/cargo.log"
+        return "$(cat "$WORK/cargo.status")"
+    }
+
+    legacy_native_failure() {
+        if grep -Fq 'error: failed to run custom build command for `sdrtop v' "$WORK/cargo.log" \
+           && grep -Eq 'panicked at .*build\.rs:[0-9]+:' "$WORK/cargo.log" \
+           && grep -Fq 'libhackrf not found (' "$WORK/cargo.log" \
+           && grep -Fq 'Install: apt install libhackrf-dev' "$WORK/cargo.log"; then
+            return 0
+        fi
+        grep -Fq 'error: could not compile `sdrtop` (bin "sdrtop")' "$WORK/cargo.log" \
+            && grep -Eq '(cannot find|unable to find library|library not found for) -l(hackrf|rtlsdr)(:|[[:space:]]|$)' "$WORK/cargo.log"
+    }
+
+    if ! run_cargo_install; then
+        if [ "$FROM_GIT" -eq 1 ] || ! legacy_native_failure; then
             die "the build failed; see the output above"
-        }
+        fi
+        if [ -z "$TAG" ]; then
+            # Pin Cargo's resolved release before retrying an unversioned install
+            TAG=$(sed -n 's/^error: failed to compile `sdrtop v\([0-9][0-9A-Za-z.+-]*\)`.*/\1/p' \
+                "$WORK/cargo.log" | head -1)
+            printf '%s\n' "$TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$' \
+                || die "could not identify the failed release; retry with --version"
+            src_args="--version =$TAG"
+        fi
+        [ -n "$LEGACY_DEV_PKGS" ] \
+            || die "this release needs libhackrf and librtlsdr development packages plus pkg-config; install them and retry"
+        step "Installing native development packages for $CRATE ${TAG#v}"
+        say "(this may ask for your password)"
+        if [ "$PM" = apt-get ]; then
+            as_root apt-get update -qq || warn "apt-get update failed, trying anyway"
+        fi
+        for p in $LEGACY_DEV_PKGS; do
+            pm_install "$p" || die "could not install $p; the existing installation was left unchanged"
+        done
+        say "retrying $CRATE ${TAG#v}"
+        run_cargo_install || die "the build failed; see the output above"
+    fi
 
     BINARY="$WORK/cargo/bin/sdrtop"
     [ -x "$BINARY" ] || die "cargo reported success but produced no binary"
@@ -602,5 +655,6 @@ case ":$PATH:" in
 esac
 
 say ""
+say "For a HackRF or RTL-SDR, re-run this installer with --hackrf or --rtlsdr."
 say "Run 'sdrtop'. It opens on its menu: Enter takes a layout, Space starts"
 say "receiving, Esc brings the menu back, q quits and saves."

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -154,20 +154,21 @@ pub fn parse_device_arg(spec: &str) -> anyhow::Result<(DeviceKind, Option<String
     Ok((kind, filter))
 }
 
-/// What else the operator could look at, when enumeration found nothing.
-///
-/// Empty when there is nothing useful to add. Mentioning SoapySDR to someone who
-/// does not have it installed is a wild goose chase, and they have enough to
-/// check already.
-///
-/// Asked here rather than in `main` so that finding out costs the caller no
-/// knowledge of which backends exist or how one reports itself present.
-pub fn no_device_hint() -> &'static str {
-    if soapy::api::api().is_some() {
-        " SoapySDR is installed: `SoapySDRUtil --find` lists what it can see."
-    } else {
-        ""
+/// Reports relevant backend diagnostics after empty discovery
+pub fn no_device_hint(want: Option<DeviceKind>) -> String {
+    let mut hint = String::new();
+    for kind in [DeviceKind::HackRf, DeviceKind::RtlSdr] {
+        if want.is_none() || want == Some(kind) {
+            if let Err(err) = kind.check_available() {
+                hint.push('\n');
+                hint.push_str(&err.to_string());
+            }
+        }
     }
+    if (want.is_none() || want == Some(DeviceKind::Soapy)) && soapy::api::api().is_some() {
+        hint.push_str("\nSoapySDR is installed: `SoapySDRUtil --find` lists what it can see.");
+    }
+    hint
 }
 
 /// Every connected device across all compiled-in backends. Never fails: a
@@ -292,6 +293,11 @@ mod tests {
     fn native_availability_check_accepts_non_native_backends() {
         assert!(DeviceKind::Soapy.check_available().is_ok());
         assert!(DeviceKind::TinySa.check_available().is_ok());
+    }
+
+    #[test]
+    fn tiny_sa_empty_discovery_has_no_native_library_hint() {
+        assert!(no_device_hint(Some(DeviceKind::TinySa)).is_empty());
     }
 
     fn listing(

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -51,7 +51,7 @@ impl DeviceKind {
         match self {
             Self::HackRf => hackrf::ffi::api().map(|_| ()),
             Self::RtlSdr => rtlsdr::ffi::api().map(|_| ()),
-            Self::Soapy | Self::TinySa => Ok(()),
+            Self::Soapy => Ok(()),
         }
     }
 

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -46,6 +46,15 @@ pub struct ObserverProfile {
 }
 
 impl DeviceKind {
+    /// Reports a missing or incompatible native runtime library
+    pub fn check_available(self) -> anyhow::Result<()> {
+        match self {
+            Self::HackRf => hackrf::ffi::api().map(|_| ()),
+            Self::RtlSdr => rtlsdr::ffi::api().map(|_| ()),
+            Self::Soapy | Self::TinySa => Ok(()),
+        }
+    }
+
     /// How observer mode describes this backend, when it can.
     ///
     /// Observer mode reads sysfs for a USB device sdrtop knows by vendor and

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -289,8 +289,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn native_availability_check_accepts_soapy() {
+    fn native_availability_check_accepts_non_native_backends() {
         assert!(DeviceKind::Soapy.check_available().is_ok());
+        assert!(DeviceKind::TinySa.check_available().is_ok());
     }
 
     fn listing(

--- a/src/hardware/discovery.rs
+++ b/src/hardware/discovery.rs
@@ -51,7 +51,7 @@ impl DeviceKind {
         match self {
             Self::HackRf => hackrf::ffi::api().map(|_| ()),
             Self::RtlSdr => rtlsdr::ffi::api().map(|_| ()),
-            Self::Soapy => Ok(()),
+            _ => Ok(()),
         }
     }
 
@@ -287,6 +287,11 @@ pub fn open_device(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_availability_check_accepts_soapy() {
+        assert!(DeviceKind::Soapy.check_available().is_ok());
+    }
 
     fn listing(
         kind: DeviceKind,

--- a/src/hardware/native/fixtures/library.c
+++ b/src/hardware/native/fixtures/library.c
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdatomic.h>
+
+// This layout follows hackrf_device_list_t in libhackrf 2024.02.1
+struct hackrf_device_list {
+    char **serial_numbers;
+    int *usb_board_ids;
+    int *usb_device_index;
+    int devicecount;
+    void **usb_devices;
+    int usb_devicecount;
+};
+
+static int mode;
+static _Atomic int calls[5];
+static char *serials[] = {"0000000000000000123456789abcdef0"};
+
+void fixture_mode(int value) { mode = value; }
+int fixture_calls(int slot) { return calls[slot]; }
+size_t fixture_list_layout(int field) {
+    switch (field) {
+        case 0: return sizeof(struct hackrf_device_list);
+        case 1: return offsetof(struct hackrf_device_list, usb_device_index);
+        case 2: return offsetof(struct hackrf_device_list, devicecount);
+        case 3: return offsetof(struct hackrf_device_list, usb_devices);
+        default: return offsetof(struct hackrf_device_list, usb_devicecount);
+    }
+}
+
+int hackrf_init(void) {
+    calls[0]++;
+    return mode == 1 ? -1000 : 0;
+}
+int hackrf_exit(void) { calls[1]++; return 0; }
+struct hackrf_device_list *hackrf_device_list(void) {
+    if (mode == 2) return NULL;
+    struct hackrf_device_list *list = calloc(1, sizeof(*list));
+    list->serial_numbers = serials;
+    list->devicecount = mode == 3 ? 0 : 1;
+    // Unrelated USB devices must not contribute to HackRF enumeration
+    list->usb_devicecount = 9;
+    return list;
+}
+void hackrf_device_list_free(struct hackrf_device_list *list) {
+    calls[2]++;
+    free(list);
+}
+int hackrf_device_list_open(struct hackrf_device_list *list, int index, void **device) {
+    if (mode == 4) return -6;
+    *device = mode == 5 ? NULL : malloc(1);
+    return 0;
+}
+int hackrf_close(void *device) { calls[3]++; free(device); return 0; }
+const char *hackrf_error_name(int code) { return "fixture error"; }
+const char *hackrf_board_id_name(uint8_t id) { return "Fixture HackRF"; }
+
+#define OPTIONAL(name, args) int name args { return -1005; }
+OPTIONAL(hackrf_version_string_read, (void *device, char *version, uint8_t length))
+OPTIONAL(hackrf_board_partid_serialno_read, (void *device, void *value))
+OPTIONAL(hackrf_board_id_read, (void *device, uint8_t *value))
+OPTIONAL(hackrf_board_rev_read, (void *device, uint8_t *value))
+#ifndef OMIT_LAST_SYMBOL
+OPTIONAL(hackrf_usb_api_version_read, (void *device, uint16_t *value))
+#endif
+
+#define CONTROL(name, args) int name args { return mode == 6 ? -2 : 0; }
+CONTROL(hackrf_set_sample_rate, (void *device, double rate))
+CONTROL(hackrf_set_baseband_filter_bandwidth, (void *device, uint32_t bandwidth))
+CONTROL(hackrf_set_freq, (void *device, uint64_t freq))
+CONTROL(hackrf_set_amp_enable, (void *device, uint8_t value))
+CONTROL(hackrf_set_lna_gain, (void *device, uint32_t value))
+CONTROL(hackrf_set_vga_gain, (void *device, uint32_t value))
+CONTROL(hackrf_start_rx, (void *device, int (*callback)(void *), void *ctx))
+int hackrf_is_streaming(void *device) { return 0; }
+int hackrf_stop_rx(void *device) { calls[4]++; return 0; }
+
+uint32_t rtlsdr_get_device_count(void) { return 1; }
+const char *rtlsdr_get_device_name(uint32_t index) { return "Fixture RTL-SDR"; }
+int rtlsdr_get_device_usb_strings(uint32_t index, char *manufacturer, char *product, char *serial) {
+    strcpy(manufacturer, "Fixture");
+    strcpy(product, "RTL-SDR");
+    strcpy(serial, "00000001");
+    return 0;
+}
+int rtlsdr_open(void **device, uint32_t index) {
+    if (mode == 4) return -6;
+    *device = mode == 5 ? NULL : malloc(1);
+    return 0;
+}
+int rtlsdr_close(void *device) { calls[3]++; free(device); return 0; }
+uint32_t rtlsdr_get_sample_rate(void *device) { return 2399999; }
+int rtlsdr_get_tuner_type(void *device) { return 5; }
+int rtlsdr_get_tuner_gains(void *device, int *gains) {
+    if (gains) { gains[0] = 0; gains[1] = 197; gains[2] = 496; }
+    return 3;
+}
+CONTROL(rtlsdr_set_center_freq, (void *device, uint32_t freq))
+CONTROL(rtlsdr_set_sample_rate, (void *device, uint32_t rate))
+CONTROL(rtlsdr_set_tuner_gain_mode, (void *device, int manual))
+CONTROL(rtlsdr_set_tuner_gain, (void *device, int gain))
+CONTROL(rtlsdr_reset_buffer, (void *device))
+CONTROL(rtlsdr_read_async, (void *device, void (*callback)(unsigned char *, uint32_t, void *), void *ctx, uint32_t num, uint32_t len))
+#ifndef OMIT_LAST_SYMBOL
+int rtlsdr_cancel_async(void *device) { calls[4]++; return 0; }
+#endif

--- a/src/hardware/native/fixtures/library.c
+++ b/src/hardware/native/fixtures/library.c
@@ -28,7 +28,8 @@ size_t fixture_list_layout(int field) {
         case 1: return offsetof(struct hackrf_device_list, usb_device_index);
         case 2: return offsetof(struct hackrf_device_list, devicecount);
         case 3: return offsetof(struct hackrf_device_list, usb_devices);
-        default: return offsetof(struct hackrf_device_list, usb_devicecount);
+        case 4: return offsetof(struct hackrf_device_list, usb_devicecount);
+        default: abort();
     }
 }
 
@@ -57,7 +58,7 @@ int hackrf_device_list_open(struct hackrf_device_list *list, int index, void **d
 }
 int hackrf_close(void *device) { calls[3]++; free(device); return 0; }
 const char *hackrf_error_name(int code) { return "fixture error"; }
-const char *hackrf_board_id_name(uint8_t id) { return "Fixture HackRF"; }
+const char *hackrf_board_id_name(int id) { return "Fixture HackRF"; }
 
 #define OPTIONAL(name, args) int name args { return -1005; }
 OPTIONAL(hackrf_version_string_read, (void *device, char *version, uint8_t length))
@@ -82,6 +83,7 @@ int hackrf_stop_rx(void *device) { calls[4]++; return 0; }
 uint32_t rtlsdr_get_device_count(void) { return 1; }
 const char *rtlsdr_get_device_name(uint32_t index) { return "Fixture RTL-SDR"; }
 int rtlsdr_get_device_usb_strings(uint32_t index, char *manufacturer, char *product, char *serial) {
+    calls[0]++;
     strcpy(manufacturer, "Fixture");
     strcpy(product, "RTL-SDR");
     strcpy(serial, "00000001");

--- a/src/hardware/native/hackrf/ffi.rs
+++ b/src/hardware/native/hackrf/ffi.rs
@@ -2,6 +2,9 @@
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
 use libc::{c_char, c_int, c_void};
+use std::sync::OnceLock;
+
+use super::super::loader::{load, symbol};
 
 #[repr(C)]
 pub struct hackrf_transfer {
@@ -18,10 +21,10 @@ pub struct hackrf_transfer {
 pub struct HackrfDeviceList {
     pub serial_numbers: *mut *mut c_char,
     pub usb_board_ids: *mut c_int,
-    pub usb_device_count: *mut c_int,
-    pub usb_devices: *mut *mut c_void,
     pub usb_device_index: *mut c_int,
     pub devicecount: c_int,
+    pub usb_devices: *mut *mut c_void,
+    pub usb_devicecount: c_int,
 }
 
 #[repr(C)]
@@ -32,42 +35,74 @@ pub struct ReadPartidSerialno {
 
 pub type HackrfTransferCallback = extern "C" fn(*mut hackrf_transfer) -> c_int;
 
-extern "C" {
-    pub fn hackrf_init() -> c_int;
-    pub fn hackrf_exit() -> c_int;
-    pub fn hackrf_close(device: *mut c_void) -> c_int;
-    pub fn hackrf_device_list() -> *mut HackrfDeviceList;
-    pub fn hackrf_device_list_free(list: *mut HackrfDeviceList);
-    pub fn hackrf_device_list_open(
-        list: *mut HackrfDeviceList,
-        index: c_int,
-        device: *mut *mut c_void,
-    ) -> c_int;
-    pub fn hackrf_version_string_read(
-        device: *mut c_void,
-        version: *mut c_char,
-        length: u8,
-    ) -> c_int;
-    pub fn hackrf_is_streaming(device: *mut c_void) -> c_int;
-    pub fn hackrf_set_sample_rate(device: *mut c_void, freq_hz: f64) -> c_int;
-    pub fn hackrf_set_baseband_filter_bandwidth(device: *mut c_void, bandwidth_hz: u32) -> c_int;
-    pub fn hackrf_set_freq(device: *mut c_void, freq_hz: u64) -> c_int;
-    pub fn hackrf_set_amp_enable(device: *mut c_void, value: u8) -> c_int;
-    pub fn hackrf_start_rx(
-        device: *mut c_void,
-        callback: HackrfTransferCallback,
-        user_param: *mut c_void,
-    ) -> c_int;
-    pub fn hackrf_stop_rx(device: *mut c_void) -> c_int;
-    pub fn hackrf_set_lna_gain(device: *mut c_void, value: u32) -> c_int;
-    pub fn hackrf_set_vga_gain(device: *mut c_void, value: u32) -> c_int;
-    pub fn hackrf_board_partid_serialno_read(
-        device: *mut c_void,
-        value: *mut ReadPartidSerialno,
-    ) -> c_int;
-    pub fn hackrf_board_id_read(device: *mut c_void, value: *mut u8) -> c_int;
-    pub fn hackrf_board_id_name(id: u8) -> *const c_char;
-    pub fn hackrf_error_name(errcode: c_int) -> *const c_char;
-    pub fn hackrf_board_rev_read(device: *mut c_void, value: *mut u8) -> c_int;
-    pub fn hackrf_usb_api_version_read(device: *mut c_void, version: *mut u16) -> c_int;
+pub struct HackrfApi {
+    // The static API must keep the library mapped through device and callback cleanup
+    _lib: libloading::Library,
+    pub hackrf_init: unsafe extern "C" fn() -> c_int,
+    pub hackrf_exit: unsafe extern "C" fn() -> c_int,
+    pub hackrf_close: unsafe extern "C" fn(*mut c_void) -> c_int,
+    pub hackrf_device_list: unsafe extern "C" fn() -> *mut HackrfDeviceList,
+    pub hackrf_device_list_free: unsafe extern "C" fn(*mut HackrfDeviceList),
+    pub hackrf_device_list_open:
+        unsafe extern "C" fn(*mut HackrfDeviceList, c_int, *mut *mut c_void) -> c_int,
+    pub hackrf_version_string_read: unsafe extern "C" fn(*mut c_void, *mut c_char, u8) -> c_int,
+    pub hackrf_is_streaming: unsafe extern "C" fn(*mut c_void) -> c_int,
+    pub hackrf_set_sample_rate: unsafe extern "C" fn(*mut c_void, f64) -> c_int,
+    pub hackrf_set_baseband_filter_bandwidth: unsafe extern "C" fn(*mut c_void, u32) -> c_int,
+    pub hackrf_set_freq: unsafe extern "C" fn(*mut c_void, u64) -> c_int,
+    pub hackrf_set_amp_enable: unsafe extern "C" fn(*mut c_void, u8) -> c_int,
+    pub hackrf_start_rx:
+        unsafe extern "C" fn(*mut c_void, HackrfTransferCallback, *mut c_void) -> c_int,
+    pub hackrf_stop_rx: unsafe extern "C" fn(*mut c_void) -> c_int,
+    pub hackrf_set_lna_gain: unsafe extern "C" fn(*mut c_void, u32) -> c_int,
+    pub hackrf_set_vga_gain: unsafe extern "C" fn(*mut c_void, u32) -> c_int,
+    pub hackrf_board_partid_serialno_read:
+        unsafe extern "C" fn(*mut c_void, *mut ReadPartidSerialno) -> c_int,
+    pub hackrf_board_id_read: unsafe extern "C" fn(*mut c_void, *mut u8) -> c_int,
+    pub hackrf_board_id_name: unsafe extern "C" fn(u8) -> *const c_char,
+    pub hackrf_error_name: unsafe extern "C" fn(c_int) -> *const c_char,
+    pub hackrf_board_rev_read: unsafe extern "C" fn(*mut c_void, *mut u8) -> c_int,
+    pub hackrf_usb_api_version_read: unsafe extern "C" fn(*mut c_void, *mut u16) -> c_int,
+}
+
+const CANDIDATES: &[&str] = &["libhackrf.so.0", "libhackrf.so"];
+
+pub fn api() -> anyhow::Result<&'static HackrfApi> {
+    static API: OnceLock<Result<HackrfApi, String>> = OnceLock::new();
+    API.get_or_init(|| load("libhackrf", CANDIDATES, resolve))
+        .as_ref()
+        .map_err(|err| anyhow::anyhow!("{err}"))
+}
+
+pub(super) fn resolve(lib: libloading::Library) -> Result<HackrfApi, String> {
+    macro_rules! sym {
+        ($name:ident) => {
+            unsafe { symbol(&lib, concat!(stringify!($name), "\0").as_bytes())? }
+        };
+    }
+    Ok(HackrfApi {
+        hackrf_init: sym!(hackrf_init),
+        hackrf_exit: sym!(hackrf_exit),
+        hackrf_close: sym!(hackrf_close),
+        hackrf_device_list: sym!(hackrf_device_list),
+        hackrf_device_list_free: sym!(hackrf_device_list_free),
+        hackrf_device_list_open: sym!(hackrf_device_list_open),
+        hackrf_version_string_read: sym!(hackrf_version_string_read),
+        hackrf_is_streaming: sym!(hackrf_is_streaming),
+        hackrf_set_sample_rate: sym!(hackrf_set_sample_rate),
+        hackrf_set_baseband_filter_bandwidth: sym!(hackrf_set_baseband_filter_bandwidth),
+        hackrf_set_freq: sym!(hackrf_set_freq),
+        hackrf_set_amp_enable: sym!(hackrf_set_amp_enable),
+        hackrf_start_rx: sym!(hackrf_start_rx),
+        hackrf_stop_rx: sym!(hackrf_stop_rx),
+        hackrf_set_lna_gain: sym!(hackrf_set_lna_gain),
+        hackrf_set_vga_gain: sym!(hackrf_set_vga_gain),
+        hackrf_board_partid_serialno_read: sym!(hackrf_board_partid_serialno_read),
+        hackrf_board_id_read: sym!(hackrf_board_id_read),
+        hackrf_board_id_name: sym!(hackrf_board_id_name),
+        hackrf_error_name: sym!(hackrf_error_name),
+        hackrf_board_rev_read: sym!(hackrf_board_rev_read),
+        hackrf_usb_api_version_read: sym!(hackrf_usb_api_version_read),
+        _lib: lib,
+    })
 }

--- a/src/hardware/native/hackrf/ffi.rs
+++ b/src/hardware/native/hackrf/ffi.rs
@@ -59,7 +59,7 @@ pub struct HackrfApi {
     pub hackrf_board_partid_serialno_read:
         unsafe extern "C" fn(*mut c_void, *mut ReadPartidSerialno) -> c_int,
     pub hackrf_board_id_read: unsafe extern "C" fn(*mut c_void, *mut u8) -> c_int,
-    pub hackrf_board_id_name: unsafe extern "C" fn(u8) -> *const c_char,
+    pub hackrf_board_id_name: unsafe extern "C" fn(c_int) -> *const c_char,
     pub hackrf_error_name: unsafe extern "C" fn(c_int) -> *const c_char,
     pub hackrf_board_rev_read: unsafe extern "C" fn(*mut c_void, *mut u8) -> c_int,
     pub hackrf_usb_api_version_read: unsafe extern "C" fn(*mut c_void, *mut u16) -> c_int,
@@ -71,7 +71,12 @@ pub fn api() -> anyhow::Result<&'static HackrfApi> {
     static API: OnceLock<Result<HackrfApi, String>> = OnceLock::new();
     API.get_or_init(|| load("libhackrf", CANDIDATES, resolve))
         .as_ref()
-        .map_err(|err| anyhow::anyhow!("{err}"))
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "{err}\nHackRF needs libhackrf 2023.01.1 or newer. \
+                 Install libhackrf0 on Debian/Ubuntu or hackrf on Arch/Fedora."
+            )
+        })
 }
 
 pub(super) fn resolve(lib: libloading::Library) -> Result<HackrfApi, String> {

--- a/src/hardware/native/hackrf/mod.rs
+++ b/src/hardware/native/hackrf/mod.rs
@@ -24,6 +24,7 @@ use crate::hardware::traits::RateSet;
 use ffi::*;
 
 pub struct HackRfDevice {
+    api: &'static HackrfApi,
     ptr: *mut c_void,
     caps: DeviceCapabilities,
     info: DeviceInfo,
@@ -103,7 +104,7 @@ impl SdrDevice for HackRfDevice {
     fn start_rx(&self, ctx: Arc<RxContext>) -> anyhow::Result<()> {
         let user_param = Arc::as_ptr(&ctx) as *mut c_void;
         unsafe {
-            if hackrf_start_rx(self.ptr, rx_callback, user_param) != 0 {
+            if (self.api.hackrf_start_rx)(self.ptr, rx_callback, user_param) != 0 {
                 anyhow::bail!("Failed to start RX streaming");
             }
         }
@@ -113,7 +114,7 @@ impl SdrDevice for HackRfDevice {
 
     fn stop_rx(&self) -> anyhow::Result<()> {
         unsafe {
-            if hackrf_stop_rx(self.ptr) != 0 {
+            if (self.api.hackrf_stop_rx)(self.ptr) != 0 {
                 anyhow::bail!("Failed to stop RX streaming");
             }
         }
@@ -124,12 +125,12 @@ impl SdrDevice for HackRfDevice {
     }
 
     fn is_streaming(&self) -> bool {
-        unsafe { hackrf_is_streaming(self.ptr) == 1 }
+        unsafe { (self.api.hackrf_is_streaming)(self.ptr) == 1 }
     }
 
     fn set_frequency(&self, hz: u64) -> anyhow::Result<()> {
         unsafe {
-            if hackrf_set_freq(self.ptr, hz) != 0 {
+            if (self.api.hackrf_set_freq)(self.ptr, hz) != 0 {
                 anyhow::bail!("Failed to set frequency");
             }
         }
@@ -144,10 +145,10 @@ impl SdrDevice for HackRfDevice {
     fn set_sample_rate(&self, hz: f64) -> anyhow::Result<RateSet> {
         let bw = compute_bb_filter_bw(hz);
         unsafe {
-            if hackrf_set_sample_rate(self.ptr, hz) != 0 {
+            if (self.api.hackrf_set_sample_rate)(self.ptr, hz) != 0 {
                 anyhow::bail!("Failed to set sample rate");
             }
-            if hackrf_set_baseband_filter_bandwidth(self.ptr, bw) != 0 {
+            if (self.api.hackrf_set_baseband_filter_bandwidth)(self.ptr, bw) != 0 {
                 anyhow::bail!("Failed to set baseband filter bandwidth");
             }
         }
@@ -156,7 +157,7 @@ impl SdrDevice for HackRfDevice {
 
     fn set_lna_gain(&self, db: u32) -> anyhow::Result<()> {
         unsafe {
-            if hackrf_set_lna_gain(self.ptr, db) != 0 {
+            if (self.api.hackrf_set_lna_gain)(self.ptr, db) != 0 {
                 anyhow::bail!("Failed to set LNA gain");
             }
         }
@@ -165,7 +166,7 @@ impl SdrDevice for HackRfDevice {
 
     fn set_vga_gain(&self, db: u32) -> anyhow::Result<()> {
         unsafe {
-            if hackrf_set_vga_gain(self.ptr, db) != 0 {
+            if (self.api.hackrf_set_vga_gain)(self.ptr, db) != 0 {
                 anyhow::bail!("Failed to set VGA gain");
             }
         }
@@ -174,7 +175,7 @@ impl SdrDevice for HackRfDevice {
 
     fn set_amp_enable(&self, on: bool) -> anyhow::Result<()> {
         unsafe {
-            if hackrf_set_amp_enable(self.ptr, on as u8) != 0 {
+            if (self.api.hackrf_set_amp_enable)(self.ptr, on as u8) != 0 {
                 anyhow::bail!("Failed to set AMP enable");
             }
         }
@@ -185,11 +186,11 @@ impl SdrDevice for HackRfDevice {
 impl Drop for HackRfDevice {
     fn drop(&mut self) {
         unsafe {
-            if hackrf_is_streaming(self.ptr) == 1 {
-                let _ = hackrf_stop_rx(self.ptr);
+            if (self.api.hackrf_is_streaming)(self.ptr) == 1 {
+                let _ = (self.api.hackrf_stop_rx)(self.ptr);
             }
-            hackrf_close(self.ptr);
-            hackrf_exit();
+            (self.api.hackrf_close)(self.ptr);
+            (self.api.hackrf_exit)();
         }
     }
 }
@@ -201,29 +202,33 @@ impl HackRfDevice {
     /// libhackrf open fails here; missing optional metadata reads degrade to
     /// fallbacks rather than aborting (so a quirky unit still comes up).
     pub fn open(index: usize) -> anyhow::Result<Self> {
+        Self::open_with_api(api()?, index)
+    }
+
+    fn open_with_api(api: &'static HackrfApi, index: usize) -> anyhow::Result<Self> {
         unsafe {
-            let init_res = hackrf_init();
+            let init_res = (api.hackrf_init)();
             if init_res != 0 {
-                let err = CStr::from_ptr(hackrf_error_name(init_res)).to_string_lossy();
+                let err = CStr::from_ptr((api.hackrf_error_name)(init_res)).to_string_lossy();
                 anyhow::bail!("Failed to initialize libhackrf: {}", err);
             }
 
-            let list_ptr = hackrf_device_list();
+            let list_ptr = (api.hackrf_device_list)();
             if list_ptr.is_null() {
-                hackrf_exit();
+                (api.hackrf_exit)();
                 anyhow::bail!("Failed to retrieve HackRF device list.");
             }
 
             let list = &*list_ptr;
             let count = list.devicecount as usize;
             if count == 0 {
-                hackrf_device_list_free(list_ptr);
-                hackrf_exit();
+                (api.hackrf_device_list_free)(list_ptr);
+                (api.hackrf_exit)();
                 anyhow::bail!("No HackRF device found. Please connect your device and try again.");
             }
             if index >= count {
-                hackrf_device_list_free(list_ptr);
-                hackrf_exit();
+                (api.hackrf_device_list_free)(list_ptr);
+                (api.hackrf_exit)();
                 anyhow::bail!(
                     "Device index {} out of range ({} device(s) found).",
                     index,
@@ -232,27 +237,28 @@ impl HackRfDevice {
             }
 
             let mut ptr = std::ptr::null_mut();
-            let res = hackrf_device_list_open(list_ptr, index as c_int, &mut ptr);
-            hackrf_device_list_free(list_ptr);
-            if res != 0 {
-                let err = CStr::from_ptr(hackrf_error_name(res)).to_string_lossy();
-                hackrf_exit();
+            let res = (api.hackrf_device_list_open)(list_ptr, index as c_int, &mut ptr);
+            (api.hackrf_device_list_free)(list_ptr);
+            if res != 0 || ptr.is_null() {
+                let err = CStr::from_ptr((api.hackrf_error_name)(res)).to_string_lossy();
+                (api.hackrf_exit)();
                 anyhow::bail!("Failed to open HackRF device: {} (code {})", err, res);
             }
 
-            let board_id = read_board_id(ptr).unwrap_or(0);
+            let board_id = read_board_id(api, ptr).unwrap_or(0);
             let info = DeviceInfo {
-                board_name: read_board_name(board_id),
-                serial: read_serial(ptr).unwrap_or_else(|| "unknown".into()),
-                fw_version: read_version(ptr),
-                board_rev: read_board_rev(ptr),
-                usb_api_version: read_usb_api(ptr),
+                board_name: read_board_name(api, board_id),
+                serial: read_serial(api, ptr).unwrap_or_else(|| "unknown".into()),
+                fw_version: read_version(api, ptr),
+                board_rev: read_board_rev(api, ptr),
+                usb_api_version: read_usb_api(api, ptr),
                 tuner_name: None,
                 // A HackRF reports its own firmware, so the header shows that.
                 stack: None,
             };
 
             Ok(Self {
+                api,
                 ptr,
                 caps: caps(),
                 info,
@@ -266,14 +272,26 @@ impl HackRfDevice {
 /// enumeration errors (returns an empty list) - the caller unions backends and
 /// reports "no device" only when every backend is empty.
 pub fn list() -> Vec<DeviceListing> {
+    let api = match api() {
+        Ok(api) => api,
+        Err(err) => {
+            static LOG: std::sync::Once = std::sync::Once::new();
+            LOG.call_once(|| eprintln!("{err}"));
+            return Vec::new();
+        }
+    };
+    list_with_api(api)
+}
+
+fn list_with_api(api: &HackrfApi) -> Vec<DeviceListing> {
     let mut out = Vec::new();
     unsafe {
-        if hackrf_init() != 0 {
+        if (api.hackrf_init)() != 0 {
             return out;
         }
-        let list_ptr = hackrf_device_list();
+        let list_ptr = (api.hackrf_device_list)();
         if list_ptr.is_null() {
-            hackrf_exit();
+            (api.hackrf_exit)();
             return out;
         }
         let list = &*list_ptr;
@@ -299,8 +317,8 @@ pub fn list() -> Vec<DeviceListing> {
                 });
             }
         }
-        hackrf_device_list_free(list_ptr);
-        hackrf_exit();
+        (api.hackrf_device_list_free)(list_ptr);
+        (api.hackrf_exit)();
     }
     out
 }
@@ -362,13 +380,13 @@ pub fn caps() -> DeviceCapabilities {
 
 // ── Metadata readers (open-time only) ─────────────────────────────────────────
 
-unsafe fn read_board_id(ptr: *mut c_void) -> Option<u8> {
+unsafe fn read_board_id(api: &HackrfApi, ptr: *mut c_void) -> Option<u8> {
     let mut id = 0u8;
-    (hackrf_board_id_read(ptr, &mut id) == 0).then_some(id)
+    ((api.hackrf_board_id_read)(ptr, &mut id) == 0).then_some(id)
 }
 
-unsafe fn read_board_name(id: u8) -> String {
-    let p = hackrf_board_id_name(id);
+unsafe fn read_board_name(api: &HackrfApi, id: u8) -> String {
+    let p = (api.hackrf_board_id_name)(id);
     if p.is_null() {
         "Unknown".to_string()
     } else {
@@ -376,36 +394,36 @@ unsafe fn read_board_name(id: u8) -> String {
     }
 }
 
-unsafe fn read_version(ptr: *mut c_void) -> Option<String> {
+unsafe fn read_version(api: &HackrfApi, ptr: *mut c_void) -> Option<String> {
     // u8 buffer + .cast() so the pointer converts to *mut c_char on both glibc
     // (c_char = i8) and Android Bionic (c_char = u8).
     let mut buf = [0u8; 64];
-    (hackrf_version_string_read(ptr, buf.as_mut_ptr().cast(), 63) == 0).then(|| {
+    ((api.hackrf_version_string_read)(ptr, buf.as_mut_ptr().cast(), 63) == 0).then(|| {
         CStr::from_ptr(buf.as_ptr().cast())
             .to_string_lossy()
             .into_owned()
     })
 }
 
-unsafe fn read_serial(ptr: *mut c_void) -> Option<String> {
+unsafe fn read_serial(api: &HackrfApi, ptr: *mut c_void) -> Option<String> {
     let mut data = ReadPartidSerialno {
         part_id: [0; 2],
         serial_no: [0; 4],
     };
-    (hackrf_board_partid_serialno_read(ptr, &mut data) == 0).then(|| {
+    ((api.hackrf_board_partid_serialno_read)(ptr, &mut data) == 0).then(|| {
         let s = data.serial_no;
         format!("{:08x}{:08x}{:08x}{:08x}", s[0], s[1], s[2], s[3])
     })
 }
 
-unsafe fn read_board_rev(ptr: *mut c_void) -> Option<u8> {
+unsafe fn read_board_rev(api: &HackrfApi, ptr: *mut c_void) -> Option<u8> {
     let mut rev = 0u8;
-    (hackrf_board_rev_read(ptr, &mut rev) == 0).then_some(rev)
+    ((api.hackrf_board_rev_read)(ptr, &mut rev) == 0).then_some(rev)
 }
 
-unsafe fn read_usb_api(ptr: *mut c_void) -> Option<u16> {
+unsafe fn read_usb_api(api: &HackrfApi, ptr: *mut c_void) -> Option<u16> {
     let mut ver = 0u16;
-    (hackrf_usb_api_version_read(ptr, &mut ver) == 0).then_some(ver)
+    ((api.hackrf_usb_api_version_read)(ptr, &mut ver) == 0).then_some(ver)
 }
 
 /// Maps a HackRF board-revision code to a human label.
@@ -440,7 +458,124 @@ pub fn compute_bb_filter_bw(sample_rate_hz: f64) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_support::TestLibrary;
     use super::*;
+
+    #[test]
+    fn loader_rejects_missing_required_symbol() {
+        let fixture = TestLibrary::new(true);
+        let err = match super::super::loader::load("libhackrf", &[fixture.path()], ffi::resolve) {
+            Ok(_) => panic!("accepted an incomplete libhackrf"),
+            Err(err) => err,
+        };
+        assert!(err.contains(fixture.path()));
+        assert!(err.contains("missing required symbol hackrf_usb_api_version_read"));
+    }
+
+    #[test]
+    fn loaded_api_owns_its_library() {
+        let fixture = TestLibrary::new(false);
+        let incompatible = TestLibrary::new(true);
+        let api = super::super::loader::load(
+            "libhackrf",
+            &[
+                "/sdrtop-nonexistent-test-directory/libmissing.so",
+                incompatible.path(),
+                fixture.path(),
+            ],
+            ffi::resolve,
+        )
+        .unwrap();
+        drop(fixture);
+        assert_eq!(unsafe { (api.hackrf_init)() }, 0);
+        assert_eq!(unsafe { (api.hackrf_exit)() }, 0);
+    }
+
+    #[test]
+    fn discovery_uses_hackrf_count_and_balances_initialization() {
+        let fixture = TestLibrary::new(false);
+        assert_eq!(
+            std::mem::size_of::<HackrfDeviceList>(),
+            fixture.list_layout(0)
+        );
+        assert_eq!(
+            std::mem::offset_of!(HackrfDeviceList, usb_device_index),
+            fixture.list_layout(1)
+        );
+        assert_eq!(
+            std::mem::offset_of!(HackrfDeviceList, devicecount),
+            fixture.list_layout(2)
+        );
+        assert_eq!(
+            std::mem::offset_of!(HackrfDeviceList, usb_devices),
+            fixture.list_layout(3)
+        );
+        assert_eq!(
+            std::mem::offset_of!(HackrfDeviceList, usb_devicecount),
+            fixture.list_layout(4)
+        );
+        let api = ffi::resolve(fixture.library()).unwrap();
+        let devices = list_with_api(&api);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].index, 0);
+        assert_eq!(
+            devices[0].serial.as_deref(),
+            Some("0000000000000000123456789abcdef0")
+        );
+        assert_eq!(fixture.calls(0), 1);
+        assert_eq!(fixture.calls(1), 1);
+        assert_eq!(fixture.calls(2), 1);
+    }
+
+    #[test]
+    fn open_errors_release_lists_and_initialized_library() {
+        let fixture = TestLibrary::new(false);
+        let api = Box::leak(Box::new(ffi::resolve(fixture.library()).unwrap()));
+        for (mode, message, exits, freed) in [
+            (1, "Failed to initialize", 0, 0),
+            (2, "Failed to retrieve", 1, 0),
+            (3, "No HackRF device found", 2, 1),
+            (4, "Failed to open HackRF", 3, 2),
+            (5, "Failed to open HackRF", 4, 3),
+        ] {
+            fixture.mode(mode);
+            let err = match HackRfDevice::open_with_api(api, 0) {
+                Ok(_) => panic!("accepted failing mode {mode}"),
+                Err(err) => err,
+            };
+            assert!(err.to_string().contains(message), "{err}");
+            assert_eq!(fixture.calls(1), exits);
+            assert_eq!(fixture.calls(2), freed);
+        }
+        fixture.mode(0);
+        assert!(HackRfDevice::open_with_api(api, 1).is_err());
+        assert_eq!(fixture.calls(1), 5);
+        assert_eq!(fixture.calls(2), 4);
+        assert_eq!(fixture.calls(3), 0);
+    }
+
+    #[test]
+    fn loaded_device_preserves_optional_metadata_and_control_errors() {
+        let fixture = TestLibrary::new(false);
+        let api = Box::leak(Box::new(ffi::resolve(fixture.library()).unwrap()));
+        let device = HackRfDevice::open_with_api(api, 0).unwrap();
+        assert_eq!(device.info().board_name, "Fixture HackRF");
+        assert_eq!(device.info().fw_version, None);
+        assert_eq!(device.info().board_rev, None);
+        assert_eq!(device.info().usb_api_version, None);
+        let rate = device.set_sample_rate(10_000_000.0).unwrap();
+        assert_eq!(rate.rate_hz, 10_000_000.0);
+        assert_eq!(rate.bb_filter_hz, 10_000_000);
+        fixture.mode(6);
+        assert!(device.set_sample_rate(10_000_000.0).is_err());
+        assert!(device.set_frequency(100_000_000).is_err());
+        assert!(device.set_lna_gain(8).is_err());
+        assert!(device.set_vga_gain(2).is_err());
+        assert!(device.set_amp_enable(true).is_err());
+        drop(device);
+        assert_eq!(fixture.calls(3), 1);
+        assert_eq!(fixture.calls(1), 1);
+    }
 
     #[test]
     fn drop_detection_arithmetic() {

--- a/src/hardware/native/hackrf/mod.rs
+++ b/src/hardware/native/hackrf/mod.rs
@@ -198,9 +198,9 @@ impl Drop for HackRfDevice {
 // ── Open / enumerate ─────────────────────────────────────────────────────────
 
 impl HackRfDevice {
-    /// Opens the HackRF at `index` and reads its metadata once. Only a failed
-    /// libhackrf open fails here; missing optional metadata reads degrade to
-    /// fallbacks rather than aborting (so a quirky unit still comes up).
+    /// Opens the HackRF at `index` and reads its metadata once.
+    /// The library must export every required symbol. Firmware metadata read
+    /// failures leave the corresponding fields unavailable.
     pub fn open(index: usize) -> anyhow::Result<Self> {
         Self::open_with_api(api()?, index)
     }
@@ -272,13 +272,8 @@ impl HackRfDevice {
 /// enumeration errors (returns an empty list) - the caller unions backends and
 /// reports "no device" only when every backend is empty.
 pub fn list() -> Vec<DeviceListing> {
-    let api = match api() {
-        Ok(api) => api,
-        Err(err) => {
-            static LOG: std::sync::Once = std::sync::Once::new();
-            LOG.call_once(|| eprintln!("{err}"));
-            return Vec::new();
-        }
+    let Ok(api) = api() else {
+        return Vec::new();
     };
     list_with_api(api)
 }
@@ -386,7 +381,7 @@ unsafe fn read_board_id(api: &HackrfApi, ptr: *mut c_void) -> Option<u8> {
 }
 
 unsafe fn read_board_name(api: &HackrfApi, id: u8) -> String {
-    let p = (api.hackrf_board_id_name)(id);
+    let p = (api.hackrf_board_id_name)(c_int::from(id));
     if p.is_null() {
         "Unknown".to_string()
     } else {

--- a/src/hardware/native/loader.rs
+++ b/src/hardware/native/loader.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use libloading::Library;
+
+pub(super) fn load<T>(
+    backend: &str,
+    candidates: &[&str],
+    resolve: fn(Library) -> Result<T, String>,
+) -> Result<T, String> {
+    let mut errors = Vec::new();
+    for name in candidates {
+        // The names come from the backend's fixed library list
+        let result = unsafe { Library::new(name) }
+            .map_err(|err| err.to_string())
+            .and_then(resolve);
+        match result {
+            Ok(api) => return Ok(api),
+            Err(err) => errors.push(format!("{name}: {err}")),
+        }
+    }
+    Err(format!(
+        "{backend} backend unavailable. Install a compatible {backend} runtime library. Tried: {}",
+        errors.join("; ")
+    ))
+}
+
+/// The caller must use the symbol's C ABI type
+pub(super) unsafe fn symbol<T: Copy>(lib: &Library, name: &'static [u8]) -> Result<T, String> {
+    unsafe { lib.get::<T>(name) }
+        .map(|symbol| *symbol)
+        .map_err(|err| {
+            format!(
+                "missing required symbol {}: {err}",
+                String::from_utf8_lossy(name).trim_end_matches('\0')
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_library_reports_backend_and_candidate() {
+        let name = "/sdrtop-nonexistent-test-directory/libmissing.so";
+        let err = load("test", &[name], |_| Ok(())).unwrap_err();
+        assert!(err.contains("test backend unavailable"));
+        assert!(err.contains(name));
+    }
+}

--- a/src/hardware/native/mod.rs
+++ b/src/hardware/native/mod.rs
@@ -19,3 +19,13 @@ pub mod rtlsdr;
 
 #[cfg(test)]
 mod test_support;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[ignore = "requires installed libhackrf and librtlsdr runtimes"]
+    fn installed_native_libraries_resolve() {
+        super::hackrf::ffi::api().expect("the installed libhackrf must resolve");
+        super::rtlsdr::ffi::api().expect("the installed librtlsdr must resolve");
+    }
+}

--- a/src/hardware/native/mod.rs
+++ b/src/hardware/native/mod.rs
@@ -4,7 +4,7 @@
 //! The backends sdrtop drives itself: HackRF One and RTL-SDR.
 //!
 //! Each is a thin FFI wrapper ([`hackrf::ffi`], [`rtlsdr::ffi`]) plus a device
-//! struct, linked at build time and described from its own datasheet. What they
+//! struct, loaded at runtime and described from its own datasheet. What they
 //! have in common is that **support here lands only after physical testing**,
 //! which is what separates them from [`super::soapy`], where that rule is
 //! suspended and replaced.
@@ -14,4 +14,8 @@
 //! [`super::discovery`]'s job.
 
 pub mod hackrf;
+mod loader;
 pub mod rtlsdr;
+
+#[cfg(test)]
+mod test_support;

--- a/src/hardware/native/rtlsdr/ffi.rs
+++ b/src/hardware/native/rtlsdr/ffi.rs
@@ -45,7 +45,12 @@ pub fn api() -> anyhow::Result<&'static RtlSdrApi> {
     static API: OnceLock<Result<RtlSdrApi, String>> = OnceLock::new();
     API.get_or_init(|| load("librtlsdr", CANDIDATES, resolve))
         .as_ref()
-        .map_err(|err| anyhow::anyhow!("{err}"))
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "{err}\nRTL-SDR needs the librtlsdr runtime. \
+                 Install librtlsdr0 on Debian, librtlsdr2 on Ubuntu or rtl-sdr on Arch/Fedora."
+            )
+        })
 }
 
 pub(super) fn resolve(lib: libloading::Library) -> Result<RtlSdrApi, String> {

--- a/src/hardware/native/rtlsdr/ffi.rs
+++ b/src/hardware/native/rtlsdr/ffi.rs
@@ -2,48 +2,74 @@
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
 use libc::{c_char, c_int, c_uchar, c_void};
+use std::sync::OnceLock;
+
+use super::super::loader::{load, symbol};
 
 /// `void (*)(unsigned char *buf, uint32_t len, void *ctx)` - the async read sink.
 pub type RtlSdrReadAsyncCb = extern "C" fn(*mut c_uchar, u32, *mut c_void);
 
-// librtlsdr's `rtlsdr_dev_t` is opaque; carry it as `*mut c_void`.
-extern "C" {
-    pub fn rtlsdr_get_device_count() -> u32;
-    pub fn rtlsdr_get_device_name(index: u32) -> *const c_char;
-    pub fn rtlsdr_get_device_usb_strings(
-        index: u32,
-        manufact: *mut c_char,
-        product: *mut c_char,
-        serial: *mut c_char,
-    ) -> c_int;
-
-    pub fn rtlsdr_open(dev: *mut *mut c_void, index: u32) -> c_int;
-    pub fn rtlsdr_close(dev: *mut c_void) -> c_int;
-
-    pub fn rtlsdr_set_center_freq(dev: *mut c_void, freq: u32) -> c_int;
-    pub fn rtlsdr_set_sample_rate(dev: *mut c_void, rate: u32) -> c_int;
+pub struct RtlSdrApi {
+    // The static API must keep the library mapped through reader-thread cleanup
+    _lib: libloading::Library,
+    pub rtlsdr_get_device_count: unsafe extern "C" fn() -> u32,
+    pub rtlsdr_get_device_name: unsafe extern "C" fn(u32) -> *const c_char,
+    pub rtlsdr_get_device_usb_strings:
+        unsafe extern "C" fn(u32, *mut c_char, *mut c_char, *mut c_char) -> c_int,
+    pub rtlsdr_open: unsafe extern "C" fn(*mut *mut c_void, u32) -> c_int,
+    pub rtlsdr_close: unsafe extern "C" fn(*mut c_void) -> c_int,
+    pub rtlsdr_set_center_freq: unsafe extern "C" fn(*mut c_void, u32) -> c_int,
+    pub rtlsdr_set_sample_rate: unsafe extern "C" fn(*mut c_void, u32) -> c_int,
     /// The rate the device is actually running at: 28.8 MHz over an integer
     /// divider, which is rarely the rate that was asked for. Returns 0 on
     /// failure.
-    pub fn rtlsdr_get_sample_rate(dev: *mut c_void) -> u32;
-
-    /// tuner type: 0 unknown, 1 E4000, 2 FC0012, 3 FC0013, 4 FC2580, 5 R820T, 6 R828D.
-    pub fn rtlsdr_get_tuner_type(dev: *mut c_void) -> c_int;
+    pub rtlsdr_get_sample_rate: unsafe extern "C" fn(*mut c_void) -> u32,
+    pub rtlsdr_get_tuner_type: unsafe extern "C" fn(*mut c_void) -> c_int,
     /// With a null buffer, returns the number of gains; otherwise fills `gains`
     /// (in tenths of a dB) and returns the count.
-    pub fn rtlsdr_get_tuner_gains(dev: *mut c_void, gains: *mut c_int) -> c_int;
-    /// `manual`: 1 = manual gain, 0 = tuner AGC.
-    pub fn rtlsdr_set_tuner_gain_mode(dev: *mut c_void, manual: c_int) -> c_int;
-    /// `gain` in tenths of a dB (e.g. 197 = 19.7 dB), must be one of the table values.
-    pub fn rtlsdr_set_tuner_gain(dev: *mut c_void, gain: c_int) -> c_int;
+    pub rtlsdr_get_tuner_gains: unsafe extern "C" fn(*mut c_void, *mut c_int) -> c_int,
+    /// A mode of 1 selects manual gain. A mode of 0 selects tuner AGC
+    pub rtlsdr_set_tuner_gain_mode: unsafe extern "C" fn(*mut c_void, c_int) -> c_int,
+    /// The gain must be a table value in tenths of a dB
+    pub rtlsdr_set_tuner_gain: unsafe extern "C" fn(*mut c_void, c_int) -> c_int,
+    pub rtlsdr_reset_buffer: unsafe extern "C" fn(*mut c_void) -> c_int,
+    pub rtlsdr_read_async:
+        unsafe extern "C" fn(*mut c_void, RtlSdrReadAsyncCb, *mut c_void, u32, u32) -> c_int,
+    pub rtlsdr_cancel_async: unsafe extern "C" fn(*mut c_void) -> c_int,
+}
 
-    pub fn rtlsdr_reset_buffer(dev: *mut c_void) -> c_int;
-    pub fn rtlsdr_read_async(
-        dev: *mut c_void,
-        cb: RtlSdrReadAsyncCb,
-        ctx: *mut c_void,
-        buf_num: u32,
-        buf_len: u32,
-    ) -> c_int;
-    pub fn rtlsdr_cancel_async(dev: *mut c_void) -> c_int;
+// Ubuntu uses .so.2 for the same C API that Debian packages as .so.0
+const CANDIDATES: &[&str] = &["librtlsdr.so.0", "librtlsdr.so.2", "librtlsdr.so"];
+
+pub fn api() -> anyhow::Result<&'static RtlSdrApi> {
+    static API: OnceLock<Result<RtlSdrApi, String>> = OnceLock::new();
+    API.get_or_init(|| load("librtlsdr", CANDIDATES, resolve))
+        .as_ref()
+        .map_err(|err| anyhow::anyhow!("{err}"))
+}
+
+pub(super) fn resolve(lib: libloading::Library) -> Result<RtlSdrApi, String> {
+    macro_rules! sym {
+        ($name:ident) => {
+            unsafe { symbol(&lib, concat!(stringify!($name), "\0").as_bytes())? }
+        };
+    }
+    Ok(RtlSdrApi {
+        rtlsdr_get_device_count: sym!(rtlsdr_get_device_count),
+        rtlsdr_get_device_name: sym!(rtlsdr_get_device_name),
+        rtlsdr_get_device_usb_strings: sym!(rtlsdr_get_device_usb_strings),
+        rtlsdr_open: sym!(rtlsdr_open),
+        rtlsdr_close: sym!(rtlsdr_close),
+        rtlsdr_set_center_freq: sym!(rtlsdr_set_center_freq),
+        rtlsdr_set_sample_rate: sym!(rtlsdr_set_sample_rate),
+        rtlsdr_get_sample_rate: sym!(rtlsdr_get_sample_rate),
+        rtlsdr_get_tuner_type: sym!(rtlsdr_get_tuner_type),
+        rtlsdr_get_tuner_gains: sym!(rtlsdr_get_tuner_gains),
+        rtlsdr_set_tuner_gain_mode: sym!(rtlsdr_set_tuner_gain_mode),
+        rtlsdr_set_tuner_gain: sym!(rtlsdr_set_tuner_gain),
+        rtlsdr_reset_buffer: sym!(rtlsdr_reset_buffer),
+        rtlsdr_read_async: sym!(rtlsdr_read_async),
+        rtlsdr_cancel_async: sym!(rtlsdr_cancel_async),
+        _lib: lib,
+    })
 }

--- a/src/hardware/native/rtlsdr/mod.rs
+++ b/src/hardware/native/rtlsdr/mod.rs
@@ -53,6 +53,7 @@ unsafe impl Sync for RtlDevice {}
 /// Serializes the fd-2 redirect dance so two control calls on different threads
 /// (e.g. the input handler and the sweep task) can't clobber each other's saved
 /// descriptor and leave stderr pointing at /dev/null permanently.
+#[cfg(not(test))]
 static STDERR_LOCK: Mutex<()> = Mutex::new(());
 
 /// Run `f` with the process's stderr redirected to /dev/null, then restore it.
@@ -63,6 +64,7 @@ static STDERR_LOCK: Mutex<()> = Mutex::new(());
 /// control call is wrapped in this; the long-lived async read is not (it runs on
 /// its own thread). Best-effort: if the redirect can't be set up, `f` runs
 /// unsilenced.
+#[cfg(not(test))]
 fn with_stderr_silenced<R>(f: impl FnOnce() -> R) -> R {
     let _guard = STDERR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     unsafe {
@@ -82,6 +84,11 @@ fn with_stderr_silenced<R>(f: impl FnOnce() -> R) -> R {
         libc::close(saved);
         result
     }
+}
+
+#[cfg(test)]
+fn with_stderr_silenced<R>(f: impl FnOnce() -> R) -> R {
+    f()
 }
 
 // ── Async read callback (our read thread) ─────────────────────────────────────
@@ -301,13 +308,8 @@ impl RtlDevice {
 /// Enumerates connected RTL-SDR dongles. Never fails - returns an empty list
 /// when librtlsdr finds none.
 pub fn list() -> Vec<DeviceListing> {
-    let api = match api() {
-        Ok(api) => api,
-        Err(err) => {
-            static LOG: std::sync::Once = std::sync::Once::new();
-            LOG.call_once(|| eprintln!("{err}"));
-            return Vec::new();
-        }
+    let Ok(api) = api() else {
+        return Vec::new();
     };
     list_with_api(api)
 }
@@ -317,18 +319,14 @@ fn list_with_api(api: &RtlSdrApi) -> Vec<DeviceListing> {
     let count = unsafe { (api.rtlsdr_get_device_count)() };
     for i in 0..count {
         let name = device_name(api, i);
-        let serial = device_serial(api, i).unwrap_or_default();
-        let shown = if serial.is_empty() {
-            format!("#{i}")
-        } else {
-            serial
-        };
+        let serial = device_serial(api, i);
+        let shown = serial.clone().unwrap_or_else(|| format!("#{i}"));
         out.push(DeviceListing {
             kind: DeviceKind::RtlSdr,
             index: i as usize,
             label: format!("RTL-SDR · {} · {}", name, shown),
             args: None,
-            serial: device_serial(api, i),
+            serial,
             path: None,
             tiny_sa_input: None,
         });
@@ -519,6 +517,7 @@ mod tests {
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].index, 0);
         assert_eq!(devices[0].serial.as_deref(), Some("00000001"));
+        assert_eq!(fixture.calls(0), 1, "enumeration reads USB strings once");
         let device = RtlDevice::open_with_api(api, 0).unwrap();
         assert_eq!(device.info().board_name, "Fixture RTL-SDR");
         assert_eq!(device.info().tuner_name.as_deref(), Some("R820T"));

--- a/src/hardware/native/rtlsdr/mod.rs
+++ b/src/hardware/native/rtlsdr/mod.rs
@@ -34,6 +34,7 @@ const RTL_BUF_LEN: u32 = 65_536;
 const RTL_BUF_NUM: u32 = 0;
 
 pub struct RtlDevice {
+    api: &'static RtlSdrApi,
     ptr: *mut c_void,
     caps: DeviceCapabilities,
     info: DeviceInfo,
@@ -114,19 +115,20 @@ impl SdrDevice for RtlDevice {
             return Ok(()); // already streaming
         }
         with_stderr_silenced(|| unsafe {
-            rtlsdr_reset_buffer(self.ptr);
+            (self.api.rtlsdr_reset_buffer)(self.ptr);
         });
 
         // `rtlsdr_read_async` blocks until cancelled, so it gets its own thread.
         // The thread owns `cb_ctx`, keeping the pointer handed to the callback
         // valid for the entire call; `stop_rx` joins before that Arc drops.
         let ptr_usize = self.ptr as usize;
+        let api = self.api;
         let flag = Arc::clone(&self.streaming);
         let cb_ctx = ctx;
         let handle = std::thread::spawn(move || {
             let user = Arc::as_ptr(&cb_ctx) as *mut c_void;
             unsafe {
-                rtlsdr_read_async(
+                (api.rtlsdr_read_async)(
                     ptr_usize as *mut c_void,
                     rtl_rx_callback,
                     user,
@@ -144,7 +146,7 @@ impl SdrDevice for RtlDevice {
 
     fn stop_rx(&self) -> anyhow::Result<()> {
         unsafe {
-            rtlsdr_cancel_async(self.ptr);
+            (self.api.rtlsdr_cancel_async)(self.ptr);
         }
         // Join so the read thread (and the Arc<RxContext> it holds) is fully gone
         // before we return - no callback can fire afterward.
@@ -160,7 +162,9 @@ impl SdrDevice for RtlDevice {
     }
 
     fn set_frequency(&self, hz: u64) -> anyhow::Result<()> {
-        let res = with_stderr_silenced(|| unsafe { rtlsdr_set_center_freq(self.ptr, hz as u32) });
+        let res = with_stderr_silenced(|| unsafe {
+            (self.api.rtlsdr_set_center_freq)(self.ptr, hz as u32)
+        });
         if res != 0 {
             anyhow::bail!("Failed to set RTL-SDR frequency");
         }
@@ -179,11 +183,13 @@ impl SdrDevice for RtlDevice {
     /// No baseband filter on this radio, so the width is zero rather than a
     /// number that would have to mean something.
     fn set_sample_rate(&self, hz: f64) -> anyhow::Result<RateSet> {
-        let res = with_stderr_silenced(|| unsafe { rtlsdr_set_sample_rate(self.ptr, hz as u32) });
+        let res = with_stderr_silenced(|| unsafe {
+            (self.api.rtlsdr_set_sample_rate)(self.ptr, hz as u32)
+        });
         if res != 0 {
             anyhow::bail!("Failed to set RTL-SDR sample rate");
         }
-        let got = with_stderr_silenced(|| unsafe { rtlsdr_get_sample_rate(self.ptr) });
+        let got = with_stderr_silenced(|| unsafe { (self.api.rtlsdr_get_sample_rate)(self.ptr) });
         Ok(RateSet::new(hz, Some(got as f64), 0))
     }
 
@@ -199,8 +205,8 @@ impl SdrDevice for RtlDevice {
             .unwrap_or(target);
         // Force manual gain mode, then set the nearest table value (both chatter).
         let res = with_stderr_silenced(|| unsafe {
-            rtlsdr_set_tuner_gain_mode(self.ptr, 1);
-            rtlsdr_set_tuner_gain(self.ptr, nearest)
+            (self.api.rtlsdr_set_tuner_gain_mode)(self.ptr, 1);
+            (self.api.rtlsdr_set_tuner_gain)(self.ptr, nearest)
         });
         if res != 0 {
             anyhow::bail!("Failed to set RTL-SDR tuner gain");
@@ -211,7 +217,7 @@ impl SdrDevice for RtlDevice {
     /// Tuner AGC: on → automatic gain (mode 0), off → manual (mode 1).
     fn set_tuner_agc(&self, on: bool) -> anyhow::Result<()> {
         let res = with_stderr_silenced(|| unsafe {
-            rtlsdr_set_tuner_gain_mode(self.ptr, if on { 0 } else { 1 })
+            (self.api.rtlsdr_set_tuner_gain_mode)(self.ptr, if on { 0 } else { 1 })
         });
         if res != 0 {
             anyhow::bail!("Failed to set RTL-SDR tuner AGC");
@@ -224,14 +230,14 @@ impl Drop for RtlDevice {
     fn drop(&mut self) {
         if self.streaming.load(Ordering::SeqCst) {
             unsafe {
-                rtlsdr_cancel_async(self.ptr);
-            }
-            if let Some(h) = self.thread.lock().unwrap_or_else(|e| e.into_inner()).take() {
-                let _ = h.join();
+                (self.api.rtlsdr_cancel_async)(self.ptr);
             }
         }
+        if let Some(h) = self.thread.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            let _ = h.join();
+        }
         unsafe {
-            rtlsdr_close(self.ptr);
+            (self.api.rtlsdr_close)(self.ptr);
         }
     }
 }
@@ -240,19 +246,23 @@ impl Drop for RtlDevice {
 
 impl RtlDevice {
     pub fn open(index: usize) -> anyhow::Result<Self> {
+        Self::open_with_api(api()?, index)
+    }
+
+    fn open_with_api(api: &'static RtlSdrApi, index: usize) -> anyhow::Result<Self> {
         let mut ptr: *mut c_void = std::ptr::null_mut();
         // Open + tuner probe print kernel-driver / tuner lines to stderr; silence
         // them so they don't corrupt the TUI we've already switched into.
         let (res, tuner, gains_tenths) = with_stderr_silenced(|| {
-            let res = unsafe { rtlsdr_open(&mut ptr, index as u32) };
+            let res = unsafe { (api.rtlsdr_open)(&mut ptr, index as u32) };
             if res != 0 || ptr.is_null() {
                 return (res, 0, Vec::new());
             }
-            let tuner = unsafe { rtlsdr_get_tuner_type(ptr) };
-            let gains = unsafe { read_tuner_gains(ptr) };
+            let tuner = unsafe { (api.rtlsdr_get_tuner_type)(ptr) };
+            let gains = unsafe { read_tuner_gains(api, ptr) };
             // Default to manual gain so the gain controls take effect immediately.
             unsafe {
-                rtlsdr_set_tuner_gain_mode(ptr, 1);
+                (api.rtlsdr_set_tuner_gain_mode)(ptr, 1);
             }
             (res, tuner, gains)
         });
@@ -261,8 +271,8 @@ impl RtlDevice {
         }
 
         let info = DeviceInfo {
-            board_name: device_name(index as u32),
-            serial: device_serial(index as u32).unwrap_or_else(|| format!("rtlsdr-{index}")),
+            board_name: device_name(api, index as u32),
+            serial: device_serial(api, index as u32).unwrap_or_else(|| format!("rtlsdr-{index}")),
             fw_version: None,
             board_rev: None,
             usb_api_version: None,
@@ -277,6 +287,7 @@ impl RtlDevice {
         };
 
         Ok(Self {
+            api,
             ptr,
             caps: rtl_caps(tuner, &gains_tenths),
             info,
@@ -290,11 +301,23 @@ impl RtlDevice {
 /// Enumerates connected RTL-SDR dongles. Never fails - returns an empty list
 /// when librtlsdr finds none.
 pub fn list() -> Vec<DeviceListing> {
+    let api = match api() {
+        Ok(api) => api,
+        Err(err) => {
+            static LOG: std::sync::Once = std::sync::Once::new();
+            LOG.call_once(|| eprintln!("{err}"));
+            return Vec::new();
+        }
+    };
+    list_with_api(api)
+}
+
+fn list_with_api(api: &RtlSdrApi) -> Vec<DeviceListing> {
     let mut out = Vec::new();
-    let count = unsafe { rtlsdr_get_device_count() };
+    let count = unsafe { (api.rtlsdr_get_device_count)() };
     for i in 0..count {
-        let name = device_name(i);
-        let serial = device_serial(i).unwrap_or_default();
+        let name = device_name(api, i);
+        let serial = device_serial(api, i).unwrap_or_default();
         let shown = if serial.is_empty() {
             format!("#{i}")
         } else {
@@ -305,7 +328,7 @@ pub fn list() -> Vec<DeviceListing> {
             index: i as usize,
             label: format!("RTL-SDR · {} · {}", name, shown),
             args: None,
-            serial: device_serial(i),
+            serial: device_serial(api, i),
             path: None,
             tiny_sa_input: None,
         });
@@ -398,13 +421,13 @@ fn rtl_caps(tuner: c_int, gains_tenths: &[i32]) -> DeviceCapabilities {
     }
 }
 
-unsafe fn read_tuner_gains(ptr: *mut c_void) -> Vec<i32> {
-    let n = rtlsdr_get_tuner_gains(ptr, std::ptr::null_mut());
+unsafe fn read_tuner_gains(api: &RtlSdrApi, ptr: *mut c_void) -> Vec<i32> {
+    let n = (api.rtlsdr_get_tuner_gains)(ptr, std::ptr::null_mut());
     if n <= 0 {
         return Vec::new();
     }
     let mut buf = vec![0i32; n as usize];
-    let got = rtlsdr_get_tuner_gains(ptr, buf.as_mut_ptr());
+    let got = (api.rtlsdr_get_tuner_gains)(ptr, buf.as_mut_ptr());
     if got <= 0 {
         return Vec::new();
     }
@@ -412,9 +435,9 @@ unsafe fn read_tuner_gains(ptr: *mut c_void) -> Vec<i32> {
     buf
 }
 
-fn device_name(index: u32) -> String {
+fn device_name(api: &RtlSdrApi, index: u32) -> String {
     unsafe {
-        let p = rtlsdr_get_device_name(index);
+        let p = (api.rtlsdr_get_device_name)(index);
         if p.is_null() {
             "RTL-SDR".to_string()
         } else {
@@ -423,7 +446,7 @@ fn device_name(index: u32) -> String {
     }
 }
 
-fn device_serial(index: u32) -> Option<String> {
+fn device_serial(api: &RtlSdrApi, index: u32) -> Option<String> {
     // `libc::c_char` is `i8` on x86_64 but `u8` on ARM Linux; tying the buffer
     // element type to it keeps `.as_ptr()` matching the FFI's `*mut c_char`
     // (and `CStr::from_ptr`'s `*const c_char`) on every platform.
@@ -431,7 +454,7 @@ fn device_serial(index: u32) -> Option<String> {
     let mut product = [0 as libc::c_char; 256];
     let mut serial = [0 as libc::c_char; 256];
     unsafe {
-        if rtlsdr_get_device_usb_strings(
+        if (api.rtlsdr_get_device_usb_strings)(
             index,
             manufact.as_mut_ptr(),
             product.as_mut_ptr(),
@@ -466,7 +489,82 @@ fn tuner_name(tuner: c_int) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_support::TestLibrary;
     use super::*;
+
+    #[test]
+    fn loader_rejects_missing_required_symbol() {
+        let fixture = TestLibrary::new(true);
+        let err = match super::super::loader::load("librtlsdr", &[fixture.path()], ffi::resolve) {
+            Ok(_) => panic!("accepted an incomplete librtlsdr"),
+            Err(err) => err,
+        };
+        assert!(err.contains(fixture.path()));
+        assert!(err.contains("missing required symbol rtlsdr_cancel_async"));
+    }
+
+    #[test]
+    fn loaded_api_owns_its_library() {
+        let fixture = TestLibrary::new(false);
+        let api = ffi::resolve(fixture.library()).unwrap();
+        drop(fixture);
+        assert_eq!(unsafe { (api.rtlsdr_get_device_count)() }, 1);
+    }
+
+    #[test]
+    fn loaded_device_preserves_discovery_metadata_and_control_errors() {
+        let fixture = TestLibrary::new(false);
+        let api = Box::leak(Box::new(ffi::resolve(fixture.library()).unwrap()));
+        let devices = list_with_api(api);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].index, 0);
+        assert_eq!(devices[0].serial.as_deref(), Some("00000001"));
+        let device = RtlDevice::open_with_api(api, 0).unwrap();
+        assert_eq!(device.info().board_name, "Fixture RTL-SDR");
+        assert_eq!(device.info().tuner_name.as_deref(), Some("R820T"));
+        assert_eq!(device.gains_tenths, vec![0, 197, 496]);
+        let rate = device.set_sample_rate(2_400_000.0).unwrap();
+        assert_eq!(rate.rate_hz, 2_399_999.0);
+        assert_eq!(rate.bb_filter_hz, 0);
+        fixture.mode(6);
+        assert!(device.set_sample_rate(2_400_000.0).is_err());
+        assert!(device.set_frequency(100_000_000).is_err());
+        assert!(device.set_lna_gain(20).is_err());
+        assert!(device.set_tuner_agc(true).is_err());
+        drop(device);
+        assert_eq!(fixture.calls(3), 1);
+    }
+
+    #[test]
+    fn open_rejects_error_and_null_handles() {
+        let fixture = TestLibrary::new(false);
+        let api = Box::leak(Box::new(ffi::resolve(fixture.library()).unwrap()));
+        for mode in [4, 5] {
+            fixture.mode(mode);
+            let err = match RtlDevice::open_with_api(api, 0) {
+                Ok(_) => panic!("accepted failing mode {mode}"),
+                Err(err) => err,
+            };
+            assert!(err.to_string().contains("Failed to open RTL-SDR device"));
+        }
+        assert_eq!(fixture.calls(3), 0);
+    }
+
+    #[test]
+    fn drop_joins_reader_even_after_streaming_flag_clears() {
+        let fixture = TestLibrary::new(false);
+        let api = Box::leak(Box::new(ffi::resolve(fixture.library()).unwrap()));
+        let device = RtlDevice::open_with_api(api, 0).unwrap();
+        let finished = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&finished);
+        *device.thread.lock().unwrap() = Some(std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            flag.store(true, Ordering::SeqCst);
+        }));
+        drop(device);
+        assert!(finished.load(Ordering::SeqCst));
+        assert_eq!(fixture.calls(3), 1);
+    }
 
     #[test]
     fn caps_round_and_dedupe_gain_steps() {

--- a/src/hardware/native/test_support.rs
+++ b/src/hardware/native/test_support.rs
@@ -77,7 +77,20 @@ impl TestLibrary {
 
 impl Drop for TestLibrary {
     fn drop(&mut self) {
-        std::fs::remove_file(&self.path).unwrap();
-        std::fs::remove_dir(self.path.parent().unwrap()).unwrap();
+        let result = std::fs::remove_file(&self.path)
+            .and_then(|()| std::fs::remove_dir(self.path.parent().unwrap()));
+        if let Err(err) = result {
+            if std::thread::panicking() {
+                eprintln!(
+                    "Could not clean up native fixture {}: {err}",
+                    self.path.display()
+                );
+            } else {
+                panic!(
+                    "Could not clean up native fixture {}: {err}",
+                    self.path.display()
+                );
+            }
+        }
     }
 }

--- a/src/hardware/native/test_support.rs
+++ b/src/hardware/native/test_support.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub(super) struct TestLibrary {
+    path: PathBuf,
+    lib: libloading::Library,
+}
+
+impl TestLibrary {
+    pub fn new(omit_symbol: bool) -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "sdrtop-native-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("libfixture.so");
+        let mut cc = Command::new("cc");
+        cc.args(["-shared", "-fPIC", "-std=c11", "-Wall", "-Werror"]);
+        if omit_symbol {
+            cc.arg("-DOMIT_LAST_SYMBOL");
+        }
+        let output = cc
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/hardware/native/fixtures/library.c"
+            ))
+            .arg("-o")
+            .arg(&path)
+            .output()
+            .expect("the native loader fixture requires the C compiler used to link sdrtop");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let lib = unsafe { libloading::Library::new(&path) }.unwrap();
+        Self { path, lib }
+    }
+
+    pub fn library(&self) -> libloading::Library {
+        unsafe { libloading::Library::new(&self.path) }.unwrap()
+    }
+
+    pub fn path(&self) -> &str {
+        self.path.to_str().unwrap()
+    }
+
+    pub fn mode(&self, mode: i32) {
+        unsafe {
+            self.lib
+                .get::<unsafe extern "C" fn(i32)>(b"fixture_mode\0")
+                .unwrap()(mode);
+        }
+    }
+
+    pub fn calls(&self, slot: i32) -> i32 {
+        unsafe {
+            self.lib
+                .get::<unsafe extern "C" fn(i32) -> i32>(b"fixture_calls\0")
+                .unwrap()(slot)
+        }
+    }
+
+    pub fn list_layout(&self, field: i32) -> usize {
+        unsafe {
+            self.lib
+                .get::<unsafe extern "C" fn(i32) -> usize>(b"fixture_list_layout\0")
+                .unwrap()(field)
+        }
+    }
+}
+
+impl Drop for TestLibrary {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.path).unwrap();
+        std::fs::remove_dir(self.path.parent().unwrap()).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,12 @@ async fn main() -> Result<()> {
         },
     };
 
+    if let Some(kind) = want {
+        if let Err(err) = kind.check_available() {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
     let devices = hardware::list_all_devices(want, soapy_filter.as_deref());
     if devices.is_empty() {
         eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> Result<()> {
     if devices.is_empty() {
         eprintln!(
             "No device found. Connect a HackRF, RTL-SDR, or tinySA and try again.{}",
-            hardware::discovery::no_device_hint()
+            hardware::discovery::no_device_hint(want)
         );
         std::process::exit(1);
     }

--- a/user_docs/getting-started.md
+++ b/user_docs/getting-started.md
@@ -34,12 +34,13 @@ An incompatible architecture or libc triggers a source build through
 
 Runtime installation is opt-in. `--hackrf` adds libhackrf. `--rtlsdr` adds
 librtlsdr. `--soapy` adds SoapySDR and its driver modules. These flags can be
-combined. A plain install adds none of these libraries.
+combined. A plain install of a runtime-loading release adds none of these libraries.
 Missing or incompatible libraries disable only their respective backends.
 
-Before a runtime-loading release is published, the latest-release URL can still
-select an older version that requires native SDR development packages.
-Use `sh install.sh --git` to build `main`. See
+Older releases can require native SDR development packages.
+After a recognized native-link build failure, the installer adds those packages
+and retries the same release once. It never switches to `main`.
+Use `sh install.sh --git` to select `main` explicitly. See
 [older-release build failures](troubleshooting.md#the-build-fails-looking-for-libhackrf).
 
 Runtime package installation is best-effort. Check warnings for packages that
@@ -75,7 +76,7 @@ that list cannot drift out of date the way this page can.
 
 `--deps-only` installs only the runtimes selected by `--hackrf`, `--rtlsdr`
 and `--soapy`. It never installs sdrtop or build tools. Without a runtime flag
-it does nothing.
+it exits with a usage error.
 
 `--no-verify` earns a warning of its own. It turns off the checksum check on a
 download, which is the one thing standing between you and a tarball that isn't
@@ -91,7 +92,8 @@ Everything below is the same job done by hand.
 - **Host:** A Linux machine.
 - **Radio:** A HackRF One, RTL-SDR or a supported SoapySDR device.
 - **Source builds:** Rust 1.88+ and a C compiler/linker. Install Rust with
-  [rustup](https://rustup.rs). No SDR development headers or pkg-config are needed.
+  [rustup](https://rustup.rs). Runtime-loading releases need no SDR development
+  headers or pkg-config. Older releases can require both native development libraries.
 - **Runtime:** Install only the library for the backend you use.
 
 Build tools by distribution:

--- a/user_docs/getting-started.md
+++ b/user_docs/getting-started.md
@@ -12,48 +12,38 @@ If you already have Rust, this is the whole thing:
 cargo install sdrtop --locked
 ```
 
-sdrtop is on [crates.io](https://crates.io/crates/sdrtop), so cargo compiles it
-on your machine and links whatever your machine actually has. Works on every
-architecture and every distribution. You still need the two libraries first,
-which is the "What you need" section below.
+sdrtop is on [crates.io](https://crates.io/crates/sdrtop). Building needs Rust
+1.88+ and a C compiler/linker. Native SDR libraries are optional at runtime.
 
 ## The shorter way, if you don't want to think about it
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/musithang/sdrtop/main/packaging/install.sh | sh
 
+# Install the runtime for a HackRF
+curl -fsSL https://raw.githubusercontent.com/musithang/sdrtop/main/packaging/install.sh | sh -s -- --hackrf
+
 # ...and with SoapySDR, if you have an Airspy, an RSP, a Pluto or a Lime
 curl -fsSL https://raw.githubusercontent.com/musithang/sdrtop/main/packaging/install.sh | sh -s -- --soapy
 ```
 
-The installer covers everything the rest of this page describes: it finds your
-package manager, installs the two libraries under whatever names your
-distribution gives them, and puts sdrtop into `/usr/local/bin` (or `~/.local`
-with `--prefix` if you would rather not use root). Then it runs the result to
-prove it works.
+The installer puts sdrtop into `/usr/local/bin`. Use `--prefix ~/.local` for
+a user-local install. It runs the binary to check compatibility with your machine.
+An incompatible architecture or libc triggers a source build through
+`cargo install sdrtop --locked`.
 
-It uses the prebuilt binary only when that binary can run on your machine, and
-it decides that by **running it**, not by guessing from your distribution's
-name. When it cannot, on a Raspberry Pi or on Ubuntu and Mint, which package the
-exact same `librtlsdr` as Debian under a different soname because of course they
-do, it makes sure Rust is present and hands over to `cargo install sdrtop
---locked` instead. That takes a few minutes and needs no
-decisions from you.
+Runtime installation is opt-in. `--hackrf` adds libhackrf. `--rtlsdr` adds
+librtlsdr. `--soapy` adds SoapySDR and its driver modules. These flags can be
+combined. A plain install adds none of these libraries. tinySA needs none of them.
+Missing or incompatible libraries disable only their respective backends.
 
-**SoapySDR is not installed unless you ask.** sdrtop opens it at runtime and
-works perfectly well without it, so a plain run leaves it alone and just tells
-you at the end whether you have it and what it would buy you. `--soapy` adds the
-library and the driver modules your distribution ships. If your distribution's
-packages are named something this script has not heard of, it says so rather
-than failing, and the fix is one line in
-[`packaging/install.sh`](https://github.com/musithang/sdrtop/blob/main/packaging/install.sh)
-plus an issue so I can correct it for everyone else.
+Runtime package installation is best-effort. Check warnings for packages that
+could not be installed. The runtime package lists fall back to development
+packages on some distributions. Those packages include the runtime library.
 
-What it does **not** do is set up device permissions. It reports on them, and
-that is deliberate: the `libhackrf` and `rtl-sdr` packages ship their own udev
-rules, so installing the libraries is what grants access. If your radio still
-needs root afterwards, [troubleshooting](troubleshooting.md#permission-denied)
-has the fix.
+The installer uses distribution packages for native SDR udev rules. It reports
+device-access advice when `--hackrf` or `--rtlsdr` is selected. See
+[troubleshooting](troubleshooting.md#permission-denied) for access problems.
 
 Read it before you pipe it into a shell if you like:
 [`packaging/install.sh`](https://github.com/musithang/sdrtop/blob/main/packaging/install.sh).
@@ -66,8 +56,10 @@ sh install.sh --version v0.4.1      # a specific release instead of the latest
 sh install.sh --from-source         # skip the prebuilt binary, always compile
 sh install.sh --git                 # compile the main branch, live dangerously
 sh install.sh --no-verify           # skip the checksum check (say why first)
+sh install.sh --hackrf              # Install the HackRF runtime
+sh install.sh --rtlsdr              # Install the RTL-SDR runtime
 sh install.sh --soapy               # add SoapySDR and its driver modules
-sh install.sh --deps-only           # the libraries and nothing else
+sh install.sh --deps-only --rtlsdr   # Install only the selected runtime
 sh install.sh --uninstall           # remove what a previous run installed
 sh install.sh --help                # this list, from the script itself
 ```
@@ -75,6 +67,10 @@ sh install.sh --help                # this list, from the script itself
 Piped straight into a shell they go after `sh -s --`, the way `--soapy` does
 higher up. `--help` is the authority here: the script prints its own flags, and
 that list cannot drift out of date the way this page can.
+
+`--deps-only` installs only the runtimes selected by `--hackrf`, `--rtlsdr`
+and `--soapy`. It never installs sdrtop or build tools. Without a runtime flag
+it does nothing.
 
 `--no-verify` earns a warning of its own. It turns off the checksum check on a
 download, which is the one thing standing between you and a tarball that isn't
@@ -87,40 +83,55 @@ Everything below is the same job done by hand.
 
 ## What you need
 
-- A Linux machine
-- A HackRF One **or** an RTL-SDR dongle connected via USB
-- The `libhackrf` and `librtlsdr` libraries
-- Rust stable 1.88 or newer. Most distributions ship something older, so
-  install it with [rustup](https://rustup.rs) rather than from your package
-  manager
+- **Host:** A Linux machine.
+- **Radio:** A HackRF One, RTL-SDR, tinySA or a supported SoapySDR device.
+- **Source builds:** Rust 1.88+ and a C compiler/linker. Install Rust with
+  [rustup](https://rustup.rs). No SDR development headers or pkg-config are needed.
+- **Runtime:** Install only the library for the backend you use. tinySA needs
+  neither libhackrf nor librtlsdr.
+
+Build tools by distribution:
 
 ```sh
 # Arch Linux / Manjaro
-sudo pacman -S hackrf rtl-sdr pkgconf
+sudo pacman -S base-devel
 
 # Debian / Ubuntu / Linux Mint / Pop!_OS
-sudo apt install libhackrf-dev librtlsdr-dev pkg-config
+sudo apt install build-essential
 
 # Fedora
-sudo dnf install hackrf-devel rtl-sdr-devel pkgconf-pkg-config
+sudo dnf install gcc
 
 # openSUSE Tumbleweed / Leap
-sudo zypper install libhackrf-devel rtl-sdr-devel pkg-config
+sudo zypper install gcc
 
 # Void Linux
-sudo xbps-install hackrf-devel rtl-sdr-devel pkg-config
+sudo xbps-install base-devel
 
 # Gentoo
-sudo emerge net-wireless/hackrf net-wireless/rtl-sdr
+sudo emerge sys-devel/gcc
 
 # NixOS: add to configuration.nix, or use a dev shell
-nix-shell -p hackrf rtl-sdr pkg-config
+nix-shell -p gcc
 ```
 
-> **Install both libraries even if you only own one radio.** sdrtop links both
-> backends at build time, so a missing `librtlsdr` breaks the build for a HackRF
-> owner and vice versa. At runtime it's perfectly happy with whichever radio you
-> actually plug in.
+Install runtime packages separately for your radio:
+
+| Distribution | HackRF | RTL-SDR |
+|---|---|---|
+| Debian / Kali / Raspberry Pi OS | `libhackrf0` | `librtlsdr0` |
+| Ubuntu / Mint / Pop!_OS | `libhackrf0` | `librtlsdr2` |
+| Arch / Manjaro / Fedora / Void | `hackrf` | `rtl-sdr` |
+| openSUSE | `libhackrf0` | `librtlsdr0` |
+| Alpine | `hackrf-libs`, `hackrf-udev` | `librtlsdr`, `librtlsdr-udev` |
+| Gentoo | `net-wireless/hackrf` | `net-wireless/rtl-sdr` |
+| Nixpkgs | `hackrf` | `rtl-sdr` |
+
+HackRF requires libhackrf 2023.01.1+ with all required symbols. RTL-SDR supports
+`librtlsdr.so.0`, `librtlsdr.so.2` and `librtlsdr.so`. HackRF supports
+`libhackrf.so.0` and `libhackrf.so`. See [hardware](hardware.md#host-platforms)
+for the runtime contract. Custom library locations must be on the dynamic
+loader's search path, for example through `LD_LIBRARY_PATH`.
 
 Rust, if you don't have it:
 
@@ -135,7 +146,7 @@ about `lock file version 4`, that's what happened, and rustup is the fix.
 
 ## Install and run
 
-With the libraries in place, either of these gets you a working `sdrtop`:
+Build and install sdrtop:
 
 ```sh
 # From crates.io, straight onto your PATH
@@ -171,11 +182,10 @@ sha256sum -c <(grep sdrtop- ../SHA256SUMS)   # check it before you trust it
 sudo install -Dm755 sdrtop /usr/local/bin/sdrtop
 ```
 
-It is x86_64 only, and it wants **glibc 2.36 or newer** plus `librtlsdr.so.0`.
-In practice that means Debian 12 and 13, Kali, and Raspberry Pi OS Bookworm.
-Ubuntu and Mint package the identical upstream library as `.so.2`, so it will
-not start there, and a Raspberry Pi is not x86_64 in the first place. On those,
-compile. It is one command, it takes a few minutes, and it always works.
+The tarball needs x86_64 Linux with glibc 2.36+. Debian 12+ and Ubuntu 24.04+
+meet that floor. Both Debian's `librtlsdr.so.0` and Ubuntu's `librtlsdr.so.2`
+are supported at runtime. Neither library is needed to start sdrtop or use
+tinySA. Raspberry Pi, musl-based systems and older glibc systems need a source build.
 
 From 0.4.2 onward every release also carries a signed build provenance
 attestation. The checksum only tells you the download arrived intact. This tells

--- a/user_docs/getting-started.md
+++ b/user_docs/getting-started.md
@@ -34,8 +34,13 @@ An incompatible architecture or libc triggers a source build through
 
 Runtime installation is opt-in. `--hackrf` adds libhackrf. `--rtlsdr` adds
 librtlsdr. `--soapy` adds SoapySDR and its driver modules. These flags can be
-combined. A plain install adds none of these libraries. tinySA needs none of them.
+combined. A plain install adds none of these libraries.
 Missing or incompatible libraries disable only their respective backends.
+
+Before a runtime-loading release is published, the latest-release URL can still
+select an older version that requires native SDR development packages.
+Use `sh install.sh --git` to build `main`. See
+[older-release build failures](troubleshooting.md#the-build-fails-looking-for-libhackrf).
 
 Runtime package installation is best-effort. Check warnings for packages that
 could not be installed. The runtime package lists fall back to development
@@ -84,11 +89,10 @@ Everything below is the same job done by hand.
 ## What you need
 
 - **Host:** A Linux machine.
-- **Radio:** A HackRF One, RTL-SDR, tinySA or a supported SoapySDR device.
+- **Radio:** A HackRF One, RTL-SDR or a supported SoapySDR device.
 - **Source builds:** Rust 1.88+ and a C compiler/linker. Install Rust with
   [rustup](https://rustup.rs). No SDR development headers or pkg-config are needed.
-- **Runtime:** Install only the library for the backend you use. tinySA needs
-  neither libhackrf nor librtlsdr.
+- **Runtime:** Install only the library for the backend you use.
 
 Build tools by distribution:
 
@@ -184,8 +188,8 @@ sudo install -Dm755 sdrtop /usr/local/bin/sdrtop
 
 The tarball needs x86_64 Linux with glibc 2.36+. Debian 12+ and Ubuntu 24.04+
 meet that floor. Both Debian's `librtlsdr.so.0` and Ubuntu's `librtlsdr.so.2`
-are supported at runtime. Neither library is needed to start sdrtop or use
-tinySA. Raspberry Pi, musl-based systems and older glibc systems need a source build.
+are supported at runtime. Neither library is needed to start sdrtop.
+Raspberry Pi, musl-based systems and older glibc systems need a source build.
 
 From 0.4.2 onward every release also carries a signed build provenance
 attestation. The checksum only tells you the download arrived intact. This tells

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -231,10 +231,22 @@ which is the honest answer rather than a guess dressed as two.
 | Raspberry Pi (Pi 2 and newer, 64-bit Raspberry Pi OS Bookworm) | Supported, with lower sample rates on older Pis |
 | ARM / Android (Termux) | Builds and runs; needs a root-capable USB stack to reach the device |
 
-sdrtop needs **libhackrf 2023.01.1 or newer**, which is what ships in Raspberry Pi
-OS Bookworm and Ubuntu 24.04. Older distributions need it built from source. It
-also links **librtlsdr** (`librtlsdr-dev` on Debian and Ubuntu, `rtl-sdr` on
-Arch), and both are needed at build time regardless of which radio you own.
+sdrtop loads libhackrf and librtlsdr at runtime. Neither library is required
+to build sdrtop or use tinySA. A missing or incompatible library disables only
+its backend.
+
+HackRF needs libhackrf 2023.01.1+ with all required symbols, including
+`hackrf_board_rev_read` and `hackrf_usb_api_version_read`. Linux candidates are
+`libhackrf.so.0` and `libhackrf.so`. Firmware metadata reads may fail without
+preventing the device from opening.
+
+RTL-SDR needs librtlsdr with all required symbols. Linux candidates are
+`librtlsdr.so.0`, `librtlsdr.so.2` and `librtlsdr.so`. Runtime packages include
+`librtlsdr0` on Debian, `librtlsdr2` on Ubuntu and `rtl-sdr` on Arch.
+
+Library loading results are cached for the process lifetime. Unavailable-backend
+diagnostics are logged once. Loaded library handles stay open until process exit.
+Restart sdrtop after installing or updating a library.
 
 **libSoapySDR is not needed to build and not needed to run.** It is opened at
 runtime if it happens to be there, which is why the same binary serves people who

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -232,7 +232,7 @@ which is the honest answer rather than a guess dressed as two.
 | ARM / Android (Termux) | Builds and runs; needs a root-capable USB stack to reach the device |
 
 sdrtop loads libhackrf and librtlsdr at runtime. Neither library is required
-to build sdrtop or use tinySA. A missing or incompatible library disables only
+to build sdrtop. A missing or incompatible library disables only
 its backend.
 
 HackRF needs libhackrf 2023.01.1+ with all required symbols, including

--- a/user_docs/hardware.md
+++ b/user_docs/hardware.md
@@ -245,7 +245,9 @@ RTL-SDR needs librtlsdr with all required symbols. Linux candidates are
 `librtlsdr0` on Debian, `librtlsdr2` on Ubuntu and `rtl-sdr` on Arch.
 
 Library loading results are cached for the process lifetime. Unavailable-backend
-diagnostics are logged once. Loaded library handles stay open until process exit.
+diagnostics appear on explicit selection or when automatic discovery finds no devices.
+Successful discovery stays quiet about unused native backends.
+Loaded library handles stay open until process exit.
 Restart sdrtop after installing or updating a library.
 
 **libSoapySDR is not needed to build and not needed to run.** It is opened at

--- a/user_docs/troubleshooting.md
+++ b/user_docs/troubleshooting.md
@@ -42,10 +42,36 @@ sdrtop prints this and exits before the TUI starts.
    dongle something like `Realtek Semiconductor Corp. RTL2838 DVB-T`. If nothing
    appears, the problem is below sdrtop, and no amount of software configuration
    will help.
-3. **If it appears in `lsusb` but sdrtop can't open it**, that's permissions. See
-   below.
-4. **If something else already has it**, sdrtop enters observer mode rather than
+3. **Check the runtime library.** Select `--device hackrf` or `--device rtlsdr`
+   for a diagnostic naming the unavailable library. See below.
+4. **Check device permissions.** See [Permission denied](#permission-denied).
+5. **If something else already has it**, sdrtop enters observer mode rather than
    failing. See [Advanced Features](advanced.md#observer-mode-when-another-app-owns-the-radio).
+
+### A native backend's library is unavailable
+
+```sh
+sdrtop --device hackrf
+sdrtop --device rtlsdr
+```
+
+Explicit selection reports the library and candidate filename that failed.
+A missing-symbol error names the symbol too. Automatic discovery skips only
+the unavailable backend. tinySA remains usable with neither native library.
+Startup discovery diagnostics are printed to stderr before the TUI opens.
+
+1. **Install the selected runtime.** Use `sh install.sh --deps-only --hackrf`
+   or `sh install.sh --deps-only --rtlsdr`. Distribution package names are in
+   [Getting started](getting-started.md#what-you-need).
+2. **Check the filename and search path.** HackRF tries `libhackrf.so.0` and
+   `libhackrf.so`. RTL-SDR tries `librtlsdr.so.0`, `librtlsdr.so.2` and
+   `librtlsdr.so`. Custom installations need a loader search path such as
+   `LD_LIBRARY_PATH`. Installing headers alone does not make a runtime loadable.
+3. **Upgrade an incompatible library.** HackRF needs libhackrf 2023.01.1+
+   with `hackrf_board_rev_read`, `hackrf_usb_api_version_read` and the other
+   required symbols. Firmware metadata read errors remain optional.
+4. **Restart sdrtop.** Load results are cached. Discovery logs an unavailable
+   backend once per process. Loaded handles remain open until process exit.
 
 ### A SoapySDR device doesn't appear
 
@@ -361,15 +387,13 @@ You can also write them by hand; see
 
 Not a failure. That's the installer doing its job.
 
-One prebuilt tarball is published, for x86_64 with glibc 2.36 or newer and
-`librtlsdr.so.0`. Debian, Kali and Raspberry Pi OS Bookworm match that. Ubuntu
-and Mint package the identical upstream library as `.so.2`, and a Raspberry Pi
-isn't x86_64 at all, so on those machines the binary can't start.
+The prebuilt tarball needs x86_64 Linux with glibc 2.36+. Raspberry Pi,
+musl-based systems and older glibc systems need a source build. Ubuntu's
+`librtlsdr.so.2` is supported through runtime loading. Neither libhackrf nor
+librtlsdr is needed for startup.
 
-The installer finds this out by **running the binary** rather than by guessing
-from your distribution's name, prints what `ldd` says is missing, and then
-compiles from source with `cargo install` instead. That links what your machine
-actually has. It takes a few minutes and needs nothing from you.
+The installer runs the binary to check compatibility. A failed check prints
+`ldd` diagnostics and triggers a source build with `cargo install`.
 
 ### "checksum mismatch" or "could not download SHA256SUMS"
 
@@ -393,8 +417,9 @@ which doesn't need it.
 
 ### `cargo install sdrtop` fails on libhackrf
 
-Same cause as the build failure below: both libraries have to be present at
-build time. See [The build fails looking for libhackrf](#the-build-fails-looking-for-libhackrf).
+Current source builds require no native SDR libraries or headers. Check the
+version being installed. Older releases linked both libraries at build time.
+See [The build fails looking for libhackrf](#the-build-fails-looking-for-libhackrf).
 
 ### Which build am I actually running?
 
@@ -427,13 +452,15 @@ the fix is the same command above: `rustup update stable`.
 
 ### The build fails looking for libhackrf
 
-sdrtop links **both** backends at build time, so you need `libhackrf` and
-`librtlsdr` present even if you only own one radio. At runtime it's happy with
-whichever you plug in. Package names per distribution are in
-[Getting Started](getting-started.md).
+Current source builds need Rust 1.88+ and a C compiler/linker. They need no
+libhackrf, librtlsdr, SDR development headers or pkg-config.
 
-libhackrf must be **2023.01.1 or newer**. That's what ships in Raspberry Pi OS
-Bookworm and Ubuntu 24.04; older distributions need it built from source.
+Check whether you selected an older release with `--version`. Those releases
+may still require both development libraries. On Debian or Ubuntu, install
+`libhackrf-dev librtlsdr-dev pkg-config` to build an older release.
+
+For a runtime loading error, follow
+[A native backend's library is unavailable](#a-native-backends-library-is-unavailable).
 
 ---
 

--- a/user_docs/troubleshooting.md
+++ b/user_docs/troubleshooting.md
@@ -57,7 +57,7 @@ sdrtop --device rtlsdr
 
 Explicit selection reports the library and candidate filename that failed.
 A missing-symbol error names the symbol too. Automatic discovery skips only
-the unavailable backend. tinySA remains usable with neither native library.
+the unavailable backend. Other installed backends remain available.
 Startup discovery diagnostics are printed to stderr before the TUI opens.
 
 1. **Install the selected runtime.** Use `sh install.sh --deps-only --hackrf`
@@ -458,6 +458,12 @@ libhackrf, librtlsdr, SDR development headers or pkg-config.
 Check whether you selected an older release with `--version`. Those releases
 may still require both development libraries. On Debian or Ubuntu, install
 `libhackrf-dev librtlsdr-dev pkg-config` to build an older release.
+
+The installer from `main` may also select an older version through the latest
+release URL. It checks downloaded binaries before installation. An old binary
+with missing libraries triggers a source build of that same release.
+Use `sh install.sh --git` to build `main` with runtime loading before the next
+release. A failed build or startup check leaves an existing installation unchanged.
 
 For a runtime loading error, follow
 [A native backend's library is unavailable](#a-native-backends-library-is-unavailable).

--- a/user_docs/troubleshooting.md
+++ b/user_docs/troubleshooting.md
@@ -56,9 +56,13 @@ sdrtop --device rtlsdr
 ```
 
 Explicit selection reports the library and candidate filename that failed.
-A missing-symbol error names the symbol too. Automatic discovery skips only
-the unavailable backend. Other installed backends remain available.
-Startup discovery diagnostics are printed to stderr before the TUI opens.
+A missing-symbol error names the symbol too.
+Errors include runtime package names.
+HackRF errors also state the libhackrf 2023.01.1+ requirement.
+Automatic discovery skips unavailable backends quietly.
+An empty automatic device list reports cached native failures in its error hint.
+Explicit native selection reports failures for that backend only.
+Explicit tinySA or SoapySDR selection produces no native-library diagnostics.
 
 1. **Install the selected runtime.** Use `sh install.sh --deps-only --hackrf`
    or `sh install.sh --deps-only --rtlsdr`. Distribution package names are in
@@ -70,8 +74,8 @@ Startup discovery diagnostics are printed to stderr before the TUI opens.
 3. **Upgrade an incompatible library.** HackRF needs libhackrf 2023.01.1+
    with `hackrf_board_rev_read`, `hackrf_usb_api_version_read` and the other
    required symbols. Firmware metadata read errors remain optional.
-4. **Restart sdrtop.** Load results are cached. Discovery logs an unavailable
-   backend once per process. Loaded handles remain open until process exit.
+4. **Restart sdrtop.** Load results are cached for the process.
+   Loaded handles remain open until process exit.
 
 ### A SoapySDR device doesn't appear
 
@@ -455,15 +459,20 @@ the fix is the same command above: `rustup update stable`.
 Current source builds need Rust 1.88+ and a C compiler/linker. They need no
 libhackrf, librtlsdr, SDR development headers or pkg-config.
 
-Check whether you selected an older release with `--version`. Those releases
-may still require both development libraries. On Debian or Ubuntu, install
-`libhackrf-dev librtlsdr-dev pkg-config` to build an older release.
+Older releases may still require both development libraries.
+The installer recognizes sdrtop's missing-libhackrf `build.rs` panic and native
+linker errors for missing `-lhackrf` or `-lrtlsdr`.
+It installs the distribution's development packages and retries the same
+release once. Unrelated build failures receive no retry.
+On Debian or Ubuntu, the packages are `libhackrf-dev librtlsdr-dev pkg-config`.
+Install these by hand if automatic package installation fails.
 
 The installer from `main` may also select an older version through the latest
 release URL. It checks downloaded binaries before installation. An old binary
 with missing libraries triggers a source build of that same release.
-Use `sh install.sh --git` to build `main` with runtime loading before the next
-release. A failed build or startup check leaves an existing installation unchanged.
+Use `sh install.sh --git` to select `main` explicitly.
+Git builds receive no legacy dependency retry.
+A failed build or startup check leaves an existing installation unchanged.
 
 For a runtime loading error, follow
 [A native backend's library is unavailable](#a-native-backends-library-is-unavailable).


### PR DESCRIPTION
This PR lets tinySA and other backends run without installing libraries for unused SDR hardware. It builds on the tinySA controls merged in #11.

The binary currently links both HackRF and RTL-SDR libraries regardless of the selected device. This forces users to install dependencies for hardware they do not use.

Native libraries now load on demand with actionable errors when needed. The installer preserves older-release compatibility, and the FFI declarations include corrected HackRF argument and device-list layouts. CI runs the full suite with and without native libraries, verifies real installed-library loading and isolated startup, and checks that releases have no native links.

<details>
<summary>Workflow reference</summary>

```mermaid
flowchart TD
  CI["PR or push to main<br/>contents read"] --> FULL["CHANGED: runtime packages only<br/>Full suite and real-library resolution<br/>Checkout credentials not persisted"]
  CI --> MSRV["CHANGED: MSRV check<br/>No native packages"]
  CI --> NONE["NEW: isolated Debian 12<br/>No SDR libraries; no secrets<br/>Checkout credentials not persisted"]
  NONE --> SMOKE["Build and full suite<br/>Isolated HOME for CLI smoke<br/>Verify exit codes and ELF dependencies"]
  T["push v* or workflow_dispatch<br/>No PR trigger"] --> B
  subgraph Build["build: contents read; id-token + attestations write"]
    B["CHANGED: Debian 12 build<br/>No SDR development libraries"] --> A
    A["CHANGED: inspect ELF dependencies<br/>Only libc / libgcc_s / libm"] --> H
    H["Tarball + installer + SHA256SUMS"] --> S
    S["OIDC: Sigstore provenance"] --> U["Upload artifact"]
  end
  U -->|"Job success; tag ref only"| P["CHANGED: publish without SDR packages<br/>contents read; id-token write<br/>OIDC: crates.io token"]
  U -->|"Download artifact"| R
  P -->|"Success; tag ref only"| R
  N["CHANGELOG.md: release notes"] --> R
  R["release: contents write<br/>GITHUB_TOKEN: draft release + assets"]
  classDef changed fill:#fff3cd,stroke:#b58100,stroke-width:3px
  class FULL,MSRV,NONE,SMOKE,A,B,P changed
```

</details>