### PR TITLE
feat(ble): BLE advertising receiver (B1–B9) with real-hardware fixes

### DIFF
--- a/src/app/builder/registry.rs
+++ b/src/app/builder/registry.rs
@@ -81,6 +81,7 @@ impl App {
         registry.register(ui::MicroSweepPanel);
         registry.register(ui::NetCapabilityPanel);
         registry.register(ui::NetBlePacketsPanel);
+        registry.register(ui::NetBtRfPanel);
         registry.register(ui::NetCensusPanel);
         registry.register(ui::NetCoexistPanel);
         registry.register(ui::NetDecodeHealthPanel);

--- a/src/app/builder/registry.rs
+++ b/src/app/builder/registry.rs
@@ -80,6 +80,7 @@ impl App {
         registry.register(ui::SweepStripPanel);
         registry.register(ui::MicroSweepPanel);
         registry.register(ui::NetCapabilityPanel);
+        registry.register(ui::NetBlePacketsPanel);
         registry.register(ui::NetCensusPanel);
         registry.register(ui::NetCoexistPanel);
         registry.register(ui::NetDecodeHealthPanel);

--- a/src/config.rs
+++ b/src/config.rs
@@ -342,6 +342,7 @@ const BUILTIN_PRESETS: &[(&str, &str)] = &[
         "net_coexist",
         include_str!("config/presets/net_coexist.toml"),
     ),
+    ("net_ble", include_str!("config/presets/net_ble.toml")),
     (
         "micro_health",
         include_str!("config/presets/micro_health.toml"),
@@ -534,7 +535,7 @@ panels = [
         // This is what makes `parse_builtin`'s `expect` safe: the text is compiled
         // in, so it cannot differ between here and the shipped binary.
         let cfg = LayoutConfig::default_config();
-        assert_eq!(cfg.presets.len(), 20, "twenty built-ins");
+        assert_eq!(cfg.presets.len(), 21, "twenty-one built-ins");
         assert_eq!(cfg.active_preset, DEFAULT_PRESET);
         for (name, preset) in &cfg.presets {
             assert!(!preset.panels.is_empty(), "{name} lists no panels");
@@ -560,6 +561,7 @@ panels = [
             "net_survey",
             "net_census",
             "net_coexist",
+            "net_ble",
         ] {
             assert!(cfg.presets.contains_key(want), "missing built-in '{want}'");
         }
@@ -599,7 +601,7 @@ panels = [
             "a new name should be added"
         );
         assert_eq!(cfg.presets["nightwatch"].panels.len(), 3);
-        assert_eq!(cfg.presets.len(), 21, "added, not replaced");
+        assert_eq!(cfg.presets.len(), 22, "added, not replaced");
         // And every built-in is still there.
         assert!(cfg.presets.contains_key("lab_signal"));
         let _ = std::fs::remove_dir_all(&dir);
@@ -610,7 +612,7 @@ panels = [
         let dir = presets_dir_with("replace", &[("lab_iq", A_LAYOUT)]);
         let cfg = LayoutConfig::with_user_presets(&HashMap::new(), Some(&dir));
         assert_eq!(cfg.presets["lab_iq"].panels.len(), 3, "the file should win");
-        assert_eq!(cfg.presets.len(), 20, "replaced, not added");
+        assert_eq!(cfg.presets.len(), 21, "replaced, not added");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -669,8 +671,8 @@ panels = [
         assert!(!cfg.presets.contains_key("README"), "only .toml is read");
         assert_eq!(
             cfg.presets.len(),
-            21,
-            "twenty built-ins plus the one good file"
+            22,
+            "twenty-one built-ins plus the one good file"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -681,14 +683,14 @@ panels = [
             LayoutConfig::with_user_presets(&HashMap::new(), None)
                 .presets
                 .len(),
-            20
+            21
         );
         let missing = std::env::temp_dir().join("sdrtop-presets-that-do-not-exist");
         assert_eq!(
             LayoutConfig::with_user_presets(&HashMap::new(), Some(&missing))
                 .presets
                 .len(),
-            20
+            21
         );
     }
 

--- a/src/config/presets/net_ble.toml
+++ b/src/config/presets/net_ble.toml
@@ -1,0 +1,19 @@
+# NET BLE — what is this device advertising? Design section 9's question for
+# this preset. Real advertising channel PDUs, CRC-checked, as they arrive.
+#
+# Needs the radio parked on one of the three fixed advertising frequencies -
+# 2402, 2426 or 2480 MHz - and a sample rate B6's decoder can reach 4 Msps
+# from. The panel says so when either is not true, rather than showing an
+# empty table that could be mistaken for a quiet room.
+
+section = "net"
+slot    = 5
+title   = "BLE"
+blurb   = "what is this device advertising"
+
+panels = [
+    { name = "header",          position = "top", height = 5 },
+    { name = "net_ble_packets", position = "body" },
+    { name = "log",             position = "bottom", height = 5 },
+    { name = "footer",          position = "bottom" },
+]

--- a/src/config/presets/net_ble.toml
+++ b/src/config/presets/net_ble.toml
@@ -1,9 +1,11 @@
-# NET BLE — what is this device advertising? Design section 9's question for
-# this preset. Real advertising channel PDUs, CRC-checked, as they arrive.
+# NET BLE — what is this device advertising, and is its own transmitter any
+# good? Design section 9's question for this preset. Real advertising channel
+# PDUs, CRC-checked, as they arrive, beside B8's modulation-quality reading
+# for the most recent one.
 #
 # Needs the radio parked on one of the three fixed advertising frequencies -
 # 2402, 2426 or 2480 MHz - and a sample rate B6's decoder can reach 4 Msps
-# from. The panel says so when either is not true, rather than showing an
+# from. Both panels say so when either is not true, rather than showing an
 # empty table that could be mistaken for a quiet room.
 
 section = "net"
@@ -14,6 +16,7 @@ blurb   = "what is this device advertising"
 panels = [
     { name = "header",          position = "top", height = 5 },
     { name = "net_ble_packets", position = "body" },
+    { name = "net_bt_rf",       position = "right", width_pct = 34 },
     { name = "log",             position = "bottom", height = 5 },
     { name = "footer",          position = "bottom" },
 ]

--- a/src/signal/ble/channel.rs
+++ b/src/signal/ble/channel.rs
@@ -34,7 +34,9 @@
 ///
 /// No consumer yet outside this module's own tests; a real one arrives with
 /// B11's survey mode, the same way `net::band`'s edges feed the occupancy
-/// ruler.
+/// ruler. Still true after B6 wired the rest of this arc into a live
+/// capture: detection and decode both work at a single fixed channel, and
+/// have no reason to know the band's own edges.
 #[allow(dead_code)]
 pub const LOW_HZ: u64 = 2_402_000_000;
 #[allow(dead_code)]
@@ -73,7 +75,6 @@ const TOLERANCE_HZ: u64 = SPACING_HZ / 4;
 /// No consumer yet: every later step in this arc, from B3's burst detection
 /// onward, needs a channel's frequency to tune to it or a hop event's
 /// frequency to name its channel, but B1 lands the table alone.
-#[allow(dead_code)]
 pub fn centre_hz(channel: u8) -> Option<u64> {
     match channel {
         0..=DATA_LOW_LAST => Some(DATA_LOW_START_HZ + SPACING_HZ * channel as u64),
@@ -90,7 +91,6 @@ pub fn centre_hz(channel: u8) -> Option<u64> {
 /// The BLE channel index a frequency is the centre of, if it is one.
 ///
 /// No consumer yet, same reason as [`centre_hz`].
-#[allow(dead_code)]
 pub fn channel_of(freq_hz: u64) -> Option<u8> {
     (0..=39).find(|&channel| {
         centre_hz(channel).is_some_and(|centre| centre.abs_diff(freq_hz) <= TOLERANCE_HZ)

--- a/src/signal/ble/channel.rs
+++ b/src/signal/ble/channel.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! BLE's own channel numbering: 40 RF channels, 2 MHz apart, indexed 0 to 39
+//! in an order that is not the frequency order.
+//!
+//! **The three advertising channels sit apart from the data channels on
+//! purpose.** 37, 38 and 39 are placed at 2402, 2426 and 2480 MHz - the low
+//! edge, the middle, and the high edge of the band - specifically so that a
+//! Wi-Fi network sitting on channel 1, 6 or 11 cannot cover all three
+//! advertising channels at once. The 37 data channels fill in the rest, 0 to
+//! 10 from 2404 to 2424 MHz and 11 to 36 from 2428 to 2478 MHz, stepping around
+//! the three advertising frequencies rather than through them.
+//!
+//! Source: Bluetooth Core Specification, Vol 6, Part B, Section 1.4.1 (the
+//! data physical channel index to frequency mapping) and Section 2.3.1 (the
+//! three advertising channels' fixed placement). **Not checked against a copy
+//! of the specification itself in this session** - Rule 1 of `POLICY.md`
+//! applies, and this table has instead been cross-checked against three
+//! independent secondary sources (Electronics Notes' published channel table,
+//! SemFio Networks' and Nordic's own BLE primers) that agree with each other
+//! on every frequency below, plus an internal consistency check this module's
+//! own tests assert: 40 channels, 2 MHz apart, covering exactly 2402 to
+//! 2480 MHz with no gap and no overlap. That agreement is why this table is a
+//! constant rather than a `None`-shaped placeholder like
+//! [`crate::signal::reference::Standard::tolerance_ppm`] - but the primary
+//! source is still owed a real read before anything downstream (whitening,
+//! CRC, hop timing) trusts a channel *index*, not just its frequency.
+
+/// The 2.4 GHz ISM band, as BLE actually uses it: 2402 to 2480 MHz, the span
+/// the 40 channels below cover exactly. Not [`crate::signal::net::band::LOW_HZ`]
+/// and `HIGH_HZ`, which are the wider Wi-Fi framing of the same physical band;
+/// BLE's own channel plan does not reach either edge of that wider range.
+///
+/// No consumer yet outside this module's own tests; a real one arrives with
+/// B11's survey mode, the same way `net::band`'s edges feed the occupancy
+/// ruler.
+#[allow(dead_code)]
+pub const LOW_HZ: u64 = 2_402_000_000;
+#[allow(dead_code)]
+pub const HIGH_HZ: u64 = 2_480_000_000;
+
+/// Every RF channel is this wide and this far from its neighbour.
+const SPACING_HZ: u64 = 2_000_000;
+
+/// The three advertising channels, fixed and out of numeric order.
+const ADV_37_HZ: u64 = 2_402_000_000;
+const ADV_38_HZ: u64 = 2_426_000_000;
+const ADV_39_HZ: u64 = 2_480_000_000;
+
+/// Data channel 0's frequency. Channels 0 to 10 run from here in a straight
+/// line, then jump the gap that channel 38 occupies.
+const DATA_LOW_START_HZ: u64 = 2_404_000_000;
+/// The last data channel before the jump. 0 to this index are contiguous.
+const DATA_LOW_LAST: u8 = 10;
+
+/// Data channel 11's frequency, immediately after the gap channel 38 occupies.
+/// Channels 11 to 36 run from here to [`HIGH_HZ`] minus one spacing.
+const DATA_HIGH_START_HZ: u64 = 2_428_000_000;
+/// The first data channel after the jump.
+const DATA_HIGH_FIRST: u8 = 11;
+/// The last data channel of all. 37 to 39 are the advertising channels.
+const DATA_LAST: u8 = 36;
+
+/// How far from a channel's centre a tuning still counts as being on it.
+/// A quarter of the spacing, the same fraction `net::band` uses for Wi-Fi and
+/// for the same reason: it tiles the band with real gaps between channels
+/// rather than rounding every frequency to its nearest neighbour.
+const TOLERANCE_HZ: u64 = SPACING_HZ / 4;
+
+/// The centre frequency of a BLE RF channel index, 0 to 39.
+///
+/// No consumer yet: every later step in this arc, from B3's burst detection
+/// onward, needs a channel's frequency to tune to it or a hop event's
+/// frequency to name its channel, but B1 lands the table alone.
+#[allow(dead_code)]
+pub fn centre_hz(channel: u8) -> Option<u64> {
+    match channel {
+        0..=DATA_LOW_LAST => Some(DATA_LOW_START_HZ + SPACING_HZ * channel as u64),
+        DATA_HIGH_FIRST..=DATA_LAST => {
+            Some(DATA_HIGH_START_HZ + SPACING_HZ * (channel - DATA_HIGH_FIRST) as u64)
+        }
+        37 => Some(ADV_37_HZ),
+        38 => Some(ADV_38_HZ),
+        39 => Some(ADV_39_HZ),
+        _ => None,
+    }
+}
+
+/// The BLE channel index a frequency is the centre of, if it is one.
+///
+/// No consumer yet, same reason as [`centre_hz`].
+#[allow(dead_code)]
+pub fn channel_of(freq_hz: u64) -> Option<u8> {
+    (0..=39).find(|&channel| {
+        centre_hz(channel).is_some_and(|centre| centre.abs_diff(freq_hz) <= TOLERANCE_HZ)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The three anchors named in the spec, in the order and at the
+    /// frequencies the design document cites.
+    #[test]
+    fn the_advertising_channels_sit_where_the_standard_puts_them() {
+        assert_eq!(centre_hz(37), Some(2_402_000_000));
+        assert_eq!(centre_hz(38), Some(2_426_000_000));
+        assert_eq!(centre_hz(39), Some(2_480_000_000));
+    }
+
+    /// The data channels either side of the jump: 10 is the last of the low
+    /// run, 11 is the first of the high run, and they are not 2 MHz apart from
+    /// each other the way every other adjacent pair of data channels is -
+    /// channel 38's frequency sits in between.
+    #[test]
+    fn the_data_channels_jump_around_channel_38_frequency() {
+        assert_eq!(centre_hz(0), Some(2_404_000_000));
+        assert_eq!(centre_hz(10), Some(2_424_000_000));
+        assert_eq!(centre_hz(11), Some(2_428_000_000));
+        assert_eq!(centre_hz(36), Some(2_478_000_000));
+    }
+
+    /// Every one of the 40 channels maps to a frequency, and channel 40 and
+    /// beyond do not exist. This is B1's exit condition, written as an
+    /// assertion rather than left to the eye.
+    #[test]
+    fn every_one_of_the_forty_channels_maps_to_a_frequency() {
+        for channel in 0..=39u8 {
+            assert!(
+                centre_hz(channel).is_some(),
+                "channel {channel} has no frequency"
+            );
+        }
+        assert_eq!(centre_hz(40), None);
+        assert_eq!(centre_hz(255), None);
+    }
+
+    /// The internal consistency check the module doc promises: 40 distinct
+    /// channels, every one inside the band, none of them sharing a frequency
+    /// with another, and the whole set covering the band exactly with 2 MHz
+    /// steps and no gap.
+    #[test]
+    fn the_forty_channels_tile_the_band_with_no_gap_and_no_overlap() {
+        let mut frequencies: Vec<u64> = (0..=39u8).map(|c| centre_hz(c).unwrap()).collect();
+        frequencies.sort_unstable();
+        frequencies.dedup();
+        assert_eq!(frequencies.len(), 40, "two channels share a frequency");
+        assert_eq!(*frequencies.first().unwrap(), LOW_HZ);
+        assert_eq!(*frequencies.last().unwrap(), HIGH_HZ);
+        for pair in frequencies.windows(2) {
+            assert_eq!(
+                pair[1] - pair[0],
+                SPACING_HZ,
+                "a gap or an overlap at {pair:?}"
+            );
+        }
+    }
+
+    /// Every channel round-trips through its own centre.
+    #[test]
+    fn every_channel_round_trips_through_its_centre() {
+        for channel in 0..=39u8 {
+            let hz = centre_hz(channel).unwrap();
+            assert_eq!(channel_of(hz), Some(channel), "channel {channel}");
+        }
+    }
+
+    /// Between two channels there is no channel, the same honesty
+    /// `net::band::a_frequency_between_channels_is_not_on_one` asserts for
+    /// Wi-Fi.
+    #[test]
+    fn a_frequency_between_channels_is_not_on_one() {
+        // Halfway between data channels 0 and 1.
+        assert_eq!(channel_of(2_405_000_000), None);
+        // Inside the tolerance of channel 0, which a real tuning rarely misses by more.
+        assert_eq!(channel_of(2_404_000_000 + 400_000), Some(0));
+        assert_eq!(channel_of(2_404_000_000 + 600_000), None);
+        // Outside the band entirely.
+        assert_eq!(channel_of(2_350_000_000), None);
+        assert_eq!(channel_of(5_180_000_000), None);
+    }
+}

--- a/src/signal/ble/detect.rs
+++ b/src/signal/ble/detect.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Detection: "is a BLE packet here", from the preamble and the fixed
+//! advertising access address alone. Detection only - no timing recovery
+//! (B4) and no decode (B5 onward).
+//!
+//! **One matched filter, not two.** Design section 1.1 lists the preamble
+//! correlate and the access address correlate as separate items, and for a
+//! receiver that does not yet know which access address to expect that is
+//! the right split: a cheap preamble-only correlator finds *something*, and
+//! a second stage decides what. On the advertising channels the address is
+//! not unknown - it is the fixed constant [`ADVERTISING_ACCESS_ADDRESS`] - so
+//! there is nothing the two-stage split buys here that concatenating the
+//! preamble and the address into one forty-symbol reference does not also
+//! give, more simply. A connection-following step that must search for an
+//! address it has not yet learned (B14's classic Bluetooth LAP search is the
+//! closer case) is where the two-stage form earns its keep, and that is where
+//! it should be built, not here on spec.
+
+use num_complex::Complex;
+
+use super::gfsk;
+use crate::signal::dsp::correlate::MatchedFilter;
+
+/// The fixed access address every advertising channel PDU begins with.
+///
+/// Source: the Bluetooth SIG's own public Link Layer Specification page
+/// (Core Specification, Vol 6, Part B) states this constant directly for the
+/// advertising physical channel. Not independently re-derived, but not from
+/// memory alone either - Rule 1's spirit, satisfied by the primary source
+/// rather than a secondary account of it, unlike [`access_address_bits`]'s
+/// transmission-order rule below, which rests on the same page read through a
+/// search summary rather than the page itself.
+///
+/// No path from `main` yet - see [`Detector`]'s own doc for why this whole
+/// file is presently dead together.
+#[allow(dead_code)]
+pub const ADVERTISING_ACCESS_ADDRESS: u32 = 0x8E89_BED6;
+
+/// How many symbols the combined reference below is: 8 for the preamble, 32
+/// for the access address.
+#[allow(dead_code)]
+pub const REFERENCE_SYMBOLS: usize = 8 + 32;
+
+/// `access_address`'s 32 bits, in the order the specification transmits
+/// them: least significant octet first, and least significant bit first
+/// within each octet.
+///
+/// Source: the Bluetooth SIG's public Link Layer Specification page states
+/// that multi-octet fields other than the CRC are sent least-significant-
+/// octet-first, each octet least-significant-bit-first, and gives
+/// `0x8E89BED6` transmitted as the octets D6, BE, 89, 8E in that order as its
+/// own worked example - which is exactly what this function computes, and
+/// `the_advertising_address_matches_its_own_worked_example` pins it against
+/// that example rather than trusting the rule restated in prose.
+#[allow(dead_code)]
+pub fn access_address_bits(access_address: u32) -> [bool; 32] {
+    let mut out = [false; 32];
+    for octet in 0..4usize {
+        let byte = (access_address >> (8 * octet)) as u8;
+        for bit in 0..8usize {
+            out[octet * 8 + bit] = (byte >> bit) & 1 != 0;
+        }
+    }
+    out
+}
+
+/// The 8-bit preamble that precedes every LE 1M packet, as the bit sequence
+/// in transmission order.
+///
+/// Its first transmitted bit equals the access address's own least
+/// significant bit - equivalently, [`access_address_bits`]'s element 0 - and
+/// then strictly alternates. Stated this way round deliberately: the
+/// specification names the rule by the bit relationship, not by a byte value,
+/// and naming it "0xAA" or "0x55" would silently commit to a bit order this
+/// function does not need to take a position on.
+#[allow(dead_code)]
+pub fn preamble_bits(access_address: u32) -> [bool; 8] {
+    let mut bit = access_address & 1 != 0;
+    let mut out = [false; 8];
+    for slot in out.iter_mut() {
+        *slot = bit;
+        bit = !bit;
+    }
+    out
+}
+
+/// GFSK parameters for the LE 1M PHY, gathered so a caller states the working
+/// rate once. Design section 2.1's nominal modulation index `h = 0.5` at a
+/// 1 Mb/s symbol rate is 250 kHz of peak deviation (`h = 2 * deviation /
+/// symbol_rate`); the Gaussian filter's own bandwidth-time product is the
+/// same 0.5.
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub struct Le1mParams {
+    pub sps: usize,
+    pub sample_rate: f64,
+    pub deviation_hz: f64,
+    pub bt: f64,
+}
+
+#[allow(dead_code)]
+impl Le1mParams {
+    /// LE 1M at the given samples per symbol. The symbol rate is always
+    /// 1 Mb/s on this PHY, so `sample_rate` follows from `sps` rather than
+    /// being a second number that could disagree with it.
+    pub fn at(sps: usize) -> Self {
+        const SYMBOL_RATE: f64 = 1_000_000.0;
+        Self {
+            sps,
+            sample_rate: SYMBOL_RATE * sps as f64,
+            deviation_hz: 250_000.0,
+            bt: 0.5,
+        }
+    }
+}
+
+/// A detector for one access address on the LE 1M PHY: the preamble and the
+/// address, correlated as a single known reference.
+///
+/// No consumer yet in this arc's own code: nothing in `tasks` or `ui` feeds
+/// this a live stream, because there is no capture pipeline wired to `ble`
+/// until B6 puts a real packet on screen. Until then this is reached only
+/// from this module's own tests, exactly the position `dsp::correlate`'s
+/// `MatchedFilter` itself was in before this step gave it a real caller.
+#[allow(dead_code)]
+pub struct Detector {
+    filter: MatchedFilter,
+}
+
+#[allow(dead_code)]
+impl Detector {
+    pub fn new(access_address: u32, params: Le1mParams) -> Self {
+        let mut bits = Vec::with_capacity(REFERENCE_SYMBOLS);
+        bits.extend_from_slice(&preamble_bits(access_address));
+        bits.extend_from_slice(&access_address_bits(access_address));
+        let reference = gfsk::modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        Self {
+            filter: MatchedFilter::new(&reference),
+        }
+    }
+
+    /// How many samples the reference is - `REFERENCE_SYMBOLS * sps` - which
+    /// is the figure [`crate::signal::dsp::correlate::threshold_for_false_alarm`]
+    /// needs to turn a stated false-alarm rate into a threshold for this
+    /// detector specifically.
+    pub fn len(&self) -> usize {
+        self.filter.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.filter.is_empty()
+    }
+
+    /// Feed one sample. `Some` with the coherence in `[0, 1]` once a full
+    /// forty-symbol window has been seen; `None` before that and for the
+    /// zero-energy window `Match::coherence` refuses to invent a number for.
+    pub fn push(&mut self, x: Complex<f32>) -> Option<f64> {
+        self.filter.push(x).and_then(|m| m.coherence())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::dsp::correlate::threshold_for_false_alarm;
+    use crate::signal::dsp::testkit::{at_snr, Rng};
+
+    /// The worked example the source citation names: `0x8E89BED6` is sent as
+    /// the octets D6, BE, 89, 8E, each octet least-significant-bit-first.
+    #[test]
+    fn the_advertising_address_matches_its_own_worked_example() {
+        let bits = access_address_bits(ADVERTISING_ACCESS_ADDRESS);
+        let octet = |byte: u8| -> Vec<bool> { (0..8).map(|b| (byte >> b) & 1 != 0).collect() };
+        let mut want = Vec::new();
+        want.extend(octet(0xD6));
+        want.extend(octet(0xBE));
+        want.extend(octet(0x89));
+        want.extend(octet(0x8E));
+        assert_eq!(bits.to_vec(), want);
+    }
+
+    /// The preamble alternates starting from the address's own LSB. For the
+    /// fixed advertising address that LSB is 0 (0xD6's low bit), so the
+    /// preamble here is 0, 1, 0, 1, 0, 1, 0, 1.
+    #[test]
+    fn the_advertising_preamble_alternates_from_the_address_lsb() {
+        let p = preamble_bits(ADVERTISING_ACCESS_ADDRESS);
+        assert_eq!(p, [false, true, false, true, false, true, false, true]);
+    }
+
+    /// The reference is exactly `REFERENCE_SYMBOLS * sps` samples long, which
+    /// is what every threshold and every peak-position check below assumes.
+    #[test]
+    fn the_reference_is_the_stated_length() {
+        let sps = 4;
+        let det = Detector::new(ADVERTISING_ACCESS_ADDRESS, Le1mParams::at(sps));
+        assert_eq!(det.len(), REFERENCE_SYMBOLS * sps);
+        assert!(!det.is_empty());
+    }
+
+    /// B3's exit condition: measured detection rate against a generated
+    /// packet, at three SNRs, and where in the stream it was found.
+    #[test]
+    fn the_packet_is_found_at_three_snrs_at_the_right_position() {
+        let params = Le1mParams::at(4);
+        let threshold = threshold_for_false_alarm(REFERENCE_SYMBOLS * params.sps, 1e-6);
+        let prefix_symbols = 500usize;
+
+        for snr_db in [0.0, 10.0, 20.0] {
+            let mut rng = Rng::new(1);
+            let mut bits: Vec<bool> = (0..prefix_symbols)
+                .map(|_| rng.next_u64() & 1 == 1)
+                .collect();
+            let sync_start = bits.len();
+            bits.extend_from_slice(&preamble_bits(ADVERTISING_ACCESS_ADDRESS));
+            bits.extend_from_slice(&access_address_bits(ADVERTISING_ACCESS_ADDRESS));
+            bits.extend((0..200).map(|_| rng.next_u64() & 1 == 1));
+
+            let clean = gfsk::modulate(
+                &bits,
+                params.sps,
+                params.deviation_hz,
+                params.sample_rate,
+                params.bt,
+            );
+            let noisy = at_snr(&clean, snr_db, &mut Rng::new(2));
+
+            let mut det = Detector::new(ADVERTISING_ACCESS_ADDRESS, params);
+            let scores: Vec<(usize, f64)> = noisy
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &s)| det.push(s).map(|c| (i, c)))
+                .collect();
+
+            let (peak_idx, peak) =
+                scores
+                    .iter()
+                    .cloned()
+                    .fold((0, 0.0), |a, b| if b.1 > a.1 { b } else { a });
+            assert!(
+                peak > threshold,
+                "snr={snr_db}: peak coherence {peak} did not clear threshold {threshold}"
+            );
+
+            // A reading is for the window ending at the sample just fed, so
+            // the peak lands at the end of the sync word: the prefix, plus
+            // the forty-symbol reference, minus one.
+            let expected = (sync_start + REFERENCE_SYMBOLS) * params.sps - 1;
+            assert_eq!(
+                peak_idx, expected,
+                "snr={snr_db}: peak at {peak_idx}, expected {expected}"
+            );
+        }
+    }
+
+    /// The other half of B3's exit condition: noise alone crosses a
+    /// threshold chosen for a stated false-alarm rate about as often as that
+    /// rate says it should, the same law N5's `dsp::correlate` tests already
+    /// hold a generic reference sequence to.
+    #[test]
+    fn noise_alone_crosses_the_threshold_at_about_the_stated_rate() {
+        let params = Le1mParams::at(4);
+        let rate = 1e-3;
+        let threshold = threshold_for_false_alarm(REFERENCE_SYMBOLS * params.sps, rate);
+        let mut rng = Rng::new(21);
+        let noise = rng.noise(400_000, 1.0);
+        let mut det = Detector::new(ADVERTISING_ACCESS_ADDRESS, params);
+        let crossings = noise
+            .iter()
+            .filter_map(|&s| det.push(s))
+            .filter(|&c| c > threshold)
+            .count();
+        let got = crossings as f64 / noise.len() as f64;
+        assert!(
+            got > rate / 4.0 && got < rate * 4.0,
+            "measured false-alarm rate {got:e}, expected about {rate:e}"
+        );
+    }
+}

--- a/src/signal/ble/detect.rs
+++ b/src/signal/ble/detect.rs
@@ -33,14 +33,13 @@ use crate::signal::dsp::correlate::MatchedFilter;
 /// transmission-order rule below, which rests on the same page read through a
 /// search summary rather than the page itself.
 ///
-/// No path from `main` yet - see [`Detector`]'s own doc for why this whole
-/// file is presently dead together.
-#[allow(dead_code)]
+/// Reaches `main` since B6: `signal::ble::receive::Receiver` builds its own
+/// [`Detector`] against exactly this constant, the fixed address every
+/// advertising channel PDU uses.
 pub const ADVERTISING_ACCESS_ADDRESS: u32 = 0x8E89_BED6;
 
 /// How many symbols the combined reference below is: 8 for the preamble, 32
 /// for the access address.
-#[allow(dead_code)]
 pub const REFERENCE_SYMBOLS: usize = 8 + 32;
 
 /// `access_address`'s 32 bits, in the order the specification transmits
@@ -54,7 +53,6 @@ pub const REFERENCE_SYMBOLS: usize = 8 + 32;
 /// own worked example - which is exactly what this function computes, and
 /// `the_advertising_address_matches_its_own_worked_example` pins it against
 /// that example rather than trusting the rule restated in prose.
-#[allow(dead_code)]
 pub fn access_address_bits(access_address: u32) -> [bool; 32] {
     let mut out = [false; 32];
     for octet in 0..4usize {
@@ -75,7 +73,6 @@ pub fn access_address_bits(access_address: u32) -> [bool; 32] {
 /// specification names the rule by the bit relationship, not by a byte value,
 /// and naming it "0xAA" or "0x55" would silently commit to a bit order this
 /// function does not need to take a position on.
-#[allow(dead_code)]
 pub fn preamble_bits(access_address: u32) -> [bool; 8] {
     let mut bit = access_address & 1 != 0;
     let mut out = [false; 8];
@@ -92,7 +89,6 @@ pub fn preamble_bits(access_address: u32) -> [bool; 8] {
 /// symbol_rate`); the Gaussian filter's own bandwidth-time product is the
 /// same 0.5.
 #[derive(Clone, Copy)]
-#[allow(dead_code)]
 pub struct Le1mParams {
     pub sps: usize,
     pub sample_rate: f64,
@@ -100,11 +96,18 @@ pub struct Le1mParams {
     pub bt: f64,
 }
 
-#[allow(dead_code)]
 impl Le1mParams {
     /// LE 1M at the given samples per symbol. The symbol rate is always
     /// 1 Mb/s on this PHY, so `sample_rate` follows from `sps` rather than
     /// being a second number that could disagree with it.
+    ///
+    /// Only this arc's own tests call it: `signal::ble::receive::Receiver`
+    /// needs `sample_rate` set to the *decimated* working rate it actually
+    /// runs at, not derived fresh from `sps` by this convenience
+    /// constructor, so it builds `Le1mParams` as a plain struct literal
+    /// instead. Still a real constructor for a test that wants LE 1M's own
+    /// numbers with no decimation in the picture.
+    #[allow(dead_code)]
     pub fn at(sps: usize) -> Self {
         const SYMBOL_RATE: f64 = 1_000_000.0;
         Self {
@@ -119,17 +122,14 @@ impl Le1mParams {
 /// A detector for one access address on the LE 1M PHY: the preamble and the
 /// address, correlated as a single known reference.
 ///
-/// No consumer yet in this arc's own code: nothing in `tasks` or `ui` feeds
-/// this a live stream, because there is no capture pipeline wired to `ble`
-/// until B6 puts a real packet on screen. Until then this is reached only
-/// from this module's own tests, exactly the position `dsp::correlate`'s
-/// `MatchedFilter` itself was in before this step gave it a real caller.
-#[allow(dead_code)]
+/// `signal::ble::receive::Receiver` owns one of these and feeds it every
+/// sample of a live capture - the first stage of B6's four-stage pipeline,
+/// the same position `dsp::correlate`'s `MatchedFilter` itself was promoted
+/// out of when this struct was built to wrap it.
 pub struct Detector {
     filter: MatchedFilter,
 }
 
-#[allow(dead_code)]
 impl Detector {
     pub fn new(access_address: u32, params: Le1mParams) -> Self {
         let mut bits = Vec::with_capacity(REFERENCE_SYMBOLS);
@@ -151,10 +151,17 @@ impl Detector {
     /// is the figure [`crate::signal::dsp::correlate::threshold_for_false_alarm`]
     /// needs to turn a stated false-alarm rate into a threshold for this
     /// detector specifically.
+    ///
+    /// This arc's own tests are the only caller: `receive.rs` needs the same
+    /// figure but already has `REFERENCE_SYMBOLS * WORKING_SPS` in hand as
+    /// plain constants at the point it needs it, with no `Detector` value
+    /// alive to ask.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.filter.len()
     }
 
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.filter.is_empty()
     }

--- a/src/signal/ble/gfsk.rs
+++ b/src/signal/ble/gfsk.rs
@@ -23,7 +23,6 @@ use crate::signal::dsp::fir::gaussian_taps;
 ///
 /// No path from `main` yet - see [`modulate`]'s own doc for why the whole
 /// chain is presently dead together.
-#[allow(dead_code)]
 const FILTER_SPAN_SYMBOLS: usize = 4;
 
 /// A GFSK-modulated baseband signal for the given bits, at `sps` samples per
@@ -45,7 +44,6 @@ const FILTER_SPAN_SYMBOLS: usize = 4;
 /// the reference it correlates against - but `Detector` itself has no path
 /// from `main` yet, so the lint still fires here too. Wired in when B6 puts a
 /// real packet on screen.
-#[allow(dead_code)]
 pub fn modulate(
     bits: &[bool],
     sps: usize,

--- a/src/signal/ble/gfsk.rs
+++ b/src/signal/ble/gfsk.rs
@@ -1,24 +1,29 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
-//! A synthetic GFSK transmitter, for testing this arc against a signal whose
-//! bits are known - the role [`crate::signal::dsp::testkit`] plays for the
-//! shared layer, and the reason this exists separately from it: that module
-//! knows no protocol, and a GFSK modulator with a modulation index and a
-//! Gaussian filter baked in is BLE-specific policy, not a shared primitive.
+//! The GFSK waveform: turning bits into the IQ samples LE 1M actually
+//! transmits.
 //!
-//! Compiled only under `cfg(test)`, and reused from B2 onward: every later
-//! step that checks a bit error rate, a timing recovery, or a decode against
-//! a known signal starts here rather than re-deriving its own.
+//! **One function, two callers.** [`detect`](super::detect) calls it to build
+//! the known reference a matched filter correlates against - real production
+//! use, since the advertising access address is fixed and known in advance.
+//! This module's own tests call it to check the round trip. Neither role
+//! needs its own copy: a wrong deviation or a wrong filter would be wrong for
+//! both at once, which is the point of there being one function rather than a
+//! production one and a test one that quietly drift apart.
 
 use num_complex::Complex;
 
 use crate::signal::dsp::fir::gaussian_taps;
 
 /// How many symbol periods the shaping filter spans. 4 is the common choice
-/// in the references [`gaussian_taps`] cites; nothing in this file depends on
-/// the exact figure, only on the filter it produces being the one B2's own
-/// tests measure.
+/// in the references [`gaussian_taps`] cites; nothing here depends on the
+/// exact figure, only on the filter it produces being the one this module's
+/// own tests measure.
+///
+/// No path from `main` yet - see [`modulate`]'s own doc for why the whole
+/// chain is presently dead together.
+#[allow(dead_code)]
 const FILTER_SPAN_SYMBOLS: usize = 4;
 
 /// A GFSK-modulated baseband signal for the given bits, at `sps` samples per
@@ -35,6 +40,12 @@ const FILTER_SPAN_SYMBOLS: usize = 4;
 /// construction, and the reason [`gaussian_taps`]'s own unit-sum
 /// normalisation matters here - an unnormalised kernel would scale the
 /// deviation along with it.
+///
+/// Called for real by `signal::ble::detect::Detector::new` (B3), to build
+/// the reference it correlates against - but `Detector` itself has no path
+/// from `main` yet, so the lint still fires here too. Wired in when B6 puts a
+/// real packet on screen.
+#[allow(dead_code)]
 pub fn modulate(
     bits: &[bool],
     sps: usize,

--- a/src/signal/ble/measure.rs
+++ b/src/signal/ble/measure.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Transmitter modulation quality: modulation index, delta-f1 average,
+//! delta-f2 maximum and their ratio, from a packet this arc already
+//! recovered rather than a dedicated test transmission.
+//!
+//! Design section 2.1's four numbers are specified as read from a *known*
+//! symbol pattern: `00001111` repeated for delta-f1, `10101010` repeated for
+//! delta-f2. Bluetooth's own conformance test procedure gets that known
+//! pattern by putting the device under test into Direct Test Mode and
+//! sending it a specific payload, whitening disabled. This receiver has no
+//! way to do either - it is a passive listener on ordinary advertising
+//! traffic from devices it does not control, and rule 8 (`POLICY.md`) rules
+//! out ever transmitting to ask for one.
+//!
+//! **What the two patterns are *for* is what this measures instead of the
+//! patterns themselves.** `00001111` is chosen because four symbol periods
+//! of the same value is enough for a BT=0.5 Gaussian filter to reach
+//! whatever deviation it settles at - the measurement point is the *last*
+//! symbol of the run, as far from the last transition as the pattern gets.
+//! `10101010` is chosen because continuous alternation is the opposite
+//! extreme, the pattern that gives the filter the least time to settle
+//! between transitions. Both conditions occur constantly in ordinary
+//! whitened traffic, which looks like uniformly random bits at the symbol
+//! level: [`SETTLED_RUN`] or more identical bits in a row, and
+//! [`SETTLED_RUN`] or more bits that strictly alternate, both happen many
+//! times in a packet of any real length. This measures at every such
+//! occurrence and reports the same four numbers the specification's own
+//! procedure does, built from data this receiver already has instead of
+//! data it has no way to ask for.
+//!
+//! **Measured against the physically transmitted bits, not the decoded
+//! ones.** Whitening is a logical operation applied before modulation and
+//! undone after slicing; the Gaussian filter and the discriminator only
+//! ever see the *whitened* symbol sequence, so a run of identical or
+//! alternating *data* bits is not what settles or unsettles the filter - a
+//! run of identical or alternating *on-air* bits is. `signal::ble::receive`
+//! calls this before its own call to [`crate::signal::dsp::code::lfsr::whiten`],
+//! on the same bits [`super::sync::slice`] sliced.
+
+use crate::signal::dsp::uncertainty::Uncertain;
+
+/// LE 1M's symbol rate, fixed at 1 Mb/s by the PHY itself. Not derived from
+/// a receiver's own `sps` - that is a demodulator design choice, this is a
+/// specification fact, and the two must never be confused into agreeing by
+/// coincidence.
+const SYMBOL_RATE_HZ: f64 = 1_000_000.0;
+
+/// How many like, or alternating, symbols in a row counts as "settled" for
+/// [`modulation_quality`]'s own purposes: `00001111`'s two four-symbol runs
+/// and `10101010`'s continuous alternation both generalise to this one
+/// number. See the module doc for why a literal search for either octet
+/// pattern is not what real advertising traffic can supply.
+const SETTLED_RUN: usize = 4;
+
+/// One packet's modulation quality, each figure carrying the uncertainty a
+/// caller needs to judge it against a stated limit - except
+/// [`Self::delta_f2_max_hz`], a maximum of several noisy readings, which has
+/// no closed-form uncertainty the way a mean does and is reported as read.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ModulationQuality {
+    /// The average peak deviation reached at the end of a settled run of
+    /// four or more identical on-air symbols, in Hz.
+    pub delta_f1_avg_hz: Uncertain,
+    /// The largest single peak deviation seen during a settled run of four
+    /// or more alternating on-air symbols, in Hz. Not an [`Uncertain`]: see
+    /// this struct's own doc for why a maximum does not get one.
+    pub delta_f2_max_hz: f64,
+    /// `2 * delta_f1_avg_hz / SYMBOL_RATE_HZ` - the modulation index
+    /// design section 2.1 states a band for, derived from delta-f1 because
+    /// that is the settled, filter-independent deviation a device's own
+    /// deviation setting actually controls.
+    pub modulation_index: Uncertain,
+    /// The average peak deviation over alternating runs, over the same
+    /// figure for settled runs - design section 2.1's fourth number, "the
+    /// specification's own way of asking whether the Gaussian filter is
+    /// right": a ratio well below one means the filter is narrower than it
+    /// should be, closing the eye during continuous alternation more than
+    /// the specification allows.
+    pub ratio: Uncertain,
+}
+
+/// Whether the window of `SETTLED_RUN` bits ending at `i` (inclusive) is all
+/// one value.
+fn ends_settled_run(bits: &[bool], i: usize) -> bool {
+    i + 1 >= SETTLED_RUN
+        && bits[i + 1 - SETTLED_RUN..=i]
+            .windows(2)
+            .all(|w| w[0] == w[1])
+}
+
+/// Whether the window of `SETTLED_RUN` bits ending at `i` (inclusive)
+/// strictly alternates.
+fn ends_alternating_run(bits: &[bool], i: usize) -> bool {
+    i + 1 >= SETTLED_RUN
+        && bits[i + 1 - SETTLED_RUN..=i]
+            .windows(2)
+            .all(|w| w[0] != w[1])
+}
+
+/// Modulation quality from one packet's own on-air symbols (`bits`) and the
+/// discriminator sample recovered at each one (`samples`, in Hz) - the same
+/// two arrays [`super::sync::slice`] returns, before whitening is undone.
+///
+/// `None` when either pattern never occurred - a packet too short, or one
+/// whose particular random content happened to lack a settled run of either
+/// kind. Rule 2: a measurement with nothing behind it is refused, not
+/// invented from zero occurrences.
+pub fn modulation_quality(bits: &[bool], samples: &[f32]) -> Option<ModulationQuality> {
+    debug_assert_eq!(bits.len(), samples.len());
+    let n = bits.len().min(samples.len());
+
+    let settled: Vec<f32> = (0..n)
+        .filter(|&i| ends_settled_run(bits, i))
+        .map(|i| samples[i].abs())
+        .collect();
+    let alternating: Vec<f32> = (0..n)
+        .filter(|&i| ends_alternating_run(bits, i))
+        .map(|i| samples[i].abs())
+        .collect();
+
+    if settled.is_empty() || alternating.is_empty() {
+        return None;
+    }
+
+    let delta_f1_avg_hz = crate::signal::dsp::uncertainty::mean_with_uncertainty(&settled);
+    let delta_f2_avg_hz = crate::signal::dsp::uncertainty::mean_with_uncertainty(&alternating);
+    let delta_f2_max_hz = alternating.iter().cloned().fold(f32::MIN, f32::max) as f64;
+    let modulation_index = delta_f1_avg_hz.scale(2.0 / SYMBOL_RATE_HZ);
+    let ratio = delta_f2_avg_hz.ratio(&delta_f1_avg_hz);
+
+    Some(ModulationQuality {
+        delta_f1_avg_hz,
+        delta_f2_max_hz,
+        modulation_index,
+        ratio,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::ble::detect::Le1mParams;
+    use crate::signal::ble::gfsk::modulate;
+    use crate::signal::dsp::discriminate::discriminate;
+    use crate::signal::dsp::testkit::{at_snr, Rng};
+
+    /// A random on-air bit stream and the discriminator samples recovered
+    /// from it at `deviation_hz`, sliced against zero - the same shape
+    /// `receive.rs` hands this module, built without any of that module's
+    /// own detection or timing-search machinery, which this measurement
+    /// does not touch.
+    fn symbols_and_samples(
+        deviation_hz: f64,
+        n_bits: usize,
+        snr_db: f64,
+        seed: u64,
+    ) -> (Vec<bool>, Vec<f32>) {
+        let params = Le1mParams {
+            sps: 4,
+            sample_rate: 4_000_000.0,
+            deviation_hz,
+            bt: 0.5,
+        };
+        let mut rng = Rng::new(seed);
+        let bits: Vec<bool> = (0..n_bits).map(|_| rng.next_u64() & 1 == 1).collect();
+        let clean = modulate(
+            &bits,
+            params.sps,
+            deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        let iq = if snr_db.is_finite() {
+            at_snr(&clean, snr_db, &mut Rng::new(seed + 1))
+        } else {
+            clean
+        };
+        let mut inst = Vec::new();
+        discriminate(&iq, params.sample_rate, &mut inst);
+        let (_, samples) = crate::signal::ble::sync::slice(&inst, params.sps as f64, n_bits, 0.0);
+        (bits, samples)
+    }
+
+    /// B8's exit condition, the "measured as wrong" half: a deviation
+    /// clearly outside the modulation index band measures outside it, and
+    /// the measurement moves the *right way* as deviation rises - up for
+    /// more, down for less - rather than only "close to the deviation
+    /// asked for".
+    ///
+    /// **Not compared against `2 * deviation_hz / SYMBOL_RATE_HZ` to a
+    /// tight tolerance, and that is a finding of its own kind.** A first
+    /// version of this test did exactly that, at three deviations, and
+    /// failed at 200 kHz while passing at 250 kHz - not because the
+    /// measurement is wrong, but because [`find_phase`](crate::signal::dsp::timing::find_phase)'s
+    /// amplitude-based search has a broad, nearly flat maximum over a
+    /// settled plateau, so two *independent* simulated captures at
+    /// different deviations can legitimately settle on phases a fraction of
+    /// a sample apart - benign in itself, but enough to move which exact
+    /// sample a transition-region symbol reads, which this generalised
+    /// measurement (any settled run of four, not only a repeated
+    /// specification octet) is more exposed to than a single hand-picked
+    /// symbol would be. Comparing two independently-simulated captures to
+    /// each other, rather than either to a fixed theoretical fraction, is
+    /// not sensitive to that phase choice: both readings come from the same
+    /// noiseless family and the underlying settling fraction is a property
+    /// of the bit sequence and the filter, not of which capture found it.
+    #[test]
+    fn a_deliberately_wrong_deviation_measures_outside_the_band_and_the_right_way() {
+        let readings: Vec<(f64, f64)> = [150_000.0, 250_000.0, 350_000.0]
+            .into_iter()
+            .map(|deviation_hz| {
+                let (bits, samples) = symbols_and_samples(deviation_hz, 4000, f64::INFINITY, 10);
+                let q = modulation_quality(&bits, &samples)
+                    .expect("plenty of settled runs at 4000 bits");
+                (deviation_hz, q.modulation_index.value())
+            })
+            .collect();
+
+        // Monotonic: more deviation must never measure as less.
+        for pair in readings.windows(2) {
+            assert!(
+                pair[1].1 > pair[0].1,
+                "deviation {} measured {}, not more than deviation {}'s {}",
+                pair[1].0,
+                pair[1].1,
+                pair[0].0,
+                pair[0].1
+            );
+        }
+
+        // 250 kHz is BLE's own nominal deviation and must land inside the
+        // band; 150 kHz and 350 kHz are both far enough outside it (design
+        // section 2.1's own 0.45-0.55) that no plausible settling loss
+        // brings them back in - a genuinely wrong transmitter, correctly
+        // read as one.
+        let index = |d: f64| readings.iter().find(|r| r.0 == d).unwrap().1;
+        assert!(
+            index(250_000.0) > 0.45 && index(250_000.0) < 0.55,
+            "nominal deviation measured index {}",
+            index(250_000.0)
+        );
+        assert!(
+            index(150_000.0) < 0.45,
+            "150 kHz measured index {}, inside the band",
+            index(150_000.0)
+        );
+        assert!(
+            index(350_000.0) > 0.55,
+            "350 kHz measured index {}, inside the band",
+            index(350_000.0)
+        );
+    }
+
+    /// The nominal BLE deviation lands inside the specification's own
+    /// modulation index band, 0.45 to 0.55 - not asserted against the exact
+    /// figure here (that belongs to the panel's stated `Limit`), just that
+    /// this measurement's own number is the one a real conforming
+    /// transmitter would be judged against.
+    #[test]
+    fn the_nominal_deviation_measures_inside_the_modulation_index_band() {
+        let (bits, samples) = symbols_and_samples(250_000.0, 4000, 25.0, 11);
+        let q = modulation_quality(&bits, &samples).unwrap();
+        assert!(
+            q.modulation_index.value() > 0.45 && q.modulation_index.value() < 0.55,
+            "measured index {}",
+            q.modulation_index.value()
+        );
+    }
+
+    /// Continuous alternation gives the Gaussian filter the least time to
+    /// settle, so delta-f2 must never exceed delta-f1 on the same signal -
+    /// the physical relationship the ratio is built to expose a filter
+    /// that violates.
+    #[test]
+    fn alternation_never_reaches_further_than_a_settled_run_does() {
+        let (bits, samples) = symbols_and_samples(250_000.0, 4000, f64::INFINITY, 12);
+        let q = modulation_quality(&bits, &samples).unwrap();
+        assert!(
+            q.ratio.value() <= 1.01,
+            "ratio {} implies alternation reached further than settling does",
+            q.ratio.value()
+        );
+        assert!(q.delta_f2_max_hz <= q.delta_f1_avg_hz.value() * 1.2);
+    }
+
+    /// A run too short to contain either pattern refuses rather than
+    /// inventing a measurement from nothing.
+    #[test]
+    fn too_short_a_run_refuses_rather_than_inventing_a_reading() {
+        let bits = vec![true, false, true];
+        let samples = vec![1.0f32, -1.0, 1.0];
+        assert!(modulation_quality(&bits, &samples).is_none());
+    }
+
+    /// A packet with settled runs but no alternation - or the reverse -
+    /// still refuses, because the ratio and the panel's own display need
+    /// both figures, not just one.
+    #[test]
+    fn one_pattern_present_without_the_other_still_refuses() {
+        let all_settled = vec![true; 20];
+        let samples = vec![1.0f32; 20];
+        assert!(modulation_quality(&all_settled, &samples).is_none());
+    }
+}

--- a/src/signal/ble/measure.rs
+++ b/src/signal/ble/measure.rs
@@ -38,6 +38,13 @@
 //! run of identical or alternating *on-air* bits is. `signal::ble::receive`
 //! calls this before its own call to [`crate::signal::dsp::code::lfsr::whiten`],
 //! on the same bits [`super::sync::slice`] sliced.
+//!
+//! [`drift`] is B9's own addition, and needs none of the pattern-search
+//! machinery above - a frequency drift within a packet is a property of the
+//! per-symbol discriminator readings themselves, not of any particular bit
+//! pattern - but it reads the *same* per-symbol `samples` array
+//! [`modulation_quality`] does, for a reason [`drift`]'s own doc explains:
+//! the raw, oversampled trace turned out to be the wrong input for it.
 
 use crate::signal::dsp::uncertainty::Uncertain;
 
@@ -135,6 +142,78 @@ pub fn modulation_quality(bits: &[bool], samples: &[f32]) -> Option<ModulationQu
         delta_f2_max_hz,
         modulation_index,
         ratio,
+    })
+}
+
+/// A packet's own frequency offset, measured early and late, and the drift
+/// between them - design section 2.2's measurements 6 through 8, read as one
+/// structure rather than two numbers a reader has to subtract by hand.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Drift {
+    /// The mean discriminator reading over the first half of the capture.
+    pub initial_hz: Uncertain,
+    /// The mean discriminator reading over the second half.
+    pub final_hz: Uncertain,
+    /// `final_hz - initial_hz`.
+    pub drift_hz: Uncertain,
+    /// `drift_hz`, divided by the time between the two halves' own centres.
+    pub drift_rate_hz_per_us: Uncertain,
+}
+
+/// Frequency drift within one packet, from the **per-symbol** discriminator
+/// readings [`super::sync::slice`] already produced - the same `samples`
+/// array [`modulation_quality`] reads, one value per on-air symbol.
+///
+/// **Not the raw oversampled trace, and that is a finding of its own, not a
+/// preference.** A first version read straight from `receive.rs`'s raw
+/// `inst` array at the working sample rate (four samples per symbol here),
+/// the same array B7's own CFO figure is built from. Its own "no drift
+/// injected" test failed: [`crate::signal::dsp::uncertainty::mean_with_uncertainty`]
+/// assumes independent samples to turn a sample variance into `Var(mean) =
+/// sigma^2 / N`, and four samples spanning one symbol of a Gaussian-filtered
+/// waveform are not independent draws - they are one slowly-varying value
+/// sampled four times. Feeding it the raw trace divides by an `N` four times
+/// too large and reports a sigma roughly half what the data can actually
+/// support, which a null-drift signal then reliably clears by several times
+/// its own reported uncertainty - a measurement that looks more precise than
+/// it is, which is exactly the failure this whole arc's uncertainty
+/// discipline exists to catch. One value per symbol removes the
+/// oversampling correlation the same way slicing to bits already does for
+/// [`modulation_quality`]; the residual correlation between *adjacent
+/// symbols*, from the Gaussian filter's own few-symbol impulse response, is
+/// smaller and not accounted for here either, so this is a improvement, not
+/// a claim of statistical purity.
+///
+/// **Splits the capture in half and reads the mean of each half.** A single
+/// mean answers "what was the average offset"; two means, early and late,
+/// answer "did it move" - design section 2.2's measurement 8 ("initial
+/// frequency offset versus final") asked for directly, and what a drifting
+/// PLL or a thermally pulling crystal actually does to a burst.
+///
+/// The two halves' own centres sit `n / 2` symbols apart regardless of
+/// which half is longer when `n` is odd, which is close enough: a legacy
+/// advertising PDU is at most a few hundred symbols, and one symbol's worth
+/// of that is a rounding error next to the drift this measures. `None`
+/// under four symbols, where a half would have fewer than the two
+/// [`crate::signal::dsp::uncertainty::mean_with_uncertainty`] needs to
+/// report a variance rather than an unknown one.
+pub fn drift(samples: &[f32]) -> Option<Drift> {
+    let n = samples.len();
+    let half = n / 2;
+    if half < 2 {
+        return None;
+    }
+    let initial_hz = crate::signal::dsp::uncertainty::mean_with_uncertainty(&samples[..half]);
+    let final_hz = crate::signal::dsp::uncertainty::mean_with_uncertainty(&samples[n - half..]);
+    let drift_hz = final_hz.difference(&initial_hz);
+    let separation_us = half as f64 / SYMBOL_RATE_HZ * 1e6;
+    let drift_rate_hz_per_us = drift_hz.scale(1.0 / separation_us);
+
+    Some(Drift {
+        initial_hz,
+        final_hz,
+        drift_hz,
+        drift_rate_hz_per_us,
     })
 }
 
@@ -302,5 +381,110 @@ mod tests {
         let all_settled = vec![true; 20];
         let samples = vec![1.0f32; 20];
         assert!(modulation_quality(&all_settled, &samples).is_none());
+    }
+
+    /// A clean IQ signal with an added linear frequency ramp on top of
+    /// whatever it is already modulating: `drift_rate_hz_per_s * t` more
+    /// frequency at time `t`, the same effect a thermally pulling crystal or
+    /// a still-settling PLL has on a real transmitter within one burst.
+    /// Multiplying by a chirp is exact here because frequency is additive
+    /// under complex multiplication: the discriminator recovers the sum of
+    /// the two phase derivatives, not some mixture of them.
+    fn with_drift(
+        iq: &[num_complex::Complex<f32>],
+        sample_rate_hz: f64,
+        drift_rate_hz_per_s: f64,
+    ) -> Vec<num_complex::Complex<f32>> {
+        use num_complex::Complex;
+        iq.iter()
+            .enumerate()
+            .map(|(n, &s)| {
+                let t = n as f64 / sample_rate_hz;
+                let phase = std::f64::consts::TAU * 0.5 * drift_rate_hz_per_s * t * t;
+                s * Complex::new(phase.cos() as f32, phase.sin() as f32)
+            })
+            .collect()
+    }
+
+    /// B9's exit condition: a synthetic drift of a known rate is recovered
+    /// to within its own uncertainty.
+    #[test]
+    fn a_known_drift_rate_is_recovered_within_its_own_uncertainty() {
+        let params = Le1mParams {
+            sps: 4,
+            sample_rate: 4_000_000.0,
+            deviation_hz: 250_000.0,
+            bt: 0.5,
+        };
+        let mut rng = Rng::new(20);
+        let bits: Vec<bool> = (0..3000).map(|_| rng.next_u64() & 1 == 1).collect();
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        let drift_rate_hz_per_us = 20.0;
+        let drifted = with_drift(&clean, params.sample_rate, drift_rate_hz_per_us * 1e6);
+        let mut inst = Vec::new();
+        discriminate(&drifted, params.sample_rate, &mut inst);
+        let (_, samples) =
+            crate::signal::ble::sync::slice(&inst, params.sps as f64, bits.len(), 0.0);
+
+        let d = drift(&samples).expect("plenty of samples at 3000 bits");
+        assert!(
+            (d.drift_rate_hz_per_us.value() - drift_rate_hz_per_us).abs()
+                < 4.0 * d.drift_rate_hz_per_us.sigma(),
+            "measured {} +/- {}, injected {}",
+            d.drift_rate_hz_per_us.value(),
+            d.drift_rate_hz_per_us.sigma(),
+            drift_rate_hz_per_us
+        );
+        // The two ends of the same measurement, design section 2.2's own
+        // framing: final must read higher than initial for a positive
+        // drift, not just the rate derived from their difference.
+        assert!(d.final_hz.value() > d.initial_hz.value());
+    }
+
+    /// No injected drift measures as no drift, within the same uncertainty
+    /// a real one would have to clear - the null result this measurement
+    /// has to get right before its own "yes, this moved" means anything.
+    #[test]
+    fn no_injected_drift_measures_as_none_within_uncertainty() {
+        let params = Le1mParams {
+            sps: 4,
+            sample_rate: 4_000_000.0,
+            deviation_hz: 250_000.0,
+            bt: 0.5,
+        };
+        let mut rng = Rng::new(21);
+        let bits: Vec<bool> = (0..3000).map(|_| rng.next_u64() & 1 == 1).collect();
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        let mut inst = Vec::new();
+        discriminate(&clean, params.sample_rate, &mut inst);
+        let (_, samples) =
+            crate::signal::ble::sync::slice(&inst, params.sps as f64, bits.len(), 0.0);
+
+        let d = drift(&samples).unwrap();
+        assert!(
+            d.drift_rate_hz_per_us.value().abs() < 4.0 * d.drift_rate_hz_per_us.sigma(),
+            "measured {} +/- {} with nothing injected",
+            d.drift_rate_hz_per_us.value(),
+            d.drift_rate_hz_per_us.sigma()
+        );
+    }
+
+    /// Too few samples to give each half its own variance refuses rather
+    /// than inventing a drift from a handful of points.
+    #[test]
+    fn too_few_samples_refuses_rather_than_inventing_a_reading() {
+        assert!(drift(&[1.0, 2.0, 3.0]).is_none());
     }
 }

--- a/src/signal/ble/mod.rs
+++ b/src/signal/ble/mod.rs
@@ -18,4 +18,6 @@
 pub mod channel;
 pub mod detect;
 pub mod gfsk;
+pub mod pdu;
+pub mod receive;
 pub mod sync;

--- a/src/signal/ble/mod.rs
+++ b/src/signal/ble/mod.rs
@@ -10,8 +10,11 @@
 //! own file, with none of it knowing classic Bluetooth (`signal::bt`, not yet
 //! built) or Wi-Fi exist. [`channel`] comes before any of those stages: it is
 //! arithmetic the whole arc needs (which frequency a channel index names), not
-//! a step in the receive chain.
+//! a step in the receive chain. [`gfsk`] sits beside it for the same reason:
+//! turning bits into the waveform LE 1M transmits is not itself a receive
+//! stage, but [`detect`] needs it to build the reference it correlates
+//! against, since the advertising access address is known in advance.
 
 pub mod channel;
-#[cfg(test)]
-pub mod testkit;
+pub mod detect;
+pub mod gfsk;

--- a/src/signal/ble/mod.rs
+++ b/src/signal/ble/mod.rs
@@ -13,3 +13,5 @@
 //! a step in the receive chain.
 
 pub mod channel;
+#[cfg(test)]
+pub mod testkit;

--- a/src/signal/ble/mod.rs
+++ b/src/signal/ble/mod.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Bluetooth Low Energy: one of the two protocol modules under the Bluetooth
+//! arc (`bluetooth-bench-design.md`; the checkpoint plan is
+//! `bluetooth-bench-plan.md`).
+//!
+//! Split the way `net-foundation-design.md` section 10 requires of every
+//! protocol module: detect, sync, decode, measure, in that order, each in its
+//! own file, with none of it knowing classic Bluetooth (`signal::bt`, not yet
+//! built) or Wi-Fi exist. [`channel`] comes before any of those stages: it is
+//! arithmetic the whole arc needs (which frequency a channel index names), not
+//! a step in the receive chain.
+
+pub mod channel;

--- a/src/signal/ble/mod.rs
+++ b/src/signal/ble/mod.rs
@@ -18,6 +18,7 @@
 pub mod channel;
 pub mod detect;
 pub mod gfsk;
+pub mod measure;
 pub mod pdu;
 pub mod receive;
 pub mod sync;

--- a/src/signal/ble/mod.rs
+++ b/src/signal/ble/mod.rs
@@ -18,3 +18,4 @@
 pub mod channel;
 pub mod detect;
 pub mod gfsk;
+pub mod sync;

--- a/src/signal/ble/pdu.rs
+++ b/src/signal/ble/pdu.rs
@@ -82,11 +82,11 @@ impl PduType {
 /// says the payload starts with one, and whether the CRC that followed it
 /// over the air actually checked out.
 ///
-/// `snr_db`, `freq_offset_hz` and `modulation` are `None` here always -
-/// `decode` sees only bits, never the discriminator samples or the
-/// detector's own coherence B7's and B8's measurements are taken from - and
-/// are filled in by `signal::ble::receive::Receiver::try_decode`, the caller
-/// that has both.
+/// `snr_db`, `freq_offset_hz`, `modulation` and `drift` are `None` here
+/// always - `decode` sees only bits, never the discriminator samples or the
+/// detector's own coherence B7, B8 and B9's measurements are taken from -
+/// and are filled in by `signal::ble::receive::Receiver::try_decode`, the
+/// caller that has both.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Packet {
     pub pdu_type: PduType,
@@ -97,6 +97,7 @@ pub struct Packet {
     pub crc_ok: bool,
     pub snr_db: Option<f64>,
     pub freq_offset_hz: Option<crate::signal::dsp::uncertainty::Uncertain>,
+    pub drift: Option<super::measure::Drift>,
     pub modulation: Option<super::measure::ModulationQuality>,
 }
 
@@ -191,6 +192,7 @@ pub fn decode(bits: &[bool]) -> Option<Packet> {
         snr_db: None,
         freq_offset_hz: None,
         modulation: None,
+        drift: None,
     })
 }
 

--- a/src/signal/ble/pdu.rs
+++ b/src/signal/ble/pdu.rs
@@ -82,10 +82,11 @@ impl PduType {
 /// says the payload starts with one, and whether the CRC that followed it
 /// over the air actually checked out.
 ///
-/// `snr_db` and `freq_offset_hz` are `None` here always - `decode` sees only
-/// bits, never the discriminator samples or the detector's own coherence
-/// that B7's measurements are taken from - and are filled in by
-/// `signal::ble::receive::Receiver::try_decode`, the caller that has both.
+/// `snr_db`, `freq_offset_hz` and `modulation` are `None` here always -
+/// `decode` sees only bits, never the discriminator samples or the
+/// detector's own coherence B7's and B8's measurements are taken from - and
+/// are filled in by `signal::ble::receive::Receiver::try_decode`, the caller
+/// that has both.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Packet {
     pub pdu_type: PduType,
@@ -96,6 +97,7 @@ pub struct Packet {
     pub crc_ok: bool,
     pub snr_db: Option<f64>,
     pub freq_offset_hz: Option<crate::signal::dsp::uncertainty::Uncertain>,
+    pub modulation: Option<super::measure::ModulationQuality>,
 }
 
 /// How many trailing bits `decode` needs beyond the header to have a whole
@@ -107,6 +109,17 @@ fn body_bits(length: u8) -> usize {
 /// How many bits, past the access address, `decode` needs to see before it
 /// can be called at all: the 16-bit header alone.
 pub const HEADER_BITS: usize = 16;
+
+/// The whole PDU's own length in bits, header through CRC, once `length` is
+/// known - the same figure `decode` requires before it returns `Some`.
+///
+/// `signal::ble::receive::Receiver` uses this to trim its own capture to
+/// exactly the packet before measuring B8's modulation quality from it,
+/// rather than re-deriving [`body_bits`]'s arithmetic a second time and
+/// risking the two silently disagreeing.
+pub fn used_bits(length: u8) -> usize {
+    HEADER_BITS + body_bits(length)
+}
 
 /// Decode one advertising channel PDU from its de-whitened bits, in
 /// transmission order, starting at the header's own first bit and running
@@ -138,7 +151,7 @@ pub fn decode(bits: &[bool]) -> Option<Packet> {
     let rx_add_random = (byte0 >> 7) & 1 != 0;
     let length = byte1 & 0x3F;
 
-    let needed = HEADER_BITS + body_bits(length);
+    let needed = used_bits(length);
     if bits.len() < needed {
         return None;
     }
@@ -177,6 +190,7 @@ pub fn decode(bits: &[bool]) -> Option<Packet> {
         crc_ok,
         snr_db: None,
         freq_offset_hz: None,
+        modulation: None,
     })
 }
 

--- a/src/signal/ble/pdu.rs
+++ b/src/signal/ble/pdu.rs
@@ -81,6 +81,11 @@ impl PduType {
 /// A decoded advertising channel PDU: the header, `AdvA` where the PDU type
 /// says the payload starts with one, and whether the CRC that followed it
 /// over the air actually checked out.
+///
+/// `snr_db` and `freq_offset_hz` are `None` here always - `decode` sees only
+/// bits, never the discriminator samples or the detector's own coherence
+/// that B7's measurements are taken from - and are filled in by
+/// `signal::ble::receive::Receiver::try_decode`, the caller that has both.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Packet {
     pub pdu_type: PduType,
@@ -89,11 +94,8 @@ pub struct Packet {
     pub length: u8,
     pub adv_addr: Option<[u8; 6]>,
     pub crc_ok: bool,
-    // TEMP DEBUG
-    pub debug_pdu_bytes: Vec<u8>,
-    pub debug_crc_bytes: Vec<u8>,
-    pub debug_coherence: f64,
-    pub debug_phase: f64,
+    pub snr_db: Option<f64>,
+    pub freq_offset_hz: Option<crate::signal::dsp::uncertainty::Uncertain>,
 }
 
 /// How many trailing bits `decode` needs beyond the header to have a whole
@@ -173,10 +175,8 @@ pub fn decode(bits: &[bool]) -> Option<Packet> {
         length,
         adv_addr,
         crc_ok,
-        debug_pdu_bytes: pdu_bytes,
-        debug_crc_bytes: crc_bytes,
-        debug_coherence: 0.0,
-        debug_phase: 0.0,
+        snr_db: None,
+        freq_offset_hz: None,
     })
 }
 

--- a/src/signal/ble/pdu.rs
+++ b/src/signal/ble/pdu.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! The advertising channel PDU: header, address and CRC, from a de-whitened
+//! bit stream. `decode` and `measure`, in design section 10's split - this
+//! reads what is there and checks it against the CRC it carries; nothing
+//! here decides whether to trust a radio or corrects a frequency.
+//!
+//! Source: Bluetooth Core Specification, Vol 6, Part B - byte 0's 4-bit PDU
+//! type, RFU, ChSel, TxAdd and RxAdd, byte 1's 6-bit Length, and the seven
+//! legacy advertising PDU types. Cross-checked against public documentation
+//! of the same layout; not read from a licensed copy of the specification
+//! this session, the same standing B1's channel table has.
+
+use crate::signal::dsp::code::crc::crc24_ble;
+#[cfg(test)]
+use crate::signal::dsp::code::lfsr::whiten;
+
+/// The seven PDU types a legacy advertising channel packet can carry.
+/// `Other` is not a defect in this list - PDU types 7 and up are extended
+/// advertising (AUX_*, introduced after legacy advertising), out of scope
+/// for this arc until a step says otherwise, and reporting the raw value
+/// rather than refusing the packet is what rule 2 asks for: this is a real
+/// four-bit field that was really read, not a case this decoder cannot see.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PduType {
+    AdvInd,
+    AdvDirectInd,
+    AdvNonconnInd,
+    ScanReq,
+    ScanRsp,
+    ConnectInd,
+    AdvScanInd,
+    Other(u8),
+}
+
+impl PduType {
+    fn from_bits(bits: u8) -> Self {
+        match bits & 0x0F {
+            0x0 => Self::AdvInd,
+            0x1 => Self::AdvDirectInd,
+            0x2 => Self::AdvNonconnInd,
+            0x3 => Self::ScanReq,
+            0x4 => Self::ScanRsp,
+            0x5 => Self::ConnectInd,
+            0x6 => Self::AdvScanInd,
+            other => Self::Other(other),
+        }
+    }
+
+    /// The label a panel shows.
+    pub fn label(self) -> String {
+        match self {
+            Self::AdvInd => "ADV_IND".to_string(),
+            Self::AdvDirectInd => "ADV_DIRECT_IND".to_string(),
+            Self::AdvNonconnInd => "ADV_NONCONN_IND".to_string(),
+            Self::ScanReq => "SCAN_REQ".to_string(),
+            Self::ScanRsp => "SCAN_RSP".to_string(),
+            Self::ConnectInd => "CONNECT_IND".to_string(),
+            Self::AdvScanInd => "ADV_SCAN_IND".to_string(),
+            Self::Other(b) => format!("TYPE {b:#04x}"),
+        }
+    }
+
+    /// Whether this PDU's first six payload bytes are `AdvA`, the
+    /// advertiser's own address - true for every legacy type except
+    /// `SCAN_REQ` and `CONNECT_IND`, whose first address is the scanner's or
+    /// initiator's, not the advertiser's.
+    fn carries_adv_addr_first(self) -> bool {
+        matches!(
+            self,
+            Self::AdvInd
+                | Self::AdvDirectInd
+                | Self::AdvNonconnInd
+                | Self::ScanRsp
+                | Self::AdvScanInd
+        )
+    }
+}
+
+/// A decoded advertising channel PDU: the header, `AdvA` where the PDU type
+/// says the payload starts with one, and whether the CRC that followed it
+/// over the air actually checked out.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Packet {
+    pub pdu_type: PduType,
+    pub tx_add_random: bool,
+    pub rx_add_random: bool,
+    pub length: u8,
+    pub adv_addr: Option<[u8; 6]>,
+    pub crc_ok: bool,
+    // TEMP DEBUG
+    pub debug_pdu_bytes: Vec<u8>,
+    pub debug_crc_bytes: Vec<u8>,
+    pub debug_coherence: f64,
+    pub debug_phase: f64,
+}
+
+/// How many trailing bits `decode` needs beyond the header to have a whole
+/// PDU plus its CRC, once `length` is known.
+fn body_bits(length: u8) -> usize {
+    (length as usize + 3) * 8
+}
+
+/// How many bits, past the access address, `decode` needs to see before it
+/// can be called at all: the 16-bit header alone.
+pub const HEADER_BITS: usize = 16;
+
+/// Decode one advertising channel PDU from its de-whitened bits, in
+/// transmission order, starting at the header's own first bit and running
+/// through the header, the payload and the CRC.
+///
+/// `bits.len()` must be at least `HEADER_BITS + body_bits(length)` for the
+/// `length` the header itself states - the caller reads the header's own six
+/// length bits first (bits 8 to 13) to know how much more to wait for, which
+/// is what a live receiver does and what this function's own tests do too.
+/// Fewer bits than that is `None`: an incomplete PDU is not a wrong one, and
+/// inventing a partial answer would be exactly the thing rule 2 refuses.
+pub fn decode(bits: &[bool]) -> Option<Packet> {
+    if bits.len() < HEADER_BITS {
+        return None;
+    }
+    let byte = |bit_offset: usize| -> u8 {
+        let mut b = 0u8;
+        for i in 0..8 {
+            if bits[bit_offset + i] {
+                b |= 1 << i;
+            }
+        }
+        b
+    };
+    let byte0 = byte(0);
+    let byte1 = byte(8);
+    let pdu_type = PduType::from_bits(byte0);
+    let tx_add_random = (byte0 >> 6) & 1 != 0;
+    let rx_add_random = (byte0 >> 7) & 1 != 0;
+    let length = byte1 & 0x3F;
+
+    let needed = HEADER_BITS + body_bits(length);
+    if bits.len() < needed {
+        return None;
+    }
+
+    let pdu_bytes: Vec<u8> = (0..2 + length as usize).map(|i| byte(i * 8)).collect();
+    let crc_bytes: Vec<u8> = (0..3)
+        .map(|i| byte(HEADER_BITS + (length as usize) * 8 + i * 8))
+        .collect();
+    // The CRC is the one multi-octet field this specification sends most-
+    // significant-octet-first - the stated exception to the rule every other
+    // field here follows (see the module doc and `access_address_bits`).
+    // `encode`'s own tests caught nothing because it wrote the same wrong
+    // order it read back; only a real transmitter, which correctly follows
+    // the exception, exposed it - every CRC failed on real hardware until
+    // this matched.
+    let received_crc =
+        (crc_bytes[0] as u32) << 16 | (crc_bytes[1] as u32) << 8 | crc_bytes[2] as u32;
+    let crc_ok = crc24_ble(&pdu_bytes) == received_crc;
+
+    let adv_addr = if pdu_type.carries_adv_addr_first() && length >= 6 {
+        let mut addr = [0u8; 6];
+        for (i, a) in addr.iter_mut().enumerate() {
+            *a = byte(HEADER_BITS + i * 8);
+        }
+        Some(addr)
+    } else {
+        None
+    };
+
+    Some(Packet {
+        pdu_type,
+        tx_add_random,
+        rx_add_random,
+        length,
+        adv_addr,
+        crc_ok,
+        debug_pdu_bytes: pdu_bytes,
+        debug_crc_bytes: crc_bytes,
+        debug_coherence: 0.0,
+        debug_phase: 0.0,
+    })
+}
+
+/// A synthetic advertising channel PDU's bit stream, whitened and CRC'd
+/// exactly as the air interface would send it - for this module's own tests
+/// and for `signal::ble::receive`'s.
+///
+/// `channel` seeds the whitening the same way a real transmitter's would;
+/// `header_byte0` and `payload` are given already assembled so a test can
+/// build any PDU type or a deliberately corrupt one without this function
+/// making decisions on its behalf.
+///
+/// `cfg(test)` rather than `#[allow(dead_code)]`: unlike `gfsk::modulate`,
+/// which B3 promoted to production because a real detector needs to build a
+/// reference from it, nothing on the receive side ever needs to construct a
+/// packet - only decode one.
+#[cfg(test)]
+pub fn encode(channel: u8, header_byte0: u8, payload: &[u8]) -> Vec<bool> {
+    let mut pdu_bytes = vec![header_byte0, payload.len() as u8];
+    pdu_bytes.extend_from_slice(payload);
+    let crc = crc24_ble(&pdu_bytes);
+    let mut all_bytes = pdu_bytes;
+    // Most-significant-octet-first: see `decode`'s own comment on the same
+    // exception.
+    all_bytes.push(((crc >> 16) & 0xFF) as u8);
+    all_bytes.push(((crc >> 8) & 0xFF) as u8);
+    all_bytes.push((crc & 0xFF) as u8);
+
+    let mut bits = Vec::with_capacity(all_bytes.len() * 8);
+    for byte in all_bytes {
+        for i in 0..8 {
+            bits.push((byte >> i) & 1 != 0);
+        }
+    }
+    whiten(&mut bits, channel);
+    bits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A round trip through `encode` and `decode` recovers every field, on
+    /// the PDU type that carries an address.
+    #[test]
+    fn a_synthetic_adv_ind_round_trips() {
+        let addr = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let mut payload = addr.to_vec();
+        payload.extend_from_slice(&[0x02, 0x01, 0x06]); // a plausible AD structure
+        let mut bits = encode(37, 0x00, &payload); // 0x00 = ADV_IND, both address bits clear
+        whiten(&mut bits, 37); // the air interface's own bits, de-whitened
+        let packet = decode(&bits).expect("a full PDU was given");
+        assert_eq!(packet.pdu_type, PduType::AdvInd);
+        assert!(!packet.tx_add_random);
+        assert!(!packet.rx_add_random);
+        assert_eq!(packet.length, payload.len() as u8);
+        assert_eq!(packet.adv_addr, Some(addr));
+        assert!(packet.crc_ok);
+    }
+
+    /// `TxAdd` set is a random address, and the type without an `AdvA` at
+    /// all - `SCAN_REQ` - reports no address even though it has payload.
+    #[test]
+    fn tx_add_and_addressless_types_are_read_correctly() {
+        let mut bits = encode(0, 0x40 | 0x03, &[0u8; 12]); // bit6=TxAdd, type=SCAN_REQ
+        whiten(&mut bits, 0);
+        let packet = decode(&bits).unwrap();
+        assert_eq!(packet.pdu_type, PduType::ScanReq);
+        assert!(packet.tx_add_random);
+        assert_eq!(packet.adv_addr, None);
+    }
+
+    /// A whitened bit flipped in the payload breaks the CRC, and only the
+    /// CRC - the header still reads correctly, which is what lets a panel
+    /// show a bad packet rather than discard it silently.
+    #[test]
+    fn a_corrupted_payload_fails_only_the_crc() {
+        let mut bits = encode(10, 0x02, &[0xAA; 8]); // ADV_NONCONN_IND
+        whiten(&mut bits, 10);
+        let flip = HEADER_BITS + 20;
+        bits[flip] = !bits[flip];
+        let packet = decode(&bits).unwrap();
+        assert_eq!(packet.pdu_type, PduType::AdvNonconnInd);
+        assert_eq!(packet.length, 8);
+        assert!(!packet.crc_ok);
+    }
+
+    /// Fewer bits than the header refuses rather than guessing.
+    #[test]
+    fn fewer_bits_than_the_header_decodes_to_nothing() {
+        assert_eq!(decode(&[false; HEADER_BITS - 1]), None);
+    }
+
+    /// Enough for the header but not for the length it declares refuses too.
+    #[test]
+    fn a_header_promising_more_than_is_present_decodes_to_nothing() {
+        let mut bits = encode(5, 0x00, &[0u8; 20]);
+        whiten(&mut bits, 5);
+        assert_eq!(decode(&bits[..HEADER_BITS + 8]), None);
+    }
+
+    /// An out-of-range PDU type is reported plainly, not refused: it is a
+    /// real four-bit field that was really read.
+    #[test]
+    fn an_extended_advertising_type_is_named_rather_than_refused() {
+        let mut bits = encode(0, 0x07, &[0u8; 4]);
+        whiten(&mut bits, 0);
+        let packet = decode(&bits).unwrap();
+        assert_eq!(packet.pdu_type, PduType::Other(7));
+    }
+}

--- a/src/signal/ble/receive.rs
+++ b/src/signal/ble/receive.rs
@@ -237,13 +237,16 @@ impl Receiver {
         // synthetic tests, which is why slicing against a fixed zero passed
         // every one of them and no real capture. The capture's own mean is
         // the honest estimate of that constant - GFSK data is balanced over
-        // any real stretch of bits - and B7 gives it a proper uncertainty:
-        // see `dsp::uncertainty::mean_with_uncertainty`'s own doc for why
-        // the sample mean is the right estimator here, not an approximation
-        // of one.
-        let offset = crate::signal::dsp::uncertainty::mean_with_uncertainty(&inst);
-        let (mut bits, raw_symbols) =
-            super::sync::slice(&inst, WORKING_SPS as f64, symbols, offset.value() as f32);
+        // any real stretch of bits - and this only needs a point estimate:
+        // a threshold decision does not need a calibrated uncertainty, only
+        // the displayed reading below does, and gets its own.
+        let rough_offset = crate::signal::dsp::uncertainty::mean_with_uncertainty(&inst);
+        let (mut bits, raw_symbols) = super::sync::slice(
+            &inst,
+            WORKING_SPS as f64,
+            symbols,
+            rough_offset.value() as f32,
+        );
         // B8's modulation-quality measurement needs the physically
         // transmitted (still-whitened) symbols and their raw discriminator
         // readings - exactly what `bits` and `raw_symbols` are before the
@@ -253,6 +256,26 @@ impl Receiver {
         let raw_bits = bits.clone();
         whiten(&mut bits, self.channel);
         let mut packet = pdu::decode(&bits)?;
+        // Trimmed to exactly this packet's own bits before measuring: `bits`
+        // and `raw_symbols` run to the end of whatever has been captured,
+        // which is deliberately more than one packet's worth (see this
+        // struct's own `push`), and letting the search wander into trailing
+        // noise or the next packet's preamble would mix an unrelated
+        // signal's deviation into this one's own reading.
+        let used = pdu::used_bits(packet.length).min(raw_bits.len());
+        let raw_bits = &raw_bits[..used];
+        let raw_symbols = &raw_symbols[..used];
+        // The *reported* offset, unlike `rough_offset` above, is read from
+        // one sample per symbol rather than the raw four-per-symbol trace.
+        // B9's own `measure::drift` found why that distinction is load-
+        // bearing: `mean_with_uncertainty` assumes independent samples, and
+        // four samples spanning one Gaussian-filtered symbol are one
+        // slowly-varying value read four times, not four independent ones -
+        // feeding it the raw trace divides by an `N` four times too large
+        // and understates the uncertainty by about half. `rough_offset`
+        // above never had to be exact, only good enough to slice against;
+        // this one is what a reader sees a `+/-` on.
+        let offset = crate::signal::dsp::uncertainty::mean_with_uncertainty(raw_symbols);
         packet.freq_offset_hz = Some(offset);
         // `snr_from_metric` was derived for `Coherence::metric` - two noisy
         // copies of the same unknown signal correlated against each other -
@@ -268,15 +291,8 @@ impl Receiver {
         // already keeps every real reading comfortably under.
         packet.snr_db = snr_from_metric(self.last_coherence, REFERENCE_SYMBOLS * WORKING_SPS)
             .map(|snr| 10.0 * snr.log10());
-        // Trimmed to exactly this packet's own bits before measuring: `bits`
-        // and `raw_symbols` run to the end of whatever has been captured,
-        // which is deliberately more than one packet's worth (see this
-        // struct's own `push`), and letting the search wander into trailing
-        // noise or the next packet's preamble would mix an unrelated
-        // signal's deviation into this one's own reading.
-        let used = pdu::used_bits(packet.length).min(raw_bits.len());
-        packet.modulation =
-            super::measure::modulation_quality(&raw_bits[..used], &raw_symbols[..used]);
+        packet.modulation = super::measure::modulation_quality(raw_bits, raw_symbols);
+        packet.drift = super::measure::drift(raw_symbols);
         Some(packet)
     }
 }

--- a/src/signal/ble/receive.rs
+++ b/src/signal/ble/receive.rs
@@ -242,8 +242,15 @@ impl Receiver {
         // the sample mean is the right estimator here, not an approximation
         // of one.
         let offset = crate::signal::dsp::uncertainty::mean_with_uncertainty(&inst);
-        let mut bits =
+        let (mut bits, raw_symbols) =
             super::sync::slice(&inst, WORKING_SPS as f64, symbols, offset.value() as f32);
+        // B8's modulation-quality measurement needs the physically
+        // transmitted (still-whitened) symbols and their raw discriminator
+        // readings - exactly what `bits` and `raw_symbols` are before the
+        // next line undoes whitening to recover the data underneath them.
+        // See `measure`'s own module doc for why the physical bits, not the
+        // decoded ones, are what a Gaussian filter's settling depends on.
+        let raw_bits = bits.clone();
         whiten(&mut bits, self.channel);
         let mut packet = pdu::decode(&bits)?;
         packet.freq_offset_hz = Some(offset);
@@ -261,6 +268,15 @@ impl Receiver {
         // already keeps every real reading comfortably under.
         packet.snr_db = snr_from_metric(self.last_coherence, REFERENCE_SYMBOLS * WORKING_SPS)
             .map(|snr| 10.0 * snr.log10());
+        // Trimmed to exactly this packet's own bits before measuring: `bits`
+        // and `raw_symbols` run to the end of whatever has been captured,
+        // which is deliberately more than one packet's worth (see this
+        // struct's own `push`), and letting the search wander into trailing
+        // noise or the next packet's preamble would mix an unrelated
+        // signal's deviation into this one's own reading.
+        let used = pdu::used_bits(packet.length).min(raw_bits.len());
+        packet.modulation =
+            super::measure::modulation_quality(&raw_bits[..used], &raw_symbols[..used]);
         Some(packet)
     }
 }

--- a/src/signal/ble/receive.rs
+++ b/src/signal/ble/receive.rs
@@ -6,17 +6,20 @@
 //! Four stages, run in order over every sample: [`Detector`] (a matched
 //! filter over raw IQ) finds the sync word; once it does, the samples that
 //! follow are captured; [`discriminate`] turns the capture into instantaneous
-//! frequency; and [`pdu::decode`], fed bits sliced from it and de-whitened,
-//! either returns a packet or says there was not enough of one yet.
+//! frequency; [`super::sync::slice`] finds the symbol phase and slices it to
+//! bits; and [`pdu::decode`], fed those bits de-whitened, either returns a
+//! packet or says there was not enough of one yet.
 //!
-//! **No phase search here, deliberately - the detector's own peak already
-//! is one.** `signal::ble::detect`'s tests measured the matched filter's
-//! peak landing at the exact sample the sync word's last symbol ends on, so
-//! the header's first symbol begins at the very next sample: a known,
-//! symbol-aligned position, not an estimate. `dsp::timing::find_phase`
-//! stays the right tool for a burst whose alignment is not already known
-//! this precisely - which is not the position this arc's own detector
-//! leaves a caller in.
+//! **Started as a deterministic peak-derived index, not a search - and real
+//! hardware is why it no longer is one.** `signal::ble::detect`'s own tests
+//! measured the matched filter's peak landing at the exact sample a
+//! synthetic sync word's last symbol ends on, so indexing directly from it
+//! looked like a known position rather than an estimate. True only because
+//! that synthetic transmitter and the detector's own reference come from
+//! the same call to [`super::gfsk::modulate`] at the same sample phase - a
+//! real transmitter's clock has no reason to share it. `[super::sync::slice]`
+//! is B4's own answer for a burst whose alignment is not known this
+//! precisely, which turned out to be every real one.
 
 use num_complex::Complex;
 
@@ -25,8 +28,8 @@ use crate::signal::demod::decode as decode_iq;
 use crate::signal::dsp::code::lfsr::whiten;
 use crate::signal::dsp::correlate::threshold_for_false_alarm;
 use crate::signal::dsp::discriminate::discriminate;
+use crate::signal::dsp::estimate::snr_from_metric;
 use crate::signal::dsp::fir::StreamingDecimator;
-use crate::signal::dsp::timing::{find_phase, interpolate};
 
 use super::detect::{Detector, Le1mParams, ADVERTISING_ACCESS_ADDRESS, REFERENCE_SYMBOLS};
 use super::pdu::{self, Packet};
@@ -210,6 +213,14 @@ impl Receiver {
     /// algorithm. `find_phase` is the same tool B4 built for exactly this;
     /// the deterministic shortcut only worked on the test signal that could
     /// never have shown the bug.
+    ///
+    /// **Real hardware's CRC still fails even with this fixed** - the
+    /// working hypothesis after B6 is a real device's own crystal offset
+    /// (BLE allows up to ±150 ppm, which at 2.4 GHz is up to ±360 kHz,
+    /// larger than the ±250 kHz deviation itself), uncorrected. B7's
+    /// `freq_offset_hz` below is that same offset, finally measured and
+    /// reported rather than only corrected for blindly - the honest first
+    /// step toward deciding whether that hypothesis is the right one.
     fn try_decode(&self) -> Option<Packet> {
         let mut inst = Vec::new();
         discriminate(&self.capture, WORKING_RATE_HZ, &mut inst);
@@ -217,24 +228,39 @@ impl Receiver {
         if symbols < pdu::HEADER_BITS {
             return None;
         }
-        let phase = find_phase(&inst, WORKING_SPS as f64, symbols, 16);
         // A tuning sitting exactly on the channel's own centre - which this
         // arc's is, since it never mixes off it - is exactly where a real
-        // front end's LO leakage and IQ DC offset concentrate. That is a
-        // constant added to every discriminator sample, not to the signal
-        // this arc's tests build, which is why no synthetic test caught it:
-        // slicing against a fixed zero silently moves the decision boundary
-        // by however large that offset is. The capture's own mean is the
-        // honest estimate of it - GFSK data is balanced over any real
-        // stretch of bits - so the threshold is that mean, not zero.
-        let bias = inst.iter().sum::<f32>() / inst.len() as f32;
-        let mut bits: Vec<bool> = (0..symbols)
-            .map(|k| interpolate(&inst, phase + k as f64 * WORKING_SPS as f64) > bias)
-            .collect();
+        // front end's LO leakage and IQ DC offset concentrate, and where a
+        // real transmitter's own crystal error shows up too: both are a
+        // constant added to every discriminator sample, indistinguishable
+        // from each other at this stage and not present in this arc's own
+        // synthetic tests, which is why slicing against a fixed zero passed
+        // every one of them and no real capture. The capture's own mean is
+        // the honest estimate of that constant - GFSK data is balanced over
+        // any real stretch of bits - and B7 gives it a proper uncertainty:
+        // see `dsp::uncertainty::mean_with_uncertainty`'s own doc for why
+        // the sample mean is the right estimator here, not an approximation
+        // of one.
+        let offset = crate::signal::dsp::uncertainty::mean_with_uncertainty(&inst);
+        let mut bits =
+            super::sync::slice(&inst, WORKING_SPS as f64, symbols, offset.value() as f32);
         whiten(&mut bits, self.channel);
         let mut packet = pdu::decode(&bits)?;
-        packet.debug_coherence = self.last_coherence; // TEMP DEBUG
-        packet.debug_phase = phase; // TEMP DEBUG
+        packet.freq_offset_hz = Some(offset);
+        // `snr_from_metric` was derived for `Coherence::metric` - two noisy
+        // copies of the same unknown signal correlated against each other -
+        // and `Match::coherence` is a different measurement, a noisy signal
+        // correlated against a known, noiseless reference. Worked through
+        // for a unit-power reference: at the window lengths this arc uses
+        // the two converge to the same `rho = snr / (1 + snr)` relationship
+        // in the limit, so this reuses the already-tested inverse rather
+        // than deriving and separately validating a second one - reasoned
+        // to be a close approximation at `REFERENCE_SYMBOLS * WORKING_SPS`
+        // samples, not proven exact for a matched filter's own statistics.
+        // `None` only at a coherence of one, which the false-alarm threshold
+        // already keeps every real reading comfortably under.
+        packet.snr_db = snr_from_metric(self.last_coherence, REFERENCE_SYMBOLS * WORKING_SPS)
+            .map(|snr| 10.0 * snr.log10());
         Some(packet)
     }
 }

--- a/src/signal/ble/receive.rs
+++ b/src/signal/ble/receive.rs
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! The live pipeline: raw device bytes to a decoded advertising channel PDU.
+//!
+//! Four stages, run in order over every sample: [`Detector`] (a matched
+//! filter over raw IQ) finds the sync word; once it does, the samples that
+//! follow are captured; [`discriminate`] turns the capture into instantaneous
+//! frequency; and [`pdu::decode`], fed bits sliced from it and de-whitened,
+//! either returns a packet or says there was not enough of one yet.
+//!
+//! **No phase search here, deliberately - the detector's own peak already
+//! is one.** `signal::ble::detect`'s tests measured the matched filter's
+//! peak landing at the exact sample the sync word's last symbol ends on, so
+//! the header's first symbol begins at the very next sample: a known,
+//! symbol-aligned position, not an estimate. `dsp::timing::find_phase`
+//! stays the right tool for a burst whose alignment is not already known
+//! this precisely - which is not the position this arc's own detector
+//! leaves a caller in.
+
+use num_complex::Complex;
+
+use crate::hardware::SampleGeometry;
+use crate::signal::demod::decode as decode_iq;
+use crate::signal::dsp::code::lfsr::whiten;
+use crate::signal::dsp::correlate::threshold_for_false_alarm;
+use crate::signal::dsp::discriminate::discriminate;
+use crate::signal::dsp::fir::StreamingDecimator;
+use crate::signal::dsp::timing::{find_phase, interpolate};
+
+use super::detect::{Detector, Le1mParams, ADVERTISING_ACCESS_ADDRESS, REFERENCE_SYMBOLS};
+use super::pdu::{self, Packet};
+
+/// Samples per symbol this arc demodulates at. Not a specification
+/// requirement - LE 1M's symbol rate is fixed at 1 Mb/s, and this is
+/// comfortably enough resolution for the matched filter and the discriminator
+/// slice both, without decimating a wide capture further than it has to.
+const WORKING_SPS: usize = 4;
+const WORKING_RATE_HZ: f64 = 1_000_000.0 * WORKING_SPS as f64;
+
+/// The longest a legacy advertising PDU can be: 2-byte header, up to 37
+/// bytes of payload, 3-byte CRC.
+const MAX_PDU_BYTES: usize = 2 + 37 + 3;
+
+/// How rare a false trigger has to be to live with continuously, at 4
+/// million matched-filter evaluations a second.
+///
+/// **Measured against real air, not just the model.** `1e-9` - about one
+/// false trigger every four minutes under `false_alarm_rate`'s assumption of
+/// circularly symmetric Gaussian noise - was tried first on a real HackRF
+/// capture and found the coherence at every real trigger sitting at 0.12 to
+/// 0.17, a hair above that rate's own 0.122 threshold, on a busy real
+/// channel. Real RF is not the model: correlated interference, ADC
+/// artefacts and genuine nearby transmissions on other protocols give a
+/// matched filter far more near-misses than white Gaussian noise would, so
+/// the same formula's rate needs to be pushed much further to buy a
+/// threshold that actually rejects them. This is that adjustment - a rate
+/// with no claim to being the true false-alarm probability of a live
+/// receiver, only to producing a threshold high enough that this arc's own
+/// clean synthetic detections (coherence 0.85 upward) still clear it
+/// comfortably while the marginal real-air ones measured here do not.
+const FALSE_ALARM_RATE: f64 = 1e-30;
+
+/// Build the decimator from `raw_rate` to [`WORKING_RATE_HZ`], or say why it
+/// cannot be built.
+///
+/// Refuses rather than approximating when `raw_rate` is narrower than the
+/// working rate, or is not close to a whole multiple of it: a decode running
+/// against a rate it silently disagreed with about would scale every
+/// deviation and timing figure downstream by exactly the mismatch, with
+/// nothing on screen to say so - the same reasoning N15's survey refusal
+/// follows for a span too narrow to plan a sweep across.
+///
+/// **No anti-alias filter, and that is a measured choice rather than an
+/// oversight.** A Kaiser-windowed lowpass sized well inside the working
+/// Nyquist was tried here first; on this arc's own synthetic signal it
+/// measured the detector's matched-filter coherence collapsing from about
+/// 0.99 to under 0.15, for a cause this step did not run down to ground -
+/// the filter passes a plain in-band tone at unity gain, so the loss is
+/// specific to the GFSK waveform and the matched-filter comparison, not a
+/// gain or scaling bug. Plain decimation - keep every `d`th sample, filter
+/// nothing - measured 0.99 on the same signal, so that is what is here.
+/// The real cost this defers rather than removes: energy from outside the
+/// working Nyquist that a real wideband capture carries can alias into the
+/// band the detector searches, and nothing here has been measured against
+/// that on real hardware yet. HackRF's own baseband filter already narrows
+/// what reaches the ADC before this ever runs, which is why this is a
+/// deferred question and not a known-broken one.
+pub fn front_end(raw_rate: f64) -> Result<StreamingDecimator, String> {
+    if raw_rate < WORKING_RATE_HZ {
+        return Err(format!(
+            "BLE decode needs at least {:.1} Msps; the radio is at {:.3} Msps",
+            WORKING_RATE_HZ / 1e6,
+            raw_rate / 1e6
+        ));
+    }
+    let d = (raw_rate / WORKING_RATE_HZ).round().max(1.0) as usize;
+    let achieved = raw_rate / d as f64;
+    if (achieved - WORKING_RATE_HZ).abs() > WORKING_RATE_HZ * 0.01 {
+        return Err(format!(
+            "BLE decode needs a sample rate near a whole multiple of {:.1} Msps; {:.3} Msps is not one",
+            WORKING_RATE_HZ / 1e6,
+            raw_rate / 1e6
+        ));
+    }
+    Ok(StreamingDecimator::new(vec![1.0], d))
+}
+
+/// One channel's live receiver: the decimator, the detector, and the capture
+/// in progress, if any.
+pub struct Receiver {
+    decim: StreamingDecimator,
+    detector: Detector,
+    threshold: f64,
+    channel: u8,
+    raw_rate: f64,
+    capture: Vec<Complex<f32>>,
+    capturing: bool,
+    last_coherence: f64,
+}
+
+impl Receiver {
+    pub fn new(raw_rate: f64, channel: u8) -> Result<Self, String> {
+        let decim = front_end(raw_rate)?;
+        let params = Le1mParams {
+            sps: WORKING_SPS,
+            sample_rate: WORKING_RATE_HZ,
+            deviation_hz: 250_000.0,
+            bt: 0.5,
+        };
+        let threshold =
+            threshold_for_false_alarm(REFERENCE_SYMBOLS * WORKING_SPS, FALSE_ALARM_RATE);
+        Ok(Self {
+            decim,
+            detector: Detector::new(ADVERTISING_ACCESS_ADDRESS, params),
+            threshold,
+            channel,
+            raw_rate,
+            capture: Vec::new(),
+            capturing: false,
+            last_coherence: 0.0,
+        })
+    }
+
+    /// Whether this receiver is still the right one for `channel` at
+    /// `raw_rate` - a retune or a sample-rate change invalidates the
+    /// detector's own reference and the capture in progress alike, so the
+    /// caller rebuilds rather than reusing.
+    pub fn matches(&self, channel: u8, raw_rate: f64) -> bool {
+        self.channel == channel && (self.raw_rate - raw_rate).abs() < 1.0
+    }
+
+    /// Feed one block of raw device bytes. Returns every packet fully
+    /// decoded from it - almost always zero, and rarely more than one: a
+    /// legacy advertising PDU is under a third of a millisecond of air time.
+    pub fn push(&mut self, bytes: &[u8], geometry: SampleGeometry) -> Vec<Packet> {
+        let mut iq = Vec::new();
+        decode_iq(bytes, geometry, usize::MAX, &mut iq);
+        let mut working = Vec::new();
+        self.decim.process(&iq, &mut working);
+
+        let cap_limit = (16 + MAX_PDU_BYTES * 8) * WORKING_SPS;
+        let mut found = Vec::new();
+        for &sample in &working {
+            if self.capturing {
+                self.capture.push(sample);
+                match self.try_decode() {
+                    Some(packet) => {
+                        found.push(packet);
+                        self.capturing = false;
+                        self.capture.clear();
+                    }
+                    None if self.capture.len() > cap_limit => {
+                        // Either a corrupt length field or a false trigger
+                        // with nothing real behind it. Either way, waiting
+                        // longer only spends memory: give up and search
+                        // again.
+                        self.capturing = false;
+                        self.capture.clear();
+                    }
+                    None => {}
+                }
+            } else if let Some(coherence) = self.detector.push(sample) {
+                if coherence > self.threshold {
+                    self.capturing = true;
+                    self.capture.clear();
+                    self.last_coherence = coherence;
+                }
+            }
+        }
+        found
+    }
+
+    /// Try to decode whatever has been captured so far. `None` means either
+    /// "not enough yet" or "the header itself is not readable yet" - both
+    /// are the same instruction to the caller: keep capturing.
+    ///
+    /// **Runs `find_phase` on the capture, and does not trust the detector's
+    /// peak position for anything beyond where the capture starts.** The
+    /// first version indexed directly from the peak, reasoning that
+    /// `signal::ble::detect`'s own tests measured it landing exactly on the
+    /// symbol boundary - true for a synthetic packet built by the same
+    /// `gfsk::modulate` call the detector's own reference comes from, and
+    /// false for a real transmitter: a real symbol clock has no reason to
+    /// share a sample-aligned phase with this receiver's, only an
+    /// unsynchronised, arbitrary one. Real hardware measured this directly -
+    /// every field decoded correctly (plausible PDU types, real advertiser
+    /// addresses) while every CRC failed, which is exactly the signature of
+    /// a small, consistent sub-sample timing error rather than a wrong
+    /// algorithm. `find_phase` is the same tool B4 built for exactly this;
+    /// the deterministic shortcut only worked on the test signal that could
+    /// never have shown the bug.
+    fn try_decode(&self) -> Option<Packet> {
+        let mut inst = Vec::new();
+        discriminate(&self.capture, WORKING_RATE_HZ, &mut inst);
+        let symbols = inst.len() / WORKING_SPS;
+        if symbols < pdu::HEADER_BITS {
+            return None;
+        }
+        let phase = find_phase(&inst, WORKING_SPS as f64, symbols, 16);
+        // A tuning sitting exactly on the channel's own centre - which this
+        // arc's is, since it never mixes off it - is exactly where a real
+        // front end's LO leakage and IQ DC offset concentrate. That is a
+        // constant added to every discriminator sample, not to the signal
+        // this arc's tests build, which is why no synthetic test caught it:
+        // slicing against a fixed zero silently moves the decision boundary
+        // by however large that offset is. The capture's own mean is the
+        // honest estimate of it - GFSK data is balanced over any real
+        // stretch of bits - so the threshold is that mean, not zero.
+        let bias = inst.iter().sum::<f32>() / inst.len() as f32;
+        let mut bits: Vec<bool> = (0..symbols)
+            .map(|k| interpolate(&inst, phase + k as f64 * WORKING_SPS as f64) > bias)
+            .collect();
+        whiten(&mut bits, self.channel);
+        let mut packet = pdu::decode(&bits)?;
+        packet.debug_coherence = self.last_coherence; // TEMP DEBUG
+        packet.debug_phase = phase; // TEMP DEBUG
+        Some(packet)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hardware::{SampleFormat, StreamBlock};
+    use crate::signal::ble::channel;
+    use crate::signal::ble::gfsk::modulate;
+    use crate::signal::dsp::testkit::{at_snr, Rng};
+
+    fn eight_bit() -> SampleGeometry {
+        SampleGeometry {
+            format: SampleFormat::Int8,
+            full_scale: 128.0,
+        }
+    }
+
+    /// A synthetic packet, preamble through CRC, at the working rate - the
+    /// same construction B3's own detection tests use, extended with a real
+    /// PDU instead of random bits after the sync word.
+    fn synthetic_packet_iq(
+        ch: u8,
+        header_byte0: u8,
+        payload: &[u8],
+        noise_snr_db: f64,
+    ) -> Vec<Complex<f32>> {
+        let params = Le1mParams {
+            sps: WORKING_SPS,
+            sample_rate: WORKING_RATE_HZ,
+            deviation_hz: 250_000.0,
+            bt: 0.5,
+        };
+        let mut bits = super::super::detect::preamble_bits(ADVERTISING_ACCESS_ADDRESS).to_vec();
+        bits.extend_from_slice(&super::super::detect::access_address_bits(
+            ADVERTISING_ACCESS_ADDRESS,
+        ));
+        bits.extend_from_slice(&pdu::encode(ch, header_byte0, payload));
+        // A real capture never stops the instant a packet's own last bit
+        // ends - there is always more stream after it, whether the next
+        // packet's own preamble or just the channel's noise floor. Trailing
+        // padding stands in for that, so decoding the last symbol never
+        // waits on a sample this test would otherwise never provide.
+        let mut rng = Rng::new(1234);
+        bits.extend((0..16).map(|_| rng.next_u64() & 1 == 1));
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        if noise_snr_db.is_finite() {
+            at_snr(&clean, noise_snr_db, &mut Rng::new(99))
+        } else {
+            clean
+        }
+    }
+
+    fn bytes_for(iq: &[Complex<f32>], geometry: SampleGeometry) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(iq.len() * 2);
+        for s in iq {
+            let re = (s.re * geometry.full_scale).clamp(-127.0, 127.0) as i8;
+            let im = (s.im * geometry.full_scale).clamp(-127.0, 127.0) as i8;
+            bytes.push(re as u8);
+            bytes.push(im as u8);
+        }
+        bytes
+    }
+
+    /// B6's exit condition, built with a synthetic transmitter standing in
+    /// for the real one: a full ADV_IND, correctly received end to end -
+    /// detection, timing, de-whitening and CRC all agreeing.
+    #[test]
+    fn a_synthetic_adv_ind_is_received_whole() {
+        let addr = [0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33];
+        let mut payload = addr.to_vec();
+        payload.extend_from_slice(&[0x02, 0x01, 0x06]);
+        let iq = synthetic_packet_iq(37, 0x00, &payload, 20.0);
+        let geometry = eight_bit();
+        let bytes = bytes_for(&iq, geometry);
+
+        let mut rx = Receiver::new(WORKING_RATE_HZ, 37).unwrap();
+        let packets = rx.push(&bytes, geometry);
+        assert_eq!(packets.len(), 1, "expected exactly one packet");
+        let p = &packets[0];
+        assert_eq!(p.pdu_type, pdu::PduType::AdvInd);
+        assert_eq!(p.adv_addr, Some(addr));
+        assert!(p.crc_ok);
+    }
+
+    /// The same packet, fed one byte at a time - the shape a real capture
+    /// actually arrives in, blocks with no relation to a packet's own
+    /// boundaries.
+    #[test]
+    fn a_packet_split_across_many_small_blocks_still_arrives() {
+        let addr = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        let payload = addr.to_vec();
+        let iq = synthetic_packet_iq(37, 0x02, &payload, 20.0); // ADV_NONCONN_IND
+        let geometry = eight_bit();
+        let bytes = bytes_for(&iq, geometry);
+
+        let mut rx = Receiver::new(WORKING_RATE_HZ, 37).unwrap();
+        let mut found = Vec::new();
+        for chunk in bytes.chunks(6) {
+            found.extend(rx.push(chunk, geometry));
+        }
+        assert_eq!(found.len(), 1);
+        assert!(found[0].crc_ok);
+        assert_eq!(found[0].adv_addr, Some(addr));
+    }
+
+    /// A capture with nothing in it produces nothing - noise alone must not
+    /// manufacture a packet.
+    #[test]
+    fn noise_alone_produces_no_packets() {
+        let mut rng = Rng::new(3);
+        let noise = rng.noise(200_000, 1.0);
+        let geometry = eight_bit();
+        let bytes = bytes_for(&noise, geometry);
+        let mut rx = Receiver::new(WORKING_RATE_HZ, 37).unwrap();
+        assert!(rx.push(&bytes, geometry).is_empty());
+    }
+
+    /// A sample rate below the working rate is refused, not silently
+    /// mis-scaled.
+    #[test]
+    fn a_sample_rate_below_the_working_rate_is_refused() {
+        assert!(front_end(2_000_000.0).is_err());
+    }
+
+    /// A sample rate that decimates cleanly to the working rate is accepted,
+    /// at a few realistic HackRF rates.
+    #[test]
+    fn clean_multiples_of_the_working_rate_are_accepted() {
+        for rate in [4_000_000.0, 8_000_000.0, 20_000_000.0] {
+            assert!(front_end(rate).is_ok(), "rate {rate} should be accepted");
+        }
+    }
+
+    /// A real capture at 20 Msps, decimated down, still finds the packet -
+    /// the one test in this module that exercises [`front_end`]'s own filter
+    /// rather than assuming the working rate directly.
+    #[test]
+    fn a_packet_survives_decimation_from_a_wider_capture_rate() {
+        let addr = [0x10, 0x20, 0x30, 0x40, 0x50, 0x60];
+        let mut payload = addr.to_vec();
+        payload.push(0xFF);
+        let raw_rate = 20_000_000.0;
+        let params = Le1mParams {
+            sps: (raw_rate / 1_000_000.0) as usize,
+            sample_rate: raw_rate,
+            deviation_hz: 250_000.0,
+            bt: 0.5,
+        };
+        let mut bits = super::super::detect::preamble_bits(ADVERTISING_ACCESS_ADDRESS).to_vec();
+        bits.extend_from_slice(&super::super::detect::access_address_bits(
+            ADVERTISING_ACCESS_ADDRESS,
+        ));
+        bits.extend_from_slice(&pdu::encode(38, 0x00, &payload));
+        // See `synthetic_packet_iq`'s own comment: a real stream keeps going
+        // past a packet's last bit, and the decimating filter's own warm-up
+        // needs a few dozen more samples of margin besides.
+        let mut rng = Rng::new(4321);
+        bits.extend((0..64).map(|_| rng.next_u64() & 1 == 1));
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        let noisy = at_snr(&clean, 25.0, &mut Rng::new(7));
+        let geometry = eight_bit();
+        let bytes = bytes_for(&noisy, geometry);
+
+        let mut rx = Receiver::new(raw_rate, 38).unwrap();
+        let packets = rx.push(&bytes, geometry);
+        assert_eq!(packets.len(), 1, "expected exactly one packet");
+        assert!(packets[0].crc_ok);
+        assert_eq!(packets[0].adv_addr, Some(addr));
+    }
+
+    /// A block carried through `StreamBlock`, the real shape blocks arrive
+    /// in from the worker - not load-bearing for the decode itself, just
+    /// that the geometry plumbing is the same type the real worker uses.
+    #[test]
+    fn the_block_shape_matches_what_the_worker_hands_it() {
+        let geometry = eight_bit();
+        let block = StreamBlock {
+            seq: 1,
+            gap_before: false,
+            bytes: vec![0u8; 64],
+        };
+        let mut rx =
+            Receiver::new(WORKING_RATE_HZ, channel::channel_of(2_426_000_000).unwrap()).unwrap();
+        assert!(rx.push(&block.bytes, geometry).is_empty());
+    }
+}

--- a/src/signal/ble/sync.rs
+++ b/src/signal/ble/sync.rs
@@ -22,29 +22,25 @@ use crate::signal::dsp::timing::{find_phase, interpolate};
 /// worst-case phase error at 1/32 of a symbol - a sixteenth either side of
 /// the best candidate tried - comfortably finer than the bias
 /// `dsp::timing`'s own tests measured Gardner settling to on this signal.
-///
-/// No path from `main` yet - see [`slice`]'s own doc for why this whole
-/// module is presently dead together.
-#[allow(dead_code)]
 const PHASE_RESOLUTION: usize = 16;
 
 /// Recover one bit per symbol from a discriminator's instantaneous-frequency
 /// output, finding the symbol phase once over the whole span given and
-/// slicing every symbol at it.
+/// slicing every symbol against `threshold`.
 ///
-/// A bit is `true` when the recovered sample is positive - the same
-/// convention [`super::gfsk::modulate`] uses to map a `true` bit to positive
-/// deviation, so a bit slices back to itself with no sign flip to remember at
-/// the call site.
-///
-/// No caller in this arc's own code yet: nothing in `tasks` or `ui` feeds
-/// this a live stream until B6 puts a real packet on screen, the same
-/// position `signal::ble::detect::Detector` and `gfsk::modulate` are in.
-#[allow(dead_code)]
-pub fn slice(discriminator: &[f32], sps: f64, symbols: usize) -> Vec<bool> {
+/// A bit is `true` when the recovered sample is above `threshold` - `0.0`
+/// for a caller with nothing else to go on, matching the convention
+/// [`super::gfsk::modulate`] uses to map a `true` bit to positive deviation.
+/// `signal::ble::receive::Receiver` passes its own capture's mean instead:
+/// real hardware measured a real device's crystal offset (or this radio's
+/// own LO leakage) sitting exactly at the tuned centre this arc never mixes
+/// off, which shifts every discriminator sample by a constant a fixed zero
+/// would slice against wrongly. See `dsp::uncertainty::mean_with_uncertainty`
+/// for how that same mean becomes B7's reported frequency offset.
+pub fn slice(discriminator: &[f32], sps: f64, symbols: usize, threshold: f32) -> Vec<bool> {
     let phase = find_phase(discriminator, sps, symbols, PHASE_RESOLUTION);
     (0..symbols)
-        .map(|k| interpolate(discriminator, phase + k as f64 * sps) > 0.0)
+        .map(|k| interpolate(discriminator, phase + k as f64 * sps) > threshold)
         .collect()
 }
 
@@ -125,7 +121,7 @@ mod tests {
             let mut inst = Vec::new();
             discriminate(&noisy, params.sample_rate, &mut inst);
 
-            let recovered = slice(&inst, params.sps as f64, n_bits - guard);
+            let recovered = slice(&inst, params.sps as f64, n_bits - guard, 0.0);
 
             let errors = recovered
                 .iter()
@@ -182,7 +178,7 @@ mod tests {
         let noisy = at_snr(&clean, snr_db, &mut Rng::new(4));
         let mut inst = Vec::new();
         discriminate(&noisy, params.sample_rate, &mut inst);
-        let recovered = slice(&inst, params.sps as f64, n_bits - 5);
+        let recovered = slice(&inst, params.sps as f64, n_bits - 5, 0.0);
 
         let errors = recovered
             .iter()
@@ -214,7 +210,7 @@ mod tests {
         );
         let mut inst = Vec::new();
         discriminate(&clean, params.sample_rate, &mut inst);
-        let recovered = slice(&inst, params.sps as f64, bits.len() - 5);
+        let recovered = slice(&inst, params.sps as f64, bits.len() - 5, 0.0);
         assert_eq!(&recovered[..], &bits[..recovered.len()]);
     }
 }

--- a/src/signal/ble/sync.rs
+++ b/src/signal/ble/sync.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Symbol timing recovery and bit slicing for LE 1M: turning a discriminator's
+//! instantaneous-frequency output into bits, once [`super::detect`] has
+//! already said a packet starts near here.
+//!
+//! Uses `dsp::timing::find_phase`, not `dsp::timing::recover` (Gardner).
+//! Design section 1.1 offers both and says to use whichever the test vectors
+//! say is enough; building this module's own test vectors found Gardner's
+//! detector converging to a phase measurably biased from the true one on a
+//! Gaussian-filtered GFSK discriminator's output - a real S-curve bias from
+//! feeding it a pulse shape its derivation does not assume, not a bug, and
+//! `dsp::timing`'s own module doc records the measurement. A BLE advertising
+//! packet is a short burst with a static phase, not a stream whose timing
+//! drifts, which is exactly what a search-once-and-hold method fits, so that
+//! is what this module uses.
+
+use crate::signal::dsp::timing::{find_phase, interpolate};
+
+/// How many candidate phases [`slice`] tries per symbol period. 16 puts the
+/// worst-case phase error at 1/32 of a symbol - a sixteenth either side of
+/// the best candidate tried - comfortably finer than the bias
+/// `dsp::timing`'s own tests measured Gardner settling to on this signal.
+///
+/// No path from `main` yet - see [`slice`]'s own doc for why this whole
+/// module is presently dead together.
+#[allow(dead_code)]
+const PHASE_RESOLUTION: usize = 16;
+
+/// Recover one bit per symbol from a discriminator's instantaneous-frequency
+/// output, finding the symbol phase once over the whole span given and
+/// slicing every symbol at it.
+///
+/// A bit is `true` when the recovered sample is positive - the same
+/// convention [`super::gfsk::modulate`] uses to map a `true` bit to positive
+/// deviation, so a bit slices back to itself with no sign flip to remember at
+/// the call site.
+///
+/// No caller in this arc's own code yet: nothing in `tasks` or `ui` feeds
+/// this a live stream until B6 puts a real packet on screen, the same
+/// position `signal::ble::detect::Detector` and `gfsk::modulate` are in.
+#[allow(dead_code)]
+pub fn slice(discriminator: &[f32], sps: f64, symbols: usize) -> Vec<bool> {
+    let phase = find_phase(discriminator, sps, symbols, PHASE_RESOLUTION);
+    (0..symbols)
+        .map(|k| interpolate(discriminator, phase + k as f64 * sps) > 0.0)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::ble::detect::Le1mParams;
+    use crate::signal::ble::gfsk::modulate;
+    use crate::signal::dsp::discriminate::discriminate;
+    use crate::signal::dsp::testkit::{at_snr, Rng};
+
+    /// The ideal noncoherent binary orthogonal FSK bit error rate.
+    ///
+    /// Source: J.G. Proakis, "Digital Communications", the standard result
+    /// for noncoherent detection of binary orthogonal signals,
+    /// `Pb = (1/2) exp(-Eb / (2 N0))`. This is a bound on the best any
+    /// receiver for this signal class can do, not a prediction of what this
+    /// one measures - GFSK's Gaussian filtering is not the rectangular pulse
+    /// the bound assumes, and slicing a single discriminator sample per
+    /// symbol is not the optimal (matched, integrate-and-dump) receiver the
+    /// bound is for. `the_measured_ber_never_beats_the_ideal_bound` is the
+    /// half of that gap this module can assert without a second citation for
+    /// exactly how large the other half is; the margin in
+    /// `bit_error_rate_tracks_the_ideal_curve_within_a_measured_margin` is
+    /// measured, not looked up.
+    fn ideal_noncoherent_fsk_ber(eb_n0_db: f64) -> f64 {
+        let eb_n0 = 10f64.powf(eb_n0_db / 10.0);
+        0.5 * (-eb_n0 / 2.0).exp()
+    }
+
+    /// `dsp::testkit::at_snr`'s SNR is per complex sample, over the whole
+    /// sampled bandwidth; `Eb/N0` is energy per bit over noise spectral
+    /// density. Oversampling by `sps` samples per bit spreads the same total
+    /// noise power over `sps` times as many samples, which is exactly the
+    /// `sps` factor between the two: `Eb/N0 = SNR * sps` linearly, derived
+    /// from `Eb = S / R_b` and `N0 = N / F_s` with `F_s = sps * R_b`.
+    fn snr_db_for_eb_n0_db(eb_n0_db: f64, sps: usize) -> f64 {
+        eb_n0_db - 10.0 * (sps as f64).log10()
+    }
+
+    /// B4's exit condition: bit error rate against a generated packet
+    /// matches the theoretical GFSK curve within a stated margin, over a
+    /// spread of SNRs wide enough to see the curve's own shape.
+    ///
+    /// **The margin is wide, and the reason is worth recording rather than
+    /// hiding.** [`ideal_noncoherent_fsk_ber`] is the bound for a receiver
+    /// that integrates a full symbol's energy (a matched filter or
+    /// integrate-and-dump). This module's [`slice`] does neither - it reads
+    /// one instantaneous discriminator sample per symbol, out of `sps`
+    /// available, and throws the rest away. Measured on this signal, that
+    /// costs on the order of 12-15 dB against the ideal bound, not the couple
+    /// of dB a shaping-filter penalty alone would - a real, substantial
+    /// implementation loss from the deliberately simple detector, and not a
+    /// number this arc can cite a receiver-specific formula for. What is
+    /// still true, and still worth asserting precisely: the curve's shape
+    /// (bit errors fall as Eb/N0 rises), the physical floor (never better
+    /// than the ideal bound), and that it actually gets good at high enough
+    /// Eb/N0 rather than plateauing at some broken floor.
+    #[test]
+    fn bit_error_rate_tracks_the_ideal_curve_within_a_measured_margin() {
+        let params = Le1mParams::at(4);
+        let n_bits = 60_000;
+        let mut rng = Rng::new(1);
+        let bits: Vec<bool> = (0..n_bits).map(|_| rng.next_u64() & 1 == 1).collect();
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+
+        let guard = 5;
+        let mut previous = f64::INFINITY;
+        for eb_n0_db in [6.0, 12.0, 18.0, 24.0] {
+            let snr_db = snr_db_for_eb_n0_db(eb_n0_db, params.sps);
+            let noisy = at_snr(&clean, snr_db, &mut Rng::new(2));
+            let mut inst = Vec::new();
+            discriminate(&noisy, params.sample_rate, &mut inst);
+
+            let recovered = slice(&inst, params.sps as f64, n_bits - guard);
+
+            let errors = recovered
+                .iter()
+                .zip(bits.iter())
+                .filter(|(a, b)| a != b)
+                .count();
+            let measured = errors as f64 / recovered.len() as f64;
+            let ideal = ideal_noncoherent_fsk_ber(eb_n0_db);
+
+            assert!(
+                measured >= ideal * 0.5,
+                "eb/n0={eb_n0_db} dB: measured BER {measured:e} is implausibly below the ideal bound {ideal:e}"
+            );
+            // Twenty dB of implementation loss as the ceiling: generous
+            // against the roughly 12-15 dB actually measured, wide enough to
+            // absorb run-to-run statistical noise, still tight enough that a
+            // detector reading pure noise (BER near 0.5 at every point)
+            // would fail it at the higher Eb/N0 values below.
+            let degraded = ideal_noncoherent_fsk_ber(eb_n0_db - 20.0);
+            assert!(
+                measured <= degraded,
+                "eb/n0={eb_n0_db} dB: measured BER {measured:e} exceeds the ideal curve degraded by 20 dB ({degraded:e})"
+            );
+            assert!(
+                measured <= previous + 1e-9,
+                "eb/n0={eb_n0_db} dB: BER {measured:e} rose above the previous point's {previous:e} - Eb/N0 increasing must not make bits worse"
+            );
+            previous = measured;
+        }
+        assert!(
+            previous < 0.01,
+            "at the highest Eb/N0 tested the receiver should be working well: BER was {previous:e}"
+        );
+    }
+
+    /// The physical floor: no receiver for this signal beats the ideal
+    /// noncoherent bound, so a measurement under it would mean the test's
+    /// own accounting is wrong, not that the receiver is unusually good.
+    #[test]
+    fn the_measured_ber_never_beats_the_ideal_bound() {
+        let params = Le1mParams::at(4);
+        let n_bits = 20_000;
+        let mut rng = Rng::new(3);
+        let bits: Vec<bool> = (0..n_bits).map(|_| rng.next_u64() & 1 == 1).collect();
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        let eb_n0_db = 3.0;
+        let snr_db = snr_db_for_eb_n0_db(eb_n0_db, params.sps);
+        let noisy = at_snr(&clean, snr_db, &mut Rng::new(4));
+        let mut inst = Vec::new();
+        discriminate(&noisy, params.sample_rate, &mut inst);
+        let recovered = slice(&inst, params.sps as f64, n_bits - 5);
+
+        let errors = recovered
+            .iter()
+            .zip(bits.iter())
+            .filter(|(a, b)| a != b)
+            .count();
+        let measured = errors as f64 / recovered.len() as f64;
+        let ideal = ideal_noncoherent_fsk_ber(eb_n0_db);
+        assert!(
+            measured >= ideal * 0.5,
+            "measured BER {measured:e} is implausibly below the ideal bound {ideal:e} at {eb_n0_db} dB"
+        );
+    }
+
+    /// A noiseless packet slices back to exactly its own bits - the floor
+    /// this module has to clear before any BER-versus-noise claim means
+    /// anything, and cheap enough to keep as its own test.
+    #[test]
+    fn a_noiseless_packet_slices_to_exactly_its_own_bits() {
+        let params = Le1mParams::at(4);
+        let mut rng = Rng::new(5);
+        let bits: Vec<bool> = (0..2000).map(|_| rng.next_u64() & 1 == 1).collect();
+        let clean = modulate(
+            &bits,
+            params.sps,
+            params.deviation_hz,
+            params.sample_rate,
+            params.bt,
+        );
+        let mut inst = Vec::new();
+        discriminate(&clean, params.sample_rate, &mut inst);
+        let recovered = slice(&inst, params.sps as f64, bits.len() - 5);
+        assert_eq!(&recovered[..], &bits[..recovered.len()]);
+    }
+}

--- a/src/signal/ble/sync.rs
+++ b/src/signal/ble/sync.rs
@@ -37,11 +37,26 @@ const PHASE_RESOLUTION: usize = 16;
 /// off, which shifts every discriminator sample by a constant a fixed zero
 /// would slice against wrongly. See `dsp::uncertainty::mean_with_uncertainty`
 /// for how that same mean becomes B7's reported frequency offset.
-pub fn slice(discriminator: &[f32], sps: f64, symbols: usize, threshold: f32) -> Vec<bool> {
+///
+/// **Returns the raw sample at each symbol alongside the bit it became.**
+/// The threshold decision throws away exactly the number
+/// `signal::ble::measure::modulation_quality` needs - how far the
+/// discriminator actually swung, not just which side of the line it landed
+/// on - so this hands both back rather than making a second caller re-run
+/// [`find_phase`] and [`interpolate`] to recover what this call already
+/// computed.
+pub fn slice(
+    discriminator: &[f32],
+    sps: f64,
+    symbols: usize,
+    threshold: f32,
+) -> (Vec<bool>, Vec<f32>) {
     let phase = find_phase(discriminator, sps, symbols, PHASE_RESOLUTION);
-    (0..symbols)
-        .map(|k| interpolate(discriminator, phase + k as f64 * sps) > threshold)
-        .collect()
+    let raw: Vec<f32> = (0..symbols)
+        .map(|k| interpolate(discriminator, phase + k as f64 * sps))
+        .collect();
+    let bits = raw.iter().map(|&s| s > threshold).collect();
+    (bits, raw)
 }
 
 #[cfg(test)]
@@ -121,7 +136,7 @@ mod tests {
             let mut inst = Vec::new();
             discriminate(&noisy, params.sample_rate, &mut inst);
 
-            let recovered = slice(&inst, params.sps as f64, n_bits - guard, 0.0);
+            let (recovered, _) = slice(&inst, params.sps as f64, n_bits - guard, 0.0);
 
             let errors = recovered
                 .iter()
@@ -178,7 +193,7 @@ mod tests {
         let noisy = at_snr(&clean, snr_db, &mut Rng::new(4));
         let mut inst = Vec::new();
         discriminate(&noisy, params.sample_rate, &mut inst);
-        let recovered = slice(&inst, params.sps as f64, n_bits - 5, 0.0);
+        let (recovered, _) = slice(&inst, params.sps as f64, n_bits - 5, 0.0);
 
         let errors = recovered
             .iter()
@@ -210,7 +225,7 @@ mod tests {
         );
         let mut inst = Vec::new();
         discriminate(&clean, params.sample_rate, &mut inst);
-        let recovered = slice(&inst, params.sps as f64, bits.len() - 5, 0.0);
+        let (recovered, _) = slice(&inst, params.sps as f64, bits.len() - 5, 0.0);
         assert_eq!(&recovered[..], &bits[..recovered.len()]);
     }
 }

--- a/src/signal/ble/testkit.rs
+++ b/src/signal/ble/testkit.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! A synthetic GFSK transmitter, for testing this arc against a signal whose
+//! bits are known - the role [`crate::signal::dsp::testkit`] plays for the
+//! shared layer, and the reason this exists separately from it: that module
+//! knows no protocol, and a GFSK modulator with a modulation index and a
+//! Gaussian filter baked in is BLE-specific policy, not a shared primitive.
+//!
+//! Compiled only under `cfg(test)`, and reused from B2 onward: every later
+//! step that checks a bit error rate, a timing recovery, or a decode against
+//! a known signal starts here rather than re-deriving its own.
+
+use num_complex::Complex;
+
+use crate::signal::dsp::fir::gaussian_taps;
+
+/// How many symbol periods the shaping filter spans. 4 is the common choice
+/// in the references [`gaussian_taps`] cites; nothing in this file depends on
+/// the exact figure, only on the filter it produces being the one B2's own
+/// tests measure.
+const FILTER_SPAN_SYMBOLS: usize = 4;
+
+/// A GFSK-modulated baseband signal for the given bits, at `sps` samples per
+/// symbol.
+///
+/// `deviation_hz` is the peak frequency deviation - 250 kHz for BLE LE 1M's
+/// nominal modulation index of 0.5 at a 1 Mb/s symbol rate, since `h = 2 *
+/// deviation / symbol_rate`. Design section 2.1's measurement 1 is this same
+/// `h`, measured the other way around from a captured signal. `bt` is the
+/// Gaussian filter's bandwidth-time product, 0.5 for BLE.
+///
+/// NRZ maps each bit to ±1, held for `sps` samples, Gaussian-filtered to
+/// shape the transitions, then frequency-modulated: the textbook GFSK
+/// construction, and the reason [`gaussian_taps`]'s own unit-sum
+/// normalisation matters here - an unnormalised kernel would scale the
+/// deviation along with it.
+pub fn modulate(
+    bits: &[bool],
+    sps: usize,
+    deviation_hz: f64,
+    sample_rate: f64,
+    bt: f64,
+) -> Vec<Complex<f32>> {
+    let n = bits.len() * sps;
+    let mut nrz = vec![0.0f32; n];
+    for (i, &b) in bits.iter().enumerate() {
+        let v = if b { 1.0 } else { -1.0 };
+        for s in nrz[i * sps..(i + 1) * sps].iter_mut() {
+            *s = v;
+        }
+    }
+
+    let taps = gaussian_taps(bt, sps, FILTER_SPAN_SYMBOLS);
+    let half = (taps.len() as isize - 1) / 2;
+    let filtered: Vec<f64> = (0..n as isize)
+        .map(|i| {
+            taps.iter()
+                .enumerate()
+                .map(|(k, &h)| {
+                    let j = i - half + k as isize;
+                    let x = if j >= 0 && (j as usize) < n {
+                        nrz[j as usize] as f64
+                    } else {
+                        0.0
+                    };
+                    h as f64 * x
+                })
+                .sum::<f64>()
+        })
+        .collect();
+
+    let mut phase = 0.0f64;
+    filtered
+        .iter()
+        .map(|&f| {
+            phase += std::f64::consts::TAU * deviation_hz * f / sample_rate;
+            Complex::new(phase.cos() as f32, phase.sin() as f32)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::dsp::discriminate::discriminate;
+    use crate::signal::dsp::testkit::{at_snr, Rng};
+
+    const SPS: usize = 4;
+    const SYMBOL_RATE: f64 = 1_000_000.0;
+    const SAMPLE_RATE: f64 = SYMBOL_RATE * SPS as f64;
+    const DEVIATION_HZ: f64 = 250_000.0;
+    const BT: f64 = 0.5;
+
+    /// Slice the discriminator output at each symbol's own centre. No timing
+    /// recovery yet - that is B4's job - so this leans on the fact that the
+    /// synthetic transmitter and this reader agree exactly on where a symbol
+    /// starts.
+    fn recover_bits(iq: &[Complex<f32>], n_bits: usize) -> Vec<bool> {
+        let mut inst = Vec::new();
+        discriminate(iq, SAMPLE_RATE, &mut inst);
+        (0..n_bits)
+            .map(|k| {
+                let centre = k * SPS + SPS / 2;
+                let idx = centre.saturating_sub(1).min(inst.len() - 1);
+                inst[idx] > 0.0
+            })
+            .collect()
+    }
+
+    /// B2's exit condition: a generated packet demodulates back to the bits
+    /// that went in, at high SNR. Guarded at both ends because a finite
+    /// kernel tapers the very first and last symbol towards zero deviation -
+    /// zero-padding at the edge of the filter, not a defect in the round trip
+    /// - and a symbol sitting in that taper is not what this test checks.
+    #[test]
+    fn a_generated_packet_demodulates_back_to_its_own_bits_at_high_snr() {
+        let mut rng = Rng::new(1);
+        let bits: Vec<bool> = (0..64).map(|_| rng.next_u64() & 1 == 1).collect();
+        let iq = modulate(&bits, SPS, DEVIATION_HZ, SAMPLE_RATE, BT);
+        let noisy = at_snr(&iq, 25.0, &mut rng);
+        let recovered = recover_bits(&noisy, bits.len());
+        for i in 2..bits.len() - 2 {
+            assert_eq!(recovered[i], bits[i], "bit {i} did not round-trip");
+        }
+    }
+
+    /// The same, with no noise at all - the cleanest possible statement of
+    /// the round trip, kept separate so a failure here is never confused with
+    /// an SNR margin problem.
+    #[test]
+    fn a_generated_packet_demodulates_back_to_its_own_bits_noiseless() {
+        let mut rng = Rng::new(2);
+        let bits: Vec<bool> = (0..64).map(|_| rng.next_u64() & 1 == 1).collect();
+        let iq = modulate(&bits, SPS, DEVIATION_HZ, SAMPLE_RATE, BT);
+        let recovered = recover_bits(&iq, bits.len());
+        for i in 2..bits.len() - 2 {
+            assert_eq!(recovered[i], bits[i], "bit {i} did not round-trip");
+        }
+    }
+
+    /// The modulator deviates by about what was asked: on a run of
+    /// same-valued bits, once the Gaussian filter has settled, the
+    /// instantaneous frequency at the centre of the run should sit close to
+    /// the full deviation rather than some other scale entirely.
+    #[test]
+    fn the_modulator_deviates_by_about_what_was_asked() {
+        let bits = vec![true; 20];
+        let iq = modulate(&bits, SPS, DEVIATION_HZ, SAMPLE_RATE, BT);
+        let mut inst = Vec::new();
+        discriminate(&iq, SAMPLE_RATE, &mut inst);
+        let settled = inst[inst.len() / 2];
+        assert!(
+            (settled - DEVIATION_HZ as f32).abs() < DEVIATION_HZ as f32 * 0.1,
+            "settled deviation {settled}, want about {DEVIATION_HZ}"
+        );
+    }
+
+    /// Flip every bit and the deviation flips sign with it - the other half
+    /// of "about what was asked", since a scale error alone would not catch a
+    /// sign error in the phase integration.
+    #[test]
+    fn a_run_of_the_other_bit_deviates_the_other_way() {
+        let bits = vec![false; 20];
+        let iq = modulate(&bits, SPS, DEVIATION_HZ, SAMPLE_RATE, BT);
+        let mut inst = Vec::new();
+        discriminate(&iq, SAMPLE_RATE, &mut inst);
+        let settled = inst[inst.len() / 2];
+        assert!(
+            (settled + DEVIATION_HZ as f32).abs() < DEVIATION_HZ as f32 * 0.1,
+            "settled deviation {settled}, want about {}",
+            -DEVIATION_HZ
+        );
+    }
+}

--- a/src/signal/demod/mod.rs
+++ b/src/signal/demod/mod.rs
@@ -173,10 +173,13 @@ const ENVELOPE_GATE: f32 = 0.35;
 
 /// Polar discriminator: instantaneous frequency in Hz.
 ///
-/// `f[n] = arg(z[n+1] · conj(z[n])) · rate / 2π`, unambiguous to ±`rate`/2 - at a
-/// 333 kHz channel rate that is ±166 kHz, comfortably clear of the 75 kHz WFM
-/// limit. Always yields `len − 1` outputs: the missing first sample is precisely
-/// the block-splice guard, since the previous block's last phase is not usable.
+/// The per-pair arithmetic is [`crate::signal::dsp::discriminate::instantaneous_freq_hz`],
+/// unambiguous to ±`rate`/2 - at a 333 kHz channel rate that is ±166 kHz,
+/// comfortably clear of the 75 kHz WFM limit. Always yields `len − 1` outputs:
+/// the missing first sample is precisely the block-splice guard, since the
+/// previous block's last phase is not usable. What is FM-specific, and stays
+/// here rather than living in `dsp`, is everything below about a sample not
+/// being trustworthy.
 ///
 /// Samples failing [`ENVELOPE_GATE`] are replaced by the previous trustworthy
 /// value rather than removed. Dropping them would leave a non-uniform time base,
@@ -185,7 +188,6 @@ const ENVELOPE_GATE: f32 = 0.35;
 /// intact, and since the gate only fires on rare envelope collapses, the
 /// spectral cost is far smaller than the aliasing that dropping would cause.
 pub fn fm_discriminate(iq: &[Complex<f32>], rate: f64, out: &mut Vec<f32>) {
-    use std::f64::consts::PI;
     out.clear();
     if iq.len() < 2 {
         return;
@@ -200,7 +202,6 @@ pub fn fm_discriminate(iq: &[Complex<f32>], rate: f64, out: &mut Vec<f32>) {
     let floor_sq = (mean_sq * (ENVELOPE_GATE * ENVELOPE_GATE) as f64) as f32;
 
     out.reserve(iq.len() - 1);
-    let scale = (rate / (2.0 * PI)) as f32;
     let mut held = 0.0f32;
     let mut have_held = false;
     for w in iq.windows(2) {
@@ -209,8 +210,7 @@ pub fn fm_discriminate(iq: &[Complex<f32>], rate: f64, out: &mut Vec<f32>) {
             out.push(held);
             continue;
         }
-        let prod = w[1] * w[0].conj();
-        let f = prod.im.atan2(prod.re) * scale;
+        let f = crate::signal::dsp::discriminate::instantaneous_freq_hz(w[0], w[1], rate);
         if !have_held {
             // Backfill any leading run gated out before the first valid sample,
             // so the block never opens with a fabricated zero.

--- a/src/signal/dsp/code/crc.rs
+++ b/src/signal/dsp/code/crc.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! CRC-24, the integrity check every Bluetooth Low Energy packet ends with.
+//!
+//! Source: Bluetooth Core Specification, Vol 6, Part B, section 3.1.1 -
+//! polynomial `0x00065B`, reflected input and output, initial value
+//! `0x555555` for advertising channel PDUs and test packets. (A data channel
+//! connection's own CRC initial value is carried in `CONNECT_IND` and is a
+//! later step's concern; nothing here assumes the advertising value where it
+//! should not.)
+//!
+//! **Verified against an independent, authoritative catalogue, not the
+//! specification restated from memory.** The CRC RevEng catalogue
+//! (<https://reveng.sourceforge.io/crc-catalogue/17plus.htm>) lists this exact
+//! algorithm as `CRC-24/BLE`, names the same specification section as its
+//! own source, and - the part worth more than the citation - publishes a
+//! check value: the CRC of the ASCII bytes `"123456789"` is `0xC25A56`.
+//! `matches_the_reveng_check_value` computes that value with the algorithm
+//! below and asserts the two agree. An independent party's own computed
+//! answer, not a formula trusted on citation alone, is the strongest
+//! verification available without a licensed copy of the specification
+//! itself.
+//!
+//! Reflected input and output means BLE's own bit order - least-significant-
+//! bit-first, the same convention `signal::ble::detect::access_address_bits`
+//! already follows - is handled by reflecting the polynomial and the initial
+//! value once at the top, then running an ordinary right-shifting register
+//! with each byte's bits taken in the order they already are. This is the
+//! standard technique for a reflected CRC (the same one that makes CRC-32's
+//! well-known `0xEDB88320` the bit-reversal of its own polynomial
+//! `0x04C11DB7`), not something specific to Bluetooth.
+
+/// No consumer yet outside this module's own tests: nothing decodes a full
+/// PDU to check against a CRC until B6 puts a real packet on screen. Applies
+/// to every item below.
+#[allow(dead_code)]
+const POLY: u32 = 0x00065B;
+#[allow(dead_code)]
+const INIT: u32 = 0x555555;
+#[allow(dead_code)]
+const MASK: u32 = 0x00FF_FFFF;
+
+/// Reverse the low 24 bits of `x`.
+#[allow(dead_code)]
+fn reflect24(mut x: u32) -> u32 {
+    let mut r = 0u32;
+    for _ in 0..24 {
+        r = (r << 1) | (x & 1);
+        x >>= 1;
+    }
+    r
+}
+
+/// CRC-24/BLE of `data`: reflected input and output, the advertising-channel
+/// and test-packet initial value.
+#[allow(dead_code)]
+pub fn crc24_ble(data: &[u8]) -> u32 {
+    let rev_poly = reflect24(POLY);
+    let mut reg = reflect24(INIT);
+    for &byte in data {
+        reg ^= byte as u32;
+        for _ in 0..8 {
+            if reg & 1 != 0 {
+                reg = (reg >> 1) ^ rev_poly;
+            } else {
+                reg >>= 1;
+            }
+        }
+    }
+    reg & MASK
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The catalogue's own check value. If this passes, the polynomial, the
+    /// initial value and the reflection are all right at once - a wrong
+    /// value in any of the three would move this number.
+    #[test]
+    fn matches_the_reveng_check_value() {
+        assert_eq!(crc24_ble(b"123456789"), 0xC2_5A56);
+    }
+
+    /// The result never exceeds 24 bits, on an input long enough that a
+    /// missing mask would show up as a wider number.
+    #[test]
+    fn the_result_stays_within_twenty_four_bits() {
+        let data = [0xFFu8; 64];
+        assert!(crc24_ble(&data) <= 0x00FF_FFFF);
+    }
+
+    /// One changed bit changes the check - the cheap sanity a degenerate
+    /// (always-zero-feedback, or similar) implementation would fail.
+    #[test]
+    fn a_single_changed_byte_changes_the_result() {
+        let a = crc24_ble(b"advertising channel PDU");
+        let b = crc24_ble(b"advertising channel PDX");
+        assert_ne!(a, b);
+    }
+
+    /// The empty message still produces a value - the initial value alone,
+    /// reflected - rather than panicking on a zero-length slice.
+    #[test]
+    fn the_empty_message_does_not_panic() {
+        assert_eq!(crc24_ble(&[]), reflect24(INIT));
+    }
+}

--- a/src/signal/dsp/code/crc.rs
+++ b/src/signal/dsp/code/crc.rs
@@ -34,15 +34,11 @@
 /// No consumer yet outside this module's own tests: nothing decodes a full
 /// PDU to check against a CRC until B6 puts a real packet on screen. Applies
 /// to every item below.
-#[allow(dead_code)]
 const POLY: u32 = 0x00065B;
-#[allow(dead_code)]
 const INIT: u32 = 0x555555;
-#[allow(dead_code)]
 const MASK: u32 = 0x00FF_FFFF;
 
 /// Reverse the low 24 bits of `x`.
-#[allow(dead_code)]
 fn reflect24(mut x: u32) -> u32 {
     let mut r = 0u32;
     for _ in 0..24 {
@@ -54,7 +50,6 @@ fn reflect24(mut x: u32) -> u32 {
 
 /// CRC-24/BLE of `data`: reflected input and output, the advertising-channel
 /// and test-packet initial value.
-#[allow(dead_code)]
 pub fn crc24_ble(data: &[u8]) -> u32 {
     let rev_poly = reflect24(POLY);
     let mut reg = reflect24(INIT);

--- a/src/signal/dsp/code/lfsr.rs
+++ b/src/signal/dsp/code/lfsr.rs
@@ -31,13 +31,11 @@
 /// No consumer yet outside this module's own tests: nothing de-whitens a
 /// real payload until B6 puts a real packet on screen. Applies to every item
 /// below.
-#[allow(dead_code)]
 pub fn seed(channel: u8) -> u8 {
     0x40 | (channel & 0x3F)
 }
 
 /// One step: the bit whitened out, and the LFSR's next state.
-#[allow(dead_code)]
 fn step(state: u8) -> (bool, u8) {
     let out = state & 1 != 0;
     let feedback = ((state >> 4) ^ state) & 1;
@@ -53,7 +51,6 @@ fn step(state: u8) -> (bool, u8) {
 /// with the same channel is the identity - whitening and de-whitening are
 /// the same XOR run once each way, which is why there is one function here
 /// rather than two that would have to agree.
-#[allow(dead_code)]
 pub fn whiten(bits: &mut [bool], channel: u8) {
     let mut state = seed(channel);
     for bit in bits.iter_mut() {

--- a/src/signal/dsp/code/lfsr.rs
+++ b/src/signal/dsp/code/lfsr.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Bit-stream whitening: the 7-bit LFSR every Bluetooth Low Energy packet is
+//! scrambled with, seeded from the channel it is sent on.
+//!
+//! Source: Bluetooth Core Specification, Vol 6, Part B - polynomial
+//! `x^7 + x^4 + 1`, seeded from the channel index. Verified two separate
+//! ways rather than trusted on one citation:
+//!
+//! - [`seed`]'s formula is pinned against a worked numeric example found in
+//!   independent public documentation: channel `0x25` seeds to `0x65`. See
+//!   `the_seed_matches_its_own_worked_example`.
+//! - The feedback taps are pinned by their own mathematical signature, not
+//!   by citation alone. Several different tap pairs on a 7-bit register give
+//!   a maximal-length (127-state) sequence, and a maximal length alone does
+//!   not say *which* primitive polynomial produced it - so
+//!   `the_output_satisfies_its_own_recurrence` checks that this sequence
+//!   obeys the specific linear recurrence `x^7 + x^4 + 1` implies,
+//!   `o[t] = o[t-3] xor o[t-7]`, which only the correct tap pair can satisfy.
+//!   Found by brute-force search over every tap pair during this step's own
+//!   development, not assumed from the first plausible-looking pair.
+
+/// The whitening LFSR's initial state for `channel`, 0 to 39.
+///
+/// Bit 6 is always set; bits 0 to 5 are the channel index. `channel` values
+/// of 64 and above have no meaning here and are masked rather than rejected,
+/// since whitening has no way to refuse an out-of-range channel of its own -
+/// the channel plan in `signal::ble::channel` is what enforces 0 to 39.
+///
+/// No consumer yet outside this module's own tests: nothing de-whitens a
+/// real payload until B6 puts a real packet on screen. Applies to every item
+/// below.
+#[allow(dead_code)]
+pub fn seed(channel: u8) -> u8 {
+    0x40 | (channel & 0x3F)
+}
+
+/// One step: the bit whitened out, and the LFSR's next state.
+#[allow(dead_code)]
+fn step(state: u8) -> (bool, u8) {
+    let out = state & 1 != 0;
+    let feedback = ((state >> 4) ^ state) & 1;
+    let next = (state >> 1) | (feedback << 6);
+    (out, next)
+}
+
+/// Whiten `bits` in place, using the sequence [`seed`] generates for
+/// `channel`.
+///
+/// **De-whitening is the same operation, not a second one.** The sequence
+/// depends only on the channel, never on the data, so applying this twice
+/// with the same channel is the identity - whitening and de-whitening are
+/// the same XOR run once each way, which is why there is one function here
+/// rather than two that would have to agree.
+#[allow(dead_code)]
+pub fn whiten(bits: &mut [bool], channel: u8) {
+    let mut state = seed(channel);
+    for bit in bits.iter_mut() {
+        let (out, next) = step(state);
+        *bit ^= out;
+        state = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The one worked example public documentation states directly.
+    #[test]
+    fn the_seed_matches_its_own_worked_example() {
+        assert_eq!(seed(0x25), 0x65);
+    }
+
+    /// Bit 6 is always the constant, and the low six bits are always the
+    /// channel, for every channel this arc actually uses.
+    #[test]
+    fn the_seed_carries_the_channel_in_its_low_six_bits() {
+        for channel in 0..=39u8 {
+            let s = seed(channel);
+            assert_eq!(s & 0x40, 0x40, "channel {channel}: bit 6 not set");
+            assert_eq!(s & 0x3F, channel, "channel {channel}: low bits wrong");
+        }
+    }
+
+    /// A 7-bit LFSR with the right primitive polynomial visits all 127
+    /// nonzero states before returning to its start. Several tap pairs on
+    /// this register give *some* maximal sequence; this alone does not yet
+    /// say it is the *right* one - `the_output_satisfies_its_own_recurrence`
+    /// is what pins that down.
+    #[test]
+    fn the_lfsr_is_maximal_length() {
+        let start = seed(0);
+        let mut state = start;
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..127 {
+            assert!(seen.insert(state), "state {state:#x} repeated early");
+            let (_, next) = step(state);
+            state = next;
+        }
+        assert_eq!(state, start, "127 steps did not return to the start");
+    }
+
+    /// The signature of `x^7 + x^4 + 1` specifically, not just of some
+    /// maximal-length polynomial: the output sequence obeys
+    /// `o[t] = o[t-3] xor o[t-7]` for every `t` past the seventh output.
+    #[test]
+    fn the_output_satisfies_its_own_recurrence() {
+        let mut state = seed(17);
+        let out: Vec<bool> = (0..60)
+            .map(|_| {
+                let (o, next) = step(state);
+                state = next;
+                o
+            })
+            .collect();
+        for t in 7..out.len() {
+            assert_eq!(
+                out[t],
+                out[t - 3] ^ out[t - 7],
+                "recurrence broken at t={t}"
+            );
+        }
+    }
+
+    /// Whitening twice with the same channel is the identity - the property
+    /// that makes de-whitening the same function as whitening.
+    #[test]
+    fn whitening_twice_with_the_same_channel_is_the_identity() {
+        let original = [
+            true, true, false, true, false, false, false, true, true, false, true, true, false,
+            false, true, false,
+        ];
+        let mut bits = original;
+        whiten(&mut bits, 6);
+        assert_ne!(bits, original, "whitening did nothing");
+        whiten(&mut bits, 6);
+        assert_eq!(bits, original, "whitening twice did not return the input");
+    }
+
+    /// Two different channels really do scramble differently - a whitening
+    /// step that ignored the channel would still pass every test above.
+    #[test]
+    fn different_channels_whiten_differently() {
+        let data = [true; 32];
+        let mut a = data;
+        let mut b = data;
+        whiten(&mut a, 0);
+        whiten(&mut b, 37);
+        assert_ne!(a, b);
+    }
+}

--- a/src/signal/dsp/code/mod.rs
+++ b/src/signal/dsp/code/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Channel coding: whitening and error checking, shared across protocols the
+//! way every other `dsp` module is. `viterbi.rs` (Wi-Fi's convolutional
+//! decoder) arrives with that arc; [`lfsr`] and [`crc`] arrive with B5,
+//! Bluetooth's own de-whitening and CRC-24.
+
+pub mod crc;
+pub mod lfsr;

--- a/src/signal/dsp/correlate.rs
+++ b/src/signal/dsp/correlate.rs
@@ -177,10 +177,15 @@ impl DelayedAutocorrelator {
 
 /// One reading from [`MatchedFilter`].
 ///
-/// No consumer yet. Design section 10's F4 (symbol timing from the L-LTF
-/// cross-correlation) is the plan's own answer for where this lands - a known
-/// preamble sequence correlated against the live stream is exactly what a
-/// matched filter is for.
+/// Has a real caller now: `signal::ble::detect::Detector` (B3) builds a
+/// combined preamble-and-access-address reference and reads this back,
+/// since the advertising access address is known in advance and a known
+/// sequence correlated against the live stream is exactly what a matched
+/// filter is for. The lint still fires because `Detector` itself has no path
+/// from `main` yet - nothing in `tasks` or `ui` feeds it a live stream until
+/// B6 puts a real packet on screen - so the whole chain is dead together and
+/// lights up together. Design section 10's F4 (symbol timing from the L-LTF
+/// cross-correlation) is a second identified consumer, not yet built.
 #[derive(Clone, Copy, Debug)]
 #[allow(dead_code)]
 pub struct Match {
@@ -210,7 +215,7 @@ impl Match {
 
 /// Correlation of a signal with a sequence known in advance.
 ///
-/// No consumer yet; see [`Match`].
+/// See [`Match`] for who uses it and why the dead-code lint still fires.
 #[allow(dead_code)]
 pub struct MatchedFilter {
     /// The reference, conjugated and reversed, so applying it is a forward walk
@@ -322,9 +327,13 @@ impl MatchedFilter {
 /// false-alarm rate it is required to have, which is a specification, rather
 /// than from a level that happened to work on one recording.
 /// `noise_alone_obeys_the_false_alarm_law` measures it rather than trusting it.
-/// No consumer yet: F2 (Wi-Fi burst detection over `dsp::correlate`) and B3
-/// (Bluetooth preamble correlation) both name a measured false-alarm rate as
-/// their exit criterion.
+///
+/// **Still no production consumer**, and that is now a more precise claim
+/// than it used to be: `signal::ble::detect`'s tests (B3) measure this exact
+/// law against a real reference, but through [`threshold_for_false_alarm`],
+/// the direction a caller actually thinks in - "I want this false-alarm rate,
+/// what threshold gives it" - not this function's own direction. F2 (Wi-Fi
+/// burst detection) is a second identified future consumer of the same kind.
 #[allow(dead_code)]
 pub fn false_alarm_rate(taps: usize, threshold: f64) -> f64 {
     if taps < 2 {

--- a/src/signal/dsp/correlate.rs
+++ b/src/signal/dsp/correlate.rs
@@ -177,17 +177,14 @@ impl DelayedAutocorrelator {
 
 /// One reading from [`MatchedFilter`].
 ///
-/// Has a real caller now: `signal::ble::detect::Detector` (B3) builds a
-/// combined preamble-and-access-address reference and reads this back,
-/// since the advertising access address is known in advance and a known
-/// sequence correlated against the live stream is exactly what a matched
-/// filter is for. The lint still fires because `Detector` itself has no path
-/// from `main` yet - nothing in `tasks` or `ui` feeds it a live stream until
-/// B6 puts a real packet on screen - so the whole chain is dead together and
-/// lights up together. Design section 10's F4 (symbol timing from the L-LTF
-/// cross-correlation) is a second identified consumer, not yet built.
+/// Reaches `main` since B6: `signal::ble::detect::Detector` builds a
+/// combined preamble-and-access-address reference and reads this back on
+/// every sample of a live capture, since the advertising access address is
+/// known in advance and a known sequence correlated against the live stream
+/// is exactly what a matched filter is for. Design section 10's F4 (symbol
+/// timing from the L-LTF cross-correlation) is a second identified consumer,
+/// not yet built.
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 pub struct Match {
     /// The correlation with the reference sequence.
     pub value: Complex<f64>,
@@ -196,7 +193,6 @@ pub struct Match {
     reference_energy: f64,
 }
 
-#[allow(dead_code)]
 impl Match {
     /// `|y|^2 / (E_reference * E_window)`, in `[0, 1]` by Cauchy-Schwarz.
     ///
@@ -215,8 +211,7 @@ impl Match {
 
 /// Correlation of a signal with a sequence known in advance.
 ///
-/// See [`Match`] for who uses it and why the dead-code lint still fires.
-#[allow(dead_code)]
+/// See [`Match`] for who uses it.
 pub struct MatchedFilter {
     /// The reference, conjugated and reversed, so applying it is a forward walk
     /// back through the history.
@@ -228,7 +223,6 @@ pub struct MatchedFilter {
     energy: f64,
 }
 
-#[allow(dead_code)]
 impl MatchedFilter {
     pub fn new(reference: &[Complex<f32>]) -> Self {
         let wide: Vec<Complex<f64>> = reference
@@ -328,12 +322,13 @@ impl MatchedFilter {
 /// than from a level that happened to work on one recording.
 /// `noise_alone_obeys_the_false_alarm_law` measures it rather than trusting it.
 ///
-/// **Still no production consumer**, and that is now a more precise claim
-/// than it used to be: `signal::ble::detect`'s tests (B3) measure this exact
-/// law against a real reference, but through [`threshold_for_false_alarm`],
-/// the direction a caller actually thinks in - "I want this false-alarm rate,
-/// what threshold gives it" - not this function's own direction. F2 (Wi-Fi
-/// burst detection) is a second identified future consumer of the same kind.
+/// **Still no production consumer.** `signal::ble::detect`'s live path (B6
+/// onward) reaches for [`threshold_for_false_alarm`] instead, the direction
+/// a caller actually thinks in - "I want this false-alarm rate, what
+/// threshold gives it" - not this function's own direction. Only this
+/// module's own tests call it, checking the law it states rather than
+/// living by it. F2 (Wi-Fi burst detection) is a second identified future
+/// consumer of the same kind.
 #[allow(dead_code)]
 pub fn false_alarm_rate(taps: usize, threshold: f64) -> f64 {
     if taps < 2 {

--- a/src/signal/dsp/discriminate.rs
+++ b/src/signal/dsp/discriminate.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! The quadrature discriminator: instantaneous frequency between two IQ
+//! samples, with no opinion about what to do when one of them is
+//! untrustworthy.
+//!
+//! Generalised the way N1 generalised `signal::demod`'s streaming decimator
+//! into [`super::fir`]: the arithmetic with a closed-form answer moved here,
+//! and `signal::demod::fm_discriminate` keeps the envelope-gate-and-hold
+//! policy it has always had, because that policy exists to protect a WFM
+//! pilot on a channel assumed to carry a continuous carrier - a decision that
+//! belongs with the demodulator that has a reason to want it, not here. BLE
+//! has neither a pilot nor a continuous carrier to protect, so B2 calls
+//! [`discriminate`] directly with no gate.
+
+use num_complex::Complex;
+
+/// Instantaneous frequency in Hz between two consecutive samples.
+///
+/// `f = arg(b * conj(a)) * rate / 2π`, unambiguous to ±`rate`/2.
+pub fn instantaneous_freq_hz(a: Complex<f32>, b: Complex<f32>, rate: f64) -> f32 {
+    use std::f64::consts::PI;
+    let prod = b * a.conj();
+    let scale = (rate / (2.0 * PI)) as f32;
+    prod.im.atan2(prod.re) * scale
+}
+
+/// The whole block, consecutive pairs. `len - 1` outputs: the first sample of
+/// the block has no predecessor to discriminate against.
+///
+/// No production consumer yet: `signal::demod::fm_discriminate` calls
+/// [`instantaneous_freq_hz`] directly rather than this, because it needs the
+/// envelope gate applied between the two calls, not around the whole block.
+/// B2's own tests are the only caller until a step in this arc needs the
+/// gate-free block form.
+#[allow(dead_code)]
+pub fn discriminate(iq: &[Complex<f32>], rate: f64, out: &mut Vec<f32>) {
+    out.clear();
+    if iq.len() < 2 {
+        return;
+    }
+    out.reserve(iq.len() - 1);
+    for w in iq.windows(2) {
+        out.push(instantaneous_freq_hz(w[0], w[1], rate));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tone offset from DC by a constant frequency reads back as exactly
+    /// that offset, everywhere except the ambiguity limit.
+    #[test]
+    fn a_constant_offset_reads_back_as_that_offset() {
+        use std::f64::consts::TAU;
+        let rate = 1_000_000.0;
+        let offset = 50_000.0;
+        let n = 200;
+        let step = TAU * offset / rate;
+        let mut phase = 0.0f64;
+        let iq: Vec<_> = (0..n)
+            .map(|_| {
+                let z = Complex::new(phase.cos() as f32, phase.sin() as f32);
+                phase += step;
+                z
+            })
+            .collect();
+        let mut out = Vec::new();
+        discriminate(&iq, rate, &mut out);
+        assert_eq!(out.len(), n - 1);
+        for &f in &out {
+            assert!((f as f64 - offset).abs() < 1.0, "got {f}, want {offset}");
+        }
+    }
+
+    /// Two samples in, one frequency out - the definition, pinned so nobody
+    /// "fixes" the off-by-one later.
+    #[test]
+    fn two_samples_yield_one_frequency() {
+        let a = Complex::new(1.0, 0.0);
+        let b = Complex::new(0.0, 1.0);
+        let mut out = Vec::new();
+        discriminate(&[a, b], 1_000_000.0, &mut out);
+        assert_eq!(out.len(), 1);
+    }
+
+    /// Fewer than two samples has no pair to discriminate, and must say so by
+    /// producing nothing rather than by panicking on an empty window.
+    #[test]
+    fn fewer_than_two_samples_yields_nothing() {
+        let mut out = Vec::new();
+        discriminate(&[], 1_000_000.0, &mut out);
+        assert!(out.is_empty());
+        discriminate(&[Complex::new(1.0, 0.0)], 1_000_000.0, &mut out);
+        assert!(out.is_empty());
+    }
+
+    /// A quarter turn per sample is exactly a quarter of the sample rate - the
+    /// single hand-checkable point on the curve, independent of the rate
+    /// scaling `a_constant_offset_reads_back_as_that_offset` exercises.
+    #[test]
+    fn a_quarter_turn_per_sample_is_a_quarter_of_the_rate() {
+        let rate = 8_000.0;
+        let f = instantaneous_freq_hz(Complex::new(1.0, 0.0), Complex::new(0.0, 1.0), rate);
+        assert!((f - 2_000.0).abs() < 1e-3, "got {f}");
+    }
+}

--- a/src/signal/dsp/discriminate.rs
+++ b/src/signal/dsp/discriminate.rs
@@ -34,7 +34,6 @@ pub fn instantaneous_freq_hz(a: Complex<f32>, b: Complex<f32>, rate: f64) -> f32
 /// envelope gate applied between the two calls, not around the whole block.
 /// B2's own tests are the only caller until a step in this arc needs the
 /// gate-free block form.
-#[allow(dead_code)]
 pub fn discriminate(iq: &[Complex<f32>], rate: f64, out: &mut Vec<f32>) {
     out.clear();
     if iq.len() < 2 {

--- a/src/signal/dsp/fir.rs
+++ b/src/signal/dsp/fir.rs
@@ -73,8 +73,9 @@ pub fn design_lowpass(taps: usize, fc: f64) -> Vec<f32> {
 /// factorial or a power, and the loop stops when a term no longer moves the sum.
 /// Sixty-four terms cover every `beta` a filter design will ask for; `beta = 20`
 /// is a 190 dB stopband and converges in about thirty.
-/// No consumer yet outside this file; see [`design_lowpass_to_spec`].
-#[allow(dead_code)]
+///
+/// Called from [`design_lowpass_kaiser`], which `super::resample::Resampler::new`
+/// reaches directly.
 fn bessel_i0(x: f64) -> f64 {
     let mut term = 1.0f64;
     let mut sum = 1.0f64;
@@ -103,8 +104,10 @@ fn bessel_i0(x: f64) -> f64 {
 /// Below 21 dB the window is rectangular. That is not a special case bolted on:
 /// truncating the sinc alone already gives about 21 dB, so there is nothing left
 /// for a window to do.
-/// No production consumer yet; see [`design_lowpass_to_spec`].
-#[allow(dead_code)]
+///
+/// `super::resample::Resampler::new` calls this directly, alongside
+/// [`kaiser_taps`] and [`design_lowpass_kaiser`], rather than through
+/// [`design_lowpass_to_spec`].
 pub fn kaiser_beta(stopband_db: f64) -> f64 {
     if stopband_db > 50.0 {
         0.1102 * (stopband_db - 8.7)
@@ -141,8 +144,8 @@ pub fn kaiser_beta(stopband_db: f64) -> f64 {
 /// is no upper clamp. A transition of a millionth of the sample rate really does
 /// need millions of taps, and whether that is affordable is the caller's
 /// question, not this function's to answer with a number nobody asked for.
-/// No production consumer yet; see [`design_lowpass_to_spec`].
-#[allow(dead_code)]
+///
+/// `super::resample::Resampler::new` calls this directly; see [`kaiser_beta`].
 pub fn kaiser_taps(transition: f64, stopband_db: f64) -> usize {
     use std::f64::consts::TAU;
     if !transition.is_finite() || transition <= 0.0 || !stopband_db.is_finite() {
@@ -158,10 +161,10 @@ pub fn kaiser_taps(transition: f64, stopband_db: f64) -> usize {
 /// -6 dB at `fc`. `beta` comes from [`kaiser_beta`], and pairing it with a tap
 /// count from [`kaiser_taps`] for the *same* attenuation is the caller's job.
 /// [`design_lowpass_to_spec`] exists so that job can be skipped.
-/// No production consumer yet; see [`design_lowpass_to_spec`], which calls
-/// this, and [`super::resample::Resampler::new`], which calls the same three
-/// primitives directly rather than through it.
-#[allow(dead_code)]
+///
+/// `super::resample::Resampler::new` calls this directly, alongside
+/// [`kaiser_beta`] and [`kaiser_taps`], rather than through
+/// [`design_lowpass_to_spec`].
 pub fn design_lowpass_kaiser(taps: usize, fc: f64, beta: f64) -> Vec<f32> {
     let denom = bessel_i0(beta);
     windowed_sinc(taps, fc, |i, taps| {
@@ -192,10 +195,11 @@ pub fn design_lowpass_kaiser(taps: usize, fc: f64, beta: f64) -> Vec<f32> {
 /// 80 dB as 79.96 dB in 253. The design rule is that close to calibrated, which
 /// is why `the_requested_stopband_is_delivered` holds it to half a dB either
 /// way rather than only checking that the filter is good enough.
-/// **No production consumer yet.** Design section 12.3's resample case - "the
-/// device's rate is a rational multiple of what a mode needs" - is the
-/// identified future need; no arc has reached the point of building a feed at a
-/// rate the radio cannot produce directly.
+/// **No production consumer.** `super::resample::Resampler::new` needs this
+/// same design rule but calls [`kaiser_taps`], [`design_lowpass_kaiser`] and
+/// [`kaiser_beta`] directly rather than through this one-call wrapper -
+/// nothing else has yet needed "ask for a stopband and a transition width, get
+/// a filter" as a single step.
 #[allow(dead_code)]
 pub fn design_lowpass_to_spec(fc: f64, transition: f64, stopband_db: f64) -> Vec<f32> {
     design_lowpass_kaiser(
@@ -226,10 +230,9 @@ pub fn design_lowpass_to_spec(fc: f64, transition: f64, stopband_db: f64) -> Vec
 /// `the_dash_3db_point_sits_at_bt_over_sps` measures the filter this produces
 /// rather than trusting the formula on faith.
 ///
-/// No production consumer yet: `signal::ble::testkit`'s synthetic transmitter
-/// is a test-only fixture, so this is presently only reached from `cfg(test)`
-/// code, the same shape as [`design_lowpass_to_spec`] above.
-#[allow(dead_code)]
+/// Reaches `main` since B6: `signal::ble::gfsk::modulate` calls this to build
+/// the pulse-shaping kernel every GFSK transmit and every reference
+/// correlation goes through, live in `signal::ble::detect::Detector`.
 pub fn gaussian_taps(bt: f64, sps: usize, span_symbols: usize) -> Vec<f32> {
     use std::f64::consts::PI;
     let n = (sps * span_symbols).max(1) | 1;

--- a/src/signal/dsp/fir.rs
+++ b/src/signal/dsp/fir.rs
@@ -205,6 +205,52 @@ pub fn design_lowpass_to_spec(fc: f64, transition: f64, stopband_db: f64) -> Vec
     )
 }
 
+/// A Gaussian low-pass kernel, for pulse-shaping a GFSK/GMSK modulator.
+///
+/// `bt` is the filter's bandwidth-time product - its own -3 dB bandwidth times
+/// the symbol period - which is the number a specification actually states
+/// (0.5 for Bluetooth BR and for BLE; see the arc documents for the clause).
+/// `sps` is samples per symbol and `span_symbols` is how many symbol periods
+/// the kernel spans, centred on zero. `sps * span_symbols` is forced odd, the
+/// same convention [`windowed_sinc`] uses, so the group delay is a whole
+/// number of samples.
+///
+/// Closed form: `alpha = sqrt(ln 2 / 2) / bt`, `h(t) = (sqrt(pi) / alpha) *
+/// exp(-(pi t / alpha)^2)` for `t` in symbol periods, normalised to unit sum
+/// so filtering a constant NRZ run leaves its level unchanged - the same
+/// DC-gain convention [`design_lowpass`] uses, for the same reason: a
+/// modulator's deviation is set by that level, not by the filter's own gain.
+/// This is the standard Gaussian pulse for GFSK/GMSK (the closed form MATLAB's
+/// Communications Toolbox `gaussdesign` documents); the mathematics is not
+/// itself a specification clause, only `bt` is, and
+/// `the_dash_3db_point_sits_at_bt_over_sps` measures the filter this produces
+/// rather than trusting the formula on faith.
+///
+/// No production consumer yet: `signal::ble::testkit`'s synthetic transmitter
+/// is a test-only fixture, so this is presently only reached from `cfg(test)`
+/// code, the same shape as [`design_lowpass_to_spec`] above.
+#[allow(dead_code)]
+pub fn gaussian_taps(bt: f64, sps: usize, span_symbols: usize) -> Vec<f32> {
+    use std::f64::consts::PI;
+    let n = (sps * span_symbols).max(1) | 1;
+    let m = (n - 1) as f64 / 2.0;
+    let alpha = (2f64.ln() / 2.0).sqrt() / bt;
+    let mut h = Vec::with_capacity(n);
+    let mut sum = 0.0f64;
+    for i in 0..n {
+        let t = (i as f64 - m) / sps as f64;
+        let v = (PI.sqrt() / alpha) * (-(PI * t / alpha).powi(2)).exp();
+        sum += v;
+        h.push(v);
+    }
+    if sum.abs() > 1e-12 {
+        for v in h.iter_mut() {
+            *v /= sum;
+        }
+    }
+    h.into_iter().map(|v| v as f32).collect()
+}
+
 /// A decimating FIR that keeps its state between calls, so successive blocks
 /// produce one seamless output stream.
 ///
@@ -635,6 +681,62 @@ mod tests {
             (hamming - kaiser).abs() < 3.0,
             "hamming gives {hamming:.2} dB and kaiser asked for 53 gives {kaiser:.2} dB"
         );
+    }
+
+    /// A Gaussian kernel has unit sum (DC gain), the way every filter in this
+    /// module normalises, so a constant NRZ run through it survives at level.
+    #[test]
+    fn a_gaussian_kernel_has_unit_dc_gain() {
+        for (bt, sps, span) in [(0.5f64, 4usize, 4usize), (0.3, 8, 6), (1.0, 4, 2)] {
+            let h = gaussian_taps(bt, sps, span);
+            let dc: f32 = h.iter().sum();
+            assert!((dc - 1.0).abs() < 1e-4, "bt={bt} sps={sps}: DC gain = {dc}");
+        }
+    }
+
+    /// Symmetric, the way an odd-length linear-phase kernel must be, so
+    /// filtering introduces a whole-sample delay and nothing else.
+    #[test]
+    fn a_gaussian_kernel_is_symmetric() {
+        let h = gaussian_taps(0.5, 4, 4);
+        let n = h.len();
+        assert_eq!(n % 2, 1, "kernel length must be odd");
+        for (i, &t) in h.iter().enumerate() {
+            assert!((t - h[n - 1 - i]).abs() < 1e-7, "tap {i} breaks symmetry");
+        }
+    }
+
+    /// The bandwidth-time product's own definition, measured rather than
+    /// assumed: `bt`'s -3 dB point sits at `bt / sps` cycles per sample, since
+    /// a symbol period is `sps` samples and `bt` is bandwidth times symbol
+    /// period.
+    #[test]
+    fn the_dash_3db_point_sits_at_bt_over_sps() {
+        for (bt, sps) in [(0.5f64, 8usize), (0.3, 8), (0.7, 4)] {
+            let h = gaussian_taps(bt, sps, 8);
+            let at = response(&h, bt / sps as f64);
+            assert!(
+                (at - std::f64::consts::FRAC_1_SQRT_2).abs() < 0.1,
+                "bt={bt} sps={sps}: |H(bt/sps)| = {at:.4}, expected about -3 dB (0.707)"
+            );
+        }
+    }
+
+    /// A wider `bt` is a wider filter: at a frequency fixed in cycles per
+    /// sample, the response only grows as `bt` grows. This is the ordering
+    /// invariant a wrong sign or an inverted formula would break even if the
+    /// -3 dB point happened to land right by coincidence.
+    #[test]
+    fn a_wider_bt_passes_more_at_a_fixed_frequency() {
+        let sps = 8;
+        let f = 0.05;
+        let mut last = 0.0;
+        for bt in [0.2f64, 0.4, 0.6, 0.8, 1.0] {
+            let h = gaussian_taps(bt, sps, 8);
+            let at = response(&h, f);
+            assert!(at > last, "bt={bt}: response {at} did not grow from {last}");
+            last = at;
+        }
     }
 
     /// The tap count follows the two things it is a function of, and refuses a

--- a/src/signal/dsp/mod.rs
+++ b/src/signal/dsp/mod.rs
@@ -36,6 +36,7 @@ pub mod nco;
 pub mod resample;
 #[cfg(test)]
 pub mod testkit;
+pub mod timing;
 pub mod uncertainty;
 pub mod window;
 

--- a/src/signal/dsp/mod.rs
+++ b/src/signal/dsp/mod.rs
@@ -29,6 +29,7 @@
 //! only knows how to build the filter it is asked for.
 
 pub mod correlate;
+pub mod discriminate;
 pub mod estimate;
 pub mod fir;
 pub mod nco;

--- a/src/signal/dsp/mod.rs
+++ b/src/signal/dsp/mod.rs
@@ -28,6 +28,7 @@
 //! filter has to be and what decimation reaches its target rate; this module
 //! only knows how to build the filter it is asked for.
 
+pub mod code;
 pub mod correlate;
 pub mod discriminate;
 pub mod estimate;

--- a/src/signal/dsp/timing.rs
+++ b/src/signal/dsp/timing.rs
@@ -123,6 +123,21 @@ pub fn recover(x: &[f32], start: f64, sps: f64, gain: f64, symbols: usize) -> Ve
 /// own caller has no path from `main` yet, the same position `dsp::correlate`
 /// and `ble::gfsk` were in until B6 wires a live capture into this arc.
 #[allow(dead_code)]
+///
+/// **Scored on the nearest raw sample, never an interpolated one - measured,
+/// not a stylistic choice.** Linear interpolation between two independent
+/// noisy samples has less variance than either sample alone - at the
+/// midpoint, exactly half - so a search that scores interpolated amplitude
+/// is biased toward whichever candidates land on a real, unblended sample:
+/// on real hardware every phase this function returned was an exact integer
+/// number of samples, never one of the fractional candidates `resolution`
+/// was supposed to also try, which is the signature of exactly this bias
+/// rather than of those candidates genuinely being worse. A clean synthetic
+/// test never showed it, because the effect is proportional to how noisy the
+/// two neighbouring samples are relative to the signal, and a noiseless test
+/// signal has none. Rounding to the nearest sample scores every candidate on
+/// an unblended value, at the cost of `resolution` values finer than `sps`
+/// buying nothing real cannot already tell apart.
 pub fn find_phase(x: &[f32], sps: f64, symbols: usize, resolution: usize) -> f64 {
     let resolution = resolution.max(1);
     let mut best_phase = 0.0;
@@ -130,14 +145,24 @@ pub fn find_phase(x: &[f32], sps: f64, symbols: usize, resolution: usize) -> f64
     for step in 0..resolution {
         let phase = sps * step as f64 / resolution as f64;
         let score: f64 = (0..symbols)
-            .map(|k| interpolate(x, phase + k as f64 * sps).abs() as f64)
+            .map(|k| {
+                let pos = (phase + k as f64 * sps).round();
+                let idx = pos.clamp(0.0, (x.len().max(1) - 1) as f64) as usize;
+                x.get(idx).copied().unwrap_or(0.0).abs() as f64
+            })
             .sum();
         if score > best_score {
             best_score = score;
             best_phase = phase;
         }
     }
-    best_phase
+    // Several candidates within one sample of each other round to the same
+    // index and therefore tie on score; snapping the winner to the nearest
+    // whole sample picks the middle of that tie rather than whichever one
+    // the search happened to reach first, and keeps a caller that samples
+    // the result with real interpolation from reintroducing the very
+    // smoothing this function exists to avoid.
+    best_phase.round()
 }
 
 #[cfg(test)]

--- a/src/signal/dsp/timing.rs
+++ b/src/signal/dsp/timing.rs
@@ -122,22 +122,24 @@ pub fn recover(x: &[f32], start: f64, sps: f64, gain: f64, symbols: usize) -> Ve
 /// Called for real by `signal::ble::sync::slice` (B4) - but that function's
 /// own caller has no path from `main` yet, the same position `dsp::correlate`
 /// and `ble::gfsk` were in until B6 wires a live capture into this arc.
-#[allow(dead_code)]
 ///
-/// **Scored on the nearest raw sample, never an interpolated one - measured,
-/// not a stylistic choice.** Linear interpolation between two independent
-/// noisy samples has less variance than either sample alone - at the
-/// midpoint, exactly half - so a search that scores interpolated amplitude
-/// is biased toward whichever candidates land on a real, unblended sample:
-/// on real hardware every phase this function returned was an exact integer
-/// number of samples, never one of the fractional candidates `resolution`
-/// was supposed to also try, which is the signature of exactly this bias
-/// rather than of those candidates genuinely being worse. A clean synthetic
-/// test never showed it, because the effect is proportional to how noisy the
-/// two neighbouring samples are relative to the signal, and a noiseless test
-/// signal has none. Rounding to the nearest sample scores every candidate on
-/// an unblended value, at the cost of `resolution` values finer than `sps`
-/// buying nothing real cannot already tell apart.
+/// **Open lead from B6's real-hardware testing, not yet acted on here.**
+/// Every phase this function returned on a real HackRF capture was an exact
+/// integer number of samples - never one of the fractional candidates
+/// `resolution` is supposed to also try. The likely cause: interpolating
+/// between two independent noisy samples has less variance than either
+/// sample alone (half, at the midpoint), so scoring interpolated amplitude
+/// is biased toward whichever candidates land on a real, unblended sample -
+/// an effect proportional to noise, which is why no synthetic test here
+/// caught it. A first fix (score the nearest raw sample instead of an
+/// interpolated one) removed that bias but cost `a_noiseless_packet_slices_
+/// to_exactly_its_own_bits` its exact match, because the coarser, integer-
+/// only resolution loses real precision this arc's own clean signal needs.
+/// Reverted rather than landed half-verified: the right fix likely scores a
+/// small window around each candidate rather than a single point, trading
+/// neither noise robustness nor precision, but that is untested and B6's
+/// own plan is where this is recorded rather than guessed at further here.
+#[allow(dead_code)]
 pub fn find_phase(x: &[f32], sps: f64, symbols: usize, resolution: usize) -> f64 {
     let resolution = resolution.max(1);
     let mut best_phase = 0.0;
@@ -145,24 +147,14 @@ pub fn find_phase(x: &[f32], sps: f64, symbols: usize, resolution: usize) -> f64
     for step in 0..resolution {
         let phase = sps * step as f64 / resolution as f64;
         let score: f64 = (0..symbols)
-            .map(|k| {
-                let pos = (phase + k as f64 * sps).round();
-                let idx = pos.clamp(0.0, (x.len().max(1) - 1) as f64) as usize;
-                x.get(idx).copied().unwrap_or(0.0).abs() as f64
-            })
+            .map(|k| interpolate(x, phase + k as f64 * sps).abs() as f64)
             .sum();
         if score > best_score {
             best_score = score;
             best_phase = phase;
         }
     }
-    // Several candidates within one sample of each other round to the same
-    // index and therefore tie on score; snapping the winner to the nearest
-    // whole sample picks the middle of that tie rather than whichever one
-    // the search happened to reach first, and keeps a caller that samples
-    // the result with real interpolation from reintroducing the very
-    // smoothing this function exists to avoid.
-    best_phase.round()
+    best_phase
 }
 
 #[cfg(test)]

--- a/src/signal/dsp/timing.rs
+++ b/src/signal/dsp/timing.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! Two ways to find a signal's own symbol phase, offered as alternatives
+//! rather than a pipeline of both: [`recover`] (Gardner's adaptive detector)
+//! and [`find_phase`] (exhaustive search over one symbol period). Design
+//! section 1.1 names both and says to use whichever the test vectors say is
+//! enough - and for `signal::ble`'s actual signal, they said something
+//! specific enough to record here rather than only in the arc's own plan.
+//!
+//! **[`recover`] is validated on its own terms and used by neither arc yet.**
+//! Gardner's detector is derived for a raised-cosine-shaped baseband PAM/PSK
+//! signal, where the "S-curve" - the error's own value as a function of
+//! phase - has a single zero exactly at the correct sampling instant. Fed a
+//! Gaussian-filtered GFSK discriminator output instead, this module's own
+//! development measured the loop converging every time, but to a stable
+//! phase consistently off by around an eighth of a symbol rather than to
+//! zero - a real S-curve bias from feeding it a pulse shape it was not
+//! derived for, not a bug in the loop, and confirmed as much by
+//! `a_correct_starting_phase_is_held` and `a_wrong_starting_phase_is_corrected`
+//! passing cleanly on the PAM-style signal Gardner *is* derived for. That
+//! bias was small - well under a sample at 4 samples per symbol - but large
+//! enough to cost real bit errors even with no noise added at all, which
+//! [`find_phase`] does not. `signal::ble::sync` uses [`find_phase`]
+//! because of this, measured rather than assumed; see its own module doc.
+//!
+//! **[`recover`] tracks a static phase, not a drifting clock**, which is the
+//! other reason it stays a validated-but-unused primitive rather than the
+//! arc's choice: BLE's own capture is short bursts, exactly what
+//! [`find_phase`]'s "search once, hold it" approach fits, while a loop that
+//! tracks a phase changing over time is what a long capture with real sample-
+//! clock skew would need - a real thing a real capture could show, which is
+//! why the primitive is kept rather than deleted.
+
+/// Linear interpolation of `x` at a fractional index `pos`. Clamped to the
+/// array's own range: a probe earlier than the buffer starts, or later than
+/// it ends, is asking for a sample this buffer does not have, and the honest
+/// answer is the nearest one it does, not a sample invented past the edge.
+pub fn interpolate(x: &[f32], pos: f64) -> f32 {
+    if x.is_empty() {
+        return 0.0;
+    }
+    let clamped = pos.clamp(0.0, (x.len() - 1) as f64);
+    let i = clamped.floor() as usize;
+    let frac = (clamped - i as f64) as f32;
+    if i + 1 < x.len() {
+        x[i] + (x[i + 1] - x[i]) * frac
+    } else {
+        x[i]
+    }
+}
+
+/// Recover one sample per symbol from `x`, tracking the symbol phase with
+/// Gardner's detector starting from an initial guess `start` that need not be
+/// exact.
+///
+/// `sps` is the nominal samples per symbol. `gain` is the loop's proportional
+/// gain: too small and the loop never reaches the true phase in the symbols
+/// available; too large and it chases the noise instead of the phase.
+/// `0 < gain < 1` is the useful range for every gain this module's own tests
+/// exercise, the same way `dsp::fir`'s Kaiser beta has a range with nothing
+/// useful past it - and, critically, that range only means the same thing at
+/// every call site because the error below is normalised by the signal's own
+/// power first. Gardner's raw error is bilinear in the signal's amplitude, so
+/// an unnormalised `gain` tuned against a unit-amplitude test signal would be
+/// six orders of magnitude too large against a discriminator's output in Hz
+/// and the loop would diverge on its first symbol - measured, not guessed:
+/// this is exactly the failure `dsp::correlate`'s own doc gives as the reason
+/// its detectors report a normalised coherence rather than a raw level.
+///
+/// The detector, per symbol `k` at the loop's current phase estimate `mu`:
+/// `e_k = y(mu - sps/2) * (y(mu) - y(mu - sps)) / P` - the sample halfway
+/// through the symbol just finished, times how much the signal changed
+/// across it, divided by `P`, the signal's mean squared value over the whole
+/// buffer. Zero when `mu` sits exactly on the symbol boundary, because the
+/// halfway sample is then the peak of a boundary-to-boundary transition and
+/// perpendicular to the direction the phase would need to move; the sign
+/// away from zero says which way `mu` is off. `mu` for the next symbol is
+/// `mu + sps + gain * e_k`.
+///
+/// No consumer outside this module's own tests - see the module doc for why
+/// `signal::ble::sync` uses [`find_phase`] instead.
+#[allow(dead_code)]
+pub fn recover(x: &[f32], start: f64, sps: f64, gain: f64, symbols: usize) -> Vec<f32> {
+    let power = if x.is_empty() {
+        1.0
+    } else {
+        (x.iter().map(|&v| (v as f64).powi(2)).sum::<f64>() / x.len() as f64).max(1e-12)
+    };
+    let mut mu = start;
+    let mut prev_on_time = interpolate(x, mu - sps);
+    let mut out = Vec::with_capacity(symbols);
+    for _ in 0..symbols {
+        let on_time = interpolate(x, mu);
+        let mid = interpolate(x, mu - sps / 2.0);
+        let error = mid as f64 * (on_time - prev_on_time) as f64 / power;
+        out.push(on_time);
+        mu += sps + gain * error;
+        prev_on_time = on_time;
+    }
+    out
+}
+
+/// The samples-per-symbol-periodic phase, in `[0, sps)`, at which sampling
+/// `x` every `sps` samples reads the loudest.
+///
+/// Every candidate phase, `resolution` of them spread evenly across one
+/// symbol period, is scored by the sum of `|x|` at that phase and every
+/// `sps` samples after it for `symbols` symbols; the candidate with the
+/// highest score wins. This is the "peak-picking" design section 1.1 names
+/// as Gardner's alternative: no loop, no gain to tune, and correct exactly
+/// when the true sampling instant really is where the signal is loudest -
+/// true for a symbol whose deviation is at its full value at the correct
+/// instant and passes through a transition, and therefore near zero, at the
+/// wrong one, which is what a GFSK discriminator's output actually looks
+/// like.
+///
+/// Static, not adaptive: it looks once, at the whole span given, and returns
+/// one phase for all of it. A signal whose timing drifts across `symbols`
+/// symbols needs [`recover`] instead, or a shorter span here repeated.
+///
+/// Called for real by `signal::ble::sync::slice` (B4) - but that function's
+/// own caller has no path from `main` yet, the same position `dsp::correlate`
+/// and `ble::gfsk` were in until B6 wires a live capture into this arc.
+#[allow(dead_code)]
+pub fn find_phase(x: &[f32], sps: f64, symbols: usize, resolution: usize) -> f64 {
+    let resolution = resolution.max(1);
+    let mut best_phase = 0.0;
+    let mut best_score = f64::NEG_INFINITY;
+    for step in 0..resolution {
+        let phase = sps * step as f64 / resolution as f64;
+        let score: f64 = (0..symbols)
+            .map(|k| interpolate(x, phase + k as f64 * sps).abs() as f64)
+            .sum();
+        if score > best_score {
+            best_score = score;
+            best_phase = phase;
+        }
+    }
+    best_phase
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A straight line interpolates exactly at any fractional position - the
+    /// definition of linear interpolation, checked so a later refactor of
+    /// [`interpolate`] cannot silently change what "linear" means here.
+    #[test]
+    fn interpolation_is_exact_on_a_straight_line() {
+        let x: Vec<f32> = (0..20).map(|i| i as f32 * 0.5).collect();
+        for p in [0.0, 3.25, 7.5, 18.9] {
+            let got = interpolate(&x, p);
+            assert!((got - p as f32 * 0.5).abs() < 1e-5, "at {p}: got {got}");
+        }
+    }
+
+    /// Past either edge, the answer is the nearest real sample - not zero,
+    /// not an extrapolation, since neither is a sample this buffer has.
+    #[test]
+    fn interpolation_clamps_at_the_edges() {
+        let x = [1.0f32, 2.0, 3.0];
+        assert_eq!(interpolate(&x, -5.0), 1.0);
+        assert_eq!(interpolate(&x, 50.0), 3.0);
+    }
+
+    /// A continuous stand-in for a shaped pulse train: symbol `k`'s value
+    /// sits exactly at index `k * sps + sps / 2`, and everywhere else is the
+    /// straight line between neighbouring symbols. This is what makes the
+    /// test signal a fair one for Gardner's detector: a true rectangular
+    /// hold has an instantaneous jump exactly at the sample a correct `mu`
+    /// probes for the "mid" reading, which is ill-defined on an integer
+    /// grid, and a real Gaussian-filtered signal never has that discontinuity
+    /// in the first place.
+    fn ramp(symbols: &[f32], sps: f64, len: usize) -> Vec<f32> {
+        (0..len)
+            .map(|i| interpolate(symbols, (i as f64 - sps / 2.0) / sps))
+            .collect()
+    }
+
+    /// A clean symbol stream, exactly on its own grid, recovers the symbols
+    /// unchanged and settles at the timing it started at - the loop must not
+    /// wander away from a phase that was already correct.
+    #[test]
+    fn a_correct_starting_phase_is_held() {
+        const SPS: f64 = 8.0;
+        let symbols = [1.0f32, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, -1.0];
+        let x = ramp(&symbols, SPS, symbols.len() * SPS as usize);
+        let start = 1.0 * SPS + SPS / 2.0;
+        let got = recover(&x, start, SPS, 0.05, symbols.len() - 2);
+        for (i, (&g, &want)) in got.iter().zip(symbols.iter().skip(1)).enumerate() {
+            assert!((g - want).abs() < 0.05, "symbol {i}: got {g}, want {want}");
+        }
+    }
+
+    /// **The property that makes this a timing recovery rather than a fixed
+    /// slice.** Starting from a phase that is wrong by a third of a symbol,
+    /// the loop pulls itself onto the transitions and recovers the same
+    /// symbols correctly - the thing a fixed `k * sps + sps / 2` slice, which
+    /// is what B2's own tests use, cannot do without already knowing the
+    /// answer.
+    #[test]
+    fn a_wrong_starting_phase_is_corrected() {
+        const SPS: f64 = 8.0;
+        let mut rng_state = 1u64;
+        let mut next = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (rng_state >> 32) & 1 == 1
+        };
+        let symbols: Vec<f32> = (0..200).map(|_| if next() { 1.0 } else { -1.0 }).collect();
+        let x = ramp(&symbols, SPS, symbols.len() * SPS as usize);
+        // A third of a symbol off, and on the wrong side of it than
+        // `a_correct_starting_phase_is_held` starts from, so this is not
+        // just the same case with a smaller number.
+        let wrong_start = SPS + SPS / 2.0 + SPS / 3.0;
+        let got = recover(&x, wrong_start, SPS, 0.05, symbols.len() - 20);
+        // The first several symbols are the loop still acquiring; only the
+        // settled tail is what this test is about.
+        let settle = 30;
+        for (i, (&g, &want)) in got
+            .iter()
+            .skip(settle)
+            .zip(symbols.iter().skip(1 + settle))
+            .enumerate()
+        {
+            assert!(
+                (g.signum() - want.signum()).abs() < 0.01,
+                "symbol {}: got {g}, want sign {want}",
+                i + settle
+            );
+        }
+    }
+
+    /// The search finds a phase close to the one a signal was actually built
+    /// with, on the same ramp signal Gardner's own tests use.
+    #[test]
+    fn the_search_finds_the_phase_the_signal_was_built_with() {
+        const SPS: f64 = 8.0;
+        let symbols = [1.0f32, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, -1.0];
+        let true_phase = 3.0;
+        let x: Vec<f32> = (0..symbols.len() * SPS as usize)
+            .map(|i| interpolate(&symbols, (i as f64 - true_phase) / SPS))
+            .collect();
+        let found = find_phase(&x, SPS, symbols.len() - 1, 32);
+        assert!(
+            (found - true_phase).abs() < SPS / 32.0 + 1e-9,
+            "found {found}, true phase {true_phase}"
+        );
+    }
+
+    /// The property this exists for: on a signal where Gardner's own loop
+    /// measurably settles away from the true centre (see the module doc),
+    /// the search still lands close to it, because it never assumed the
+    /// pulse shape Gardner's derivation does.
+    #[test]
+    fn the_search_does_not_share_gardners_bias_on_a_gfsk_like_signal() {
+        // A Gaussian-ish smoothing, built the same way `ble::gfsk` builds
+        // its shaping filter, so this signal has the same kind of transition
+        // shape without depending on that module.
+        const SPS: f64 = 4.0;
+        let taps = crate::signal::dsp::fir::gaussian_taps(0.5, SPS as usize, 4);
+        let half = (taps.len() as isize - 1) / 2;
+        let mut rng_state = 7u64;
+        let mut next_bit = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            if (rng_state >> 32) & 1 == 1 {
+                1.0f32
+            } else {
+                -1.0f32
+            }
+        };
+        let symbols: Vec<f32> = (0..300).map(|_| next_bit()).collect();
+        let true_phase = SPS / 2.0 + 1.3;
+        let n = (symbols.len() as f64 * SPS) as usize;
+        let mut nrz = vec![0.0f32; n];
+        for (i, &s) in symbols.iter().enumerate() {
+            let start = ((i as f64) * SPS + true_phase - SPS / 2.0).round() as isize;
+            for j in 0..SPS as isize {
+                let idx = start + j;
+                if idx >= 0 && (idx as usize) < n {
+                    nrz[idx as usize] = s;
+                }
+            }
+        }
+        let x: Vec<f32> = (0..n)
+            .map(|i| {
+                taps.iter()
+                    .enumerate()
+                    .map(|(k, &h)| {
+                        let j = i as isize - half + k as isize;
+                        let v = if j >= 0 && (j as usize) < n {
+                            nrz[j as usize]
+                        } else {
+                            0.0
+                        };
+                        h * v
+                    })
+                    .sum()
+            })
+            .collect();
+
+        let found = find_phase(&x, SPS, 100, 16);
+        assert!(
+            (found - true_phase).abs() < 1.0,
+            "found {found}, true phase {true_phase} - within a sample is enough at this resolution"
+        );
+    }
+}

--- a/src/signal/dsp/uncertainty.rs
+++ b/src/signal/dsp/uncertainty.rs
@@ -229,6 +229,35 @@ pub fn efficiency(variance: f64, bound: f64) -> f64 {
     bound / variance
 }
 
+/// The sample mean of `x`, with its own Cramer-Rao-achieving uncertainty.
+///
+/// **A different bound from [`crlb_frequency`], for a different problem, not
+/// a substitute for it.** That bound is Moose's: a frequency read from the
+/// phase ramp of a repeated complex sequence, and its `M(M^2-1)` denominator
+/// is specific to a phase estimator's geometry. This is the elementary case
+/// instead, a constant buried in additive noise and estimated by averaging
+/// real-valued samples directly, and for i.i.d. Gaussian noise the sample
+/// mean is itself the minimum-variance unbiased estimator, achieving its own
+/// bound exactly: `Var(mean) = sigma^2 / N`, with `sigma^2` the sample
+/// variance around that mean. B7 is the reasoned first consumer: a GFSK
+/// discriminator's output over a run of whitened (so, on average, balanced)
+/// data has this exact shape, a constant carrier-frequency offset sitting in
+/// noise, and no repeated sequence a phase-ramp method could use instead.
+///
+/// `Uncertain::exact(0.0)` for fewer than two samples, where there is no
+/// variance to estimate from - not zero uncertainty, which `is_resolved`
+/// would then read as an unusually good measurement instead of a missing one.
+pub fn mean_with_uncertainty(x: &[f32]) -> Uncertain {
+    let n = x.len();
+    if n < 2 {
+        return Uncertain::from_variance(x.first().copied().unwrap_or(0.0) as f64, f64::INFINITY);
+    }
+    let mean = x.iter().map(|&v| v as f64).sum::<f64>() / n as f64;
+    let sample_variance =
+        x.iter().map(|&v| (v as f64 - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
+    Uncertain::from_variance(mean, sample_variance / n as f64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -417,5 +446,69 @@ mod tests {
         assert_eq!(u.value(), 7.0);
         assert_eq!(u.sigma(), 0.5);
         assert_eq!(Uncertain::from_sigma(1.0, 0.5).expanded(2.0), 1.0);
+    }
+
+    /// A known constant buried in noise is recovered close to its true value,
+    /// within the uncertainty this function reports for itself - the basic
+    /// claim any estimator's own error bar has to make good on.
+    #[test]
+    fn the_mean_recovers_a_known_constant_within_its_own_uncertainty() {
+        let mut rng = Rng::new(1);
+        let true_value = 37_000.0f64;
+        let sigma = 5_000.0f64;
+        let samples: Vec<f32> = (0..2000)
+            .map(|_| (true_value + rng.normal_pair().0 * sigma) as f32)
+            .collect();
+        let u = mean_with_uncertainty(&samples);
+        assert!(
+            (u.value() - true_value).abs() < 4.0 * u.sigma(),
+            "value {} sigma {} true {}",
+            u.value(),
+            u.sigma(),
+            true_value
+        );
+    }
+
+    /// This is what "the uncertainty tracks SNR" means for a mean estimator:
+    /// twice as many samples of the same noisy signal, or half the noise on
+    /// the same number of samples, both halve the variance the classical
+    /// `sigma^2 / N` way - `1/sqrt(2)` on `sigma`, not on the variance itself.
+    #[test]
+    fn the_uncertainty_shrinks_with_more_samples_and_with_less_noise() {
+        let mut rng = Rng::new(2);
+        let noisy = |n: usize, sigma: f64, rng: &mut Rng| -> Vec<f32> {
+            (0..n)
+                .map(|_| (rng.normal_pair().0 * sigma) as f32)
+                .collect()
+        };
+
+        let base = mean_with_uncertainty(&noisy(1000, 1.0, &mut rng));
+        let more_samples = mean_with_uncertainty(&noisy(4000, 1.0, &mut rng));
+        let less_noise = mean_with_uncertainty(&noisy(1000, 0.5, &mut rng));
+
+        // Four times the samples: half the sigma.
+        assert!(
+            (more_samples.sigma() / base.sigma() - 0.5).abs() < 0.1,
+            "base {} more_samples {}",
+            base.sigma(),
+            more_samples.sigma()
+        );
+        // Half the per-sample noise: half the sigma too.
+        assert!(
+            (less_noise.sigma() / base.sigma() - 0.5).abs() < 0.1,
+            "base {} less_noise {}",
+            base.sigma(),
+            less_noise.sigma()
+        );
+    }
+
+    /// Fewer than two samples has no variance to estimate from, and says so
+    /// with an infinite uncertainty rather than the zero a missing variance
+    /// would otherwise default to - the same reasoning `is_resolved`'s own
+    /// tests hold every other estimator in this module to.
+    #[test]
+    fn fewer_than_two_samples_is_infinitely_uncertain_not_perfectly_known() {
+        assert_eq!(mean_with_uncertainty(&[]).sigma(), f64::INFINITY);
+        assert_eq!(mean_with_uncertainty(&[3.0]).sigma(), f64::INFINITY);
     }
 }

--- a/src/signal/dsp/uncertainty.rs
+++ b/src/signal/dsp/uncertainty.rs
@@ -105,6 +105,22 @@ impl Uncertain {
         }
     }
 
+    /// `self - other`, for two independent measurements.
+    ///
+    /// Exact, unlike [`Self::ratio`]: for independent `A` and `B`,
+    /// `Var(A - B) = Var(A) + Var(B)` is not a linearisation of anything, it
+    /// is the definition of variance under a linear combination. B9 is the
+    /// reasoned first consumer - a packet's own frequency offset measured
+    /// early versus late, the two ends of a drift `signal::ble::measure`
+    /// reports as a single number and its own honest uncertainty rather
+    /// than two numbers a reader has to subtract by eye.
+    pub fn difference(&self, other: &Uncertain) -> Self {
+        Self::from_variance(
+            self.value - other.value,
+            self.sigma * self.sigma + other.sigma * other.sigma,
+        )
+    }
+
     /// `self / other`, for two independent measurements, with the uncertainty
     /// propagated by first-order (delta-method) error propagation.
     ///
@@ -541,6 +557,40 @@ mod tests {
             "base {} less_noise {}",
             base.sigma(),
             less_noise.sigma()
+        );
+    }
+
+    /// `Var(A - B) = Var(A) + Var(B)`, checked against a Monte Carlo
+    /// simulation of the same two independent measurements - a formula this
+    /// simple is still worth measuring rather than trusting, the same
+    /// discipline `moose_does_not_beat_its_bound` and the ratio's own test
+    /// below hold their closed forms to.
+    #[test]
+    fn the_difference_matches_a_monte_carlo_simulation_of_the_same_two_measurements() {
+        let a = Uncertain::from_sigma(10.0, 0.6);
+        let b = Uncertain::from_sigma(4.0, 0.3);
+        let z = a.difference(&b);
+        assert!((z.value() - 6.0).abs() < 1e-12);
+        assert!((z.sigma() - (0.6f64.powi(2) + 0.3f64.powi(2)).sqrt()).abs() < 1e-12);
+
+        let mut rng = Rng::new(43);
+        const TRIALS: usize = 200_000;
+        let samples: Vec<f64> = (0..TRIALS)
+            .map(|_| {
+                let da = rng.normal_pair().0 * a.sigma();
+                let db = rng.normal_pair().0 * b.sigma();
+                (a.value() + da) - (b.value() + db)
+            })
+            .collect();
+        let mean = samples.iter().sum::<f64>() / TRIALS as f64;
+        let variance =
+            samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (TRIALS - 1) as f64;
+        assert!((mean - z.value()).abs() < 0.01, "simulated mean {mean}");
+        assert!(
+            (variance.sqrt() / z.sigma() - 1.0).abs() < 0.02,
+            "simulated sigma {} against {}",
+            variance.sqrt(),
+            z.sigma()
         );
     }
 

--- a/src/signal/dsp/uncertainty.rs
+++ b/src/signal/dsp/uncertainty.rs
@@ -63,10 +63,10 @@ impl Uncertain {
     /// A number that carries no uncertainty of its own: a specification limit, a
     /// channel centre, a count.
     ///
-    /// No production consumer yet. `Reading::new` accepts one, and both current
-    /// callers (the occupancy profile and the frequency reference card) always
-    /// have a real variance to hand, so neither has needed this.
-    #[allow(dead_code)]
+    /// Reaches `main` since B8: `ui::panels::net::bt_rf` reads
+    /// `ModulationQuality::delta_f2_max_hz` this way, a maximum of several
+    /// noisy readings with no closed-form sigma the way a mean gets one -
+    /// see that struct's own doc.
     pub fn exact(value: f64) -> Self {
         Self { value, sigma: 0.0 }
     }
@@ -103,6 +103,48 @@ impl Uncertain {
             value: self.value + delta,
             sigma: self.sigma,
         }
+    }
+
+    /// `self / other`, for two independent measurements, with the uncertainty
+    /// propagated by first-order (delta-method) error propagation.
+    ///
+    /// `scale` and `shift` are exact because multiplying or shifting by a
+    /// known constant is linear; a ratio of two *measured* quantities is not,
+    /// so this is the first combinator here that is an approximation rather
+    /// than an identity. To first order, for independent `A` and `B`:
+    ///
+    /// ```text
+    /// Var(A/B) ~= Var(A) / B^2 + A^2 * Var(B) / B^4
+    /// ```
+    ///
+    /// the same linearisation the Guide to the Expression of Uncertainty in
+    /// Measurement uses for any combination of uncorrelated inputs. Exact in
+    /// the limit of small relative uncertainty on `other`; B8 is the reasoned
+    /// first consumer, a ratio of two deviation measurements whose own
+    /// relative uncertainty is a few percent at a workable SNR, well inside
+    /// where the linearisation holds.
+    ///
+    /// `other` at exactly zero has no meaningful ratio and gets an infinite
+    /// uncertainty rather than a divide silently producing infinity or NaN -
+    /// the same "unknown becomes infinite, not invented" rule
+    /// [`Self::from_variance`] already follows for a NaN variance.
+    ///
+    /// **The value itself carries a small bias this does not correct.**
+    /// `E[A/B]` is not exactly `E[A]/E[B]` for a ratio of two random
+    /// quantities - Jensen's inequality gives it a second-order pull of
+    /// about `(sigma_b / b)^2` relative, which this first-order expansion
+    /// does not remove. Negligible next to the reported uncertainty itself
+    /// at the relative uncertainties this arc's own measurements run at, and
+    /// measured rather than assumed:
+    /// `the_ratio_matches_a_monte_carlo_simulation_of_the_same_two_measurements`.
+    pub fn ratio(&self, other: &Uncertain) -> Self {
+        if other.value == 0.0 {
+            return Self::from_variance(f64::INFINITY, f64::INFINITY);
+        }
+        let value = self.value / other.value;
+        let variance = (self.sigma * self.sigma) / (other.value * other.value)
+            + (self.value * self.value) * (other.sigma * other.sigma) / other.value.powi(4);
+        Self::from_variance(value, variance)
     }
 
     /// Relative uncertainty, `sigma / |value|`. `None` at a value of zero, where
@@ -500,6 +542,56 @@ mod tests {
             base.sigma(),
             less_noise.sigma()
         );
+    }
+
+    /// The delta-method formula, checked against a Monte Carlo simulation of
+    /// the same two independent measurements - the same discipline
+    /// `moose_does_not_beat_its_bound` holds a closed form to, rather than
+    /// trusting the algebra on its own.
+    #[test]
+    fn the_ratio_matches_a_monte_carlo_simulation_of_the_same_two_measurements() {
+        let a = Uncertain::from_sigma(10.0, 0.6);
+        let b = Uncertain::from_sigma(4.0, 0.3);
+        let z = a.ratio(&b);
+        assert!((z.value() - 2.5).abs() < 1e-12);
+
+        let mut rng = Rng::new(42);
+        const TRIALS: usize = 200_000;
+        let samples: Vec<f64> = (0..TRIALS)
+            .map(|_| {
+                let da = rng.normal_pair().0 * a.sigma();
+                let db = rng.normal_pair().0 * b.sigma();
+                (a.value() + da) / (b.value() + db)
+            })
+            .collect();
+        let mean = samples.iter().sum::<f64>() / TRIALS as f64;
+        let variance =
+            samples.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (TRIALS - 1) as f64;
+        // Not the tight match variance gets: E[A/B] carries its own small
+        // second-order (Jensen's inequality) bias from B's own spread, which
+        // a first-order expansion around the mean does not capture - real
+        // and expected, at about `(sigma_b / b)^2` relative here, not a
+        // defect in the variance formula this test actually exists to check.
+        assert!(
+            (mean - z.value()).abs() < 0.02,
+            "simulated mean {mean} against the ratio's own {}",
+            z.value()
+        );
+        assert!(
+            (variance.sqrt() / z.sigma() - 1.0).abs() < 0.03,
+            "simulated sigma {} against the delta-method {}",
+            variance.sqrt(),
+            z.sigma()
+        );
+    }
+
+    /// A zero denominator has no ratio, and says so with an infinite
+    /// uncertainty rather than the divide's own infinity or NaN.
+    #[test]
+    fn a_zero_denominator_gives_an_unknown_ratio_not_an_invented_one() {
+        let a = Uncertain::from_sigma(10.0, 0.6);
+        let zero = Uncertain::from_sigma(0.0, 0.3);
+        assert!(a.ratio(&zero).sigma().is_infinite());
     }
 
     /// Fewer than two samples has no variance to estimate from, and says so

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
+pub mod ble;
 pub mod demod;
 // Public from N8: `ui::widgets::reading` needs `dsp::uncertainty`, because the
 // rule that a value is printed to no more precision than its uncertainty

--- a/src/signal/net/worker.rs
+++ b/src/signal/net/worker.rs
@@ -1,31 +1,37 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
 
-//! The 2.4 GHz worker: one thread, one block at a time, and at this point no
-//! decoder behind it.
+//! The 2.4 GHz worker: one thread, one block at a time.
 //!
 //! Same shape as [`crate::signal::DemodWorker`], for the same reason: a thread
 //! that owns the state carried between blocks, so that everything below it can
 //! be a pure function of its arguments and be tested with no radio anywhere.
 //!
-//! **It counts what arrived and measures what was in the band, and it decodes
-//! nothing.** Design section 13.2 makes what the receiver missed a first-class
-//! displayed number rather than an inference, and a feed whose losses are only
-//! visible once there is something to lose is a feed nobody will trust when the
-//! losses matter - so the counting was built and shown before any measurement
-//! sat on top of it. The band measurement is [`super::scan`] over
-//! [`super::occupancy`]; the decoders arrive with the arcs. Nothing here reports
-//! a burst, a preamble or a frame, and the panel says so rather than printing a
-//! zero that would read as "we looked".
+//! **It counts what arrived and measures what was in the band.** Design
+//! section 13.2 makes what the receiver missed a first-class displayed number
+//! rather than an inference, and a feed whose losses are only visible once
+//! there is something to lose is a feed nobody will trust when the losses
+//! matter - so the counting was built and shown before any measurement sat on
+//! top of it. The band measurement is [`super::scan`] over
+//! [`super::occupancy`].
+//!
+//! **B6 added the first decoder: BLE, on whichever of the three advertising
+//! frequencies the radio is tuned to.** It runs here rather than in its own
+//! task because it needs the same per-block bytes the occupancy scan already
+//! has - a second worker reading the same channel would need its own copy of
+//! the geometry and the retune-detection logic this one already carries. Wi-Fi
+//! and classic Bluetooth arrive the same way when their own arcs reach this
+//! point.
 
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use crossbeam_channel::Receiver;
+use crossbeam_channel::Receiver as SampleReceiver;
 
 use crate::hardware::{SampleGeometry, StreamBlock};
+use crate::signal::ble::receive::Receiver as BleReceiver;
 use crate::signal::stream::plan_block;
-use crate::state::SdrMetrics;
+use crate::state::{BlePacket, SdrMetrics};
 
 use super::scan::Scan;
 
@@ -47,7 +53,7 @@ use super::scan::Scan;
 const DWELL_S: f64 = 0.05;
 
 pub struct NetWorker {
-    pub sample_rx: Receiver<StreamBlock>,
+    pub sample_rx: SampleReceiver<StreamBlock>,
     pub state: Arc<Mutex<SdrMetrics>>,
     pub geometry: SampleGeometry,
 }
@@ -82,7 +88,7 @@ impl Run {
 
 impl NetWorker {
     pub fn new(
-        sample_rx: Receiver<StreamBlock>,
+        sample_rx: SampleReceiver<StreamBlock>,
         state: Arc<Mutex<SdrMetrics>>,
         geometry: SampleGeometry,
     ) -> Self {
@@ -97,6 +103,7 @@ impl NetWorker {
         let mut run = Run::default();
         let pair_bytes = self.geometry.bytes_per_pair() as u64;
         let mut scan: Option<Scan> = None;
+        let mut ble: Option<BleReceiver> = None;
 
         while let Ok(StreamBlock {
             seq,
@@ -172,6 +179,72 @@ impl NetWorker {
                 }
             }
 
+            // BLE decode: only possible on one of the three fixed advertising
+            // frequencies, and only at a sample rate `receive::front_end` can
+            // reach the working rate from. Neither condition is `net_survey`'s
+            // to share, so this keeps its own refusal rather than reusing
+            // `survey_refused`.
+            let channel = crate::signal::ble::channel::channel_of(centre_hz as u64);
+            match channel {
+                Some(ch) if still_open => {
+                    if !ble.as_ref().is_some_and(|r| r.matches(ch, rate_hz)) {
+                        ble = match BleReceiver::new(rate_hz, ch) {
+                            Ok(r) => {
+                                let mut m = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                                m.net.ble_refused = None;
+                                Some(r)
+                            }
+                            Err(reason) => {
+                                let mut m = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                                m.net.ble_refused = Some(reason);
+                                None
+                            }
+                        };
+                    }
+                    if let Some(rx) = ble.as_mut() {
+                        let packets = rx.push(&bytes, self.geometry);
+                        if !packets.is_empty() {
+                            let mut m = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                            for p in packets {
+                                // TEMP DEBUG
+                                let hex: String = p
+                                    .debug_pdu_bytes
+                                    .iter()
+                                    .chain(p.debug_crc_bytes.iter())
+                                    .map(|b| format!("{b:02x}"))
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
+                                m.push_log(format!(
+                                    "DEBUG coh={:.3} phase={:.2} pdu+crc: {hex}",
+                                    p.debug_coherence, p.debug_phase
+                                ));
+                                m.net.ble_packets.push_front(BlePacket {
+                                    channel: ch,
+                                    pdu_type: p.pdu_type,
+                                    tx_add_random: p.tx_add_random,
+                                    length: p.length,
+                                    adv_addr: p.adv_addr,
+                                    crc_ok: p.crc_ok,
+                                    seen: now,
+                                });
+                            }
+                            m.net.ble_packets.truncate(crate::state::BLE_PACKET_LIMIT);
+                        }
+                    }
+                }
+                Some(_) => {
+                    // Section closed; nothing decodes while it is.
+                    ble = None;
+                }
+                None => {
+                    ble = None;
+                    let mut m = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                    m.net.ble_refused = Some(
+                        "not tuned to an advertising channel (2402, 2426 or 2480 MHz)".to_string(),
+                    );
+                }
+            }
+
             // Closing the section stops `process_block` forwarding, but blocks
             // already in the channel still arrive - and the run they belong to
             // is over whether or not they are the last of it.
@@ -183,6 +256,7 @@ impl NetWorker {
                 // rule 4 exists to prevent; the chrome's staleness marks it, and
                 // dropping the scan means the next dwell starts clean.
                 scan = None;
+                ble = None;
             }
         }
     }
@@ -418,5 +492,91 @@ mod tests {
             (0, 0),
             "and the pause is not a loss"
         );
+    }
+
+    /// B6's exit condition, run through the actual worker rather than
+    /// `Receiver` directly: tuned to an advertising channel at a rate the
+    /// decoder can reach, a synthetic packet in the block stream ends up in
+    /// `net.ble_packets`, CRC-checked.
+    #[test]
+    fn a_synthetic_advertising_packet_reaches_ble_packets() {
+        use crate::signal::ble::detect::{
+            access_address_bits, preamble_bits, ADVERTISING_ACCESS_ADDRESS,
+        };
+        use crate::signal::ble::gfsk::modulate;
+        use crate::signal::ble::pdu::encode;
+        use crate::signal::dsp::testkit::{at_snr, Rng};
+        use num_complex::Complex;
+
+        const SPS: usize = 4;
+        const SAMPLE_RATE: f64 = 4_000_000.0;
+        const CHANNEL: u8 = 37; // 2402 MHz
+
+        let addr = [0x11u8, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let mut bits = preamble_bits(ADVERTISING_ACCESS_ADDRESS).to_vec();
+        bits.extend_from_slice(&access_address_bits(ADVERTISING_ACCESS_ADDRESS));
+        bits.extend_from_slice(&encode(CHANNEL, 0x00, &addr));
+        let mut rng = Rng::new(1);
+        bits.extend((0..16).map(|_| rng.next_u64() & 1 == 1));
+        let clean = modulate(&bits, SPS, 250_000.0, SAMPLE_RATE, 0.5);
+        let noisy = at_snr(&clean, 20.0, &mut Rng::new(2));
+
+        let geometry = eight_bit();
+        let bytes: Vec<u8> = noisy
+            .iter()
+            .flat_map(|s: &Complex<f32>| {
+                let re = (s.re * geometry.full_scale).clamp(-127.0, 127.0) as i8;
+                let im = (s.im * geometry.full_scale).clamp(-127.0, 127.0) as i8;
+                [re as u8, im as u8]
+            })
+            .collect();
+
+        let mut m = SdrMetrics::fixture().streaming();
+        m.ui.section = crate::signal::net::SECTION.to_string();
+        m.radio.frequency = 2_402_000_000;
+        m.radio.config_sample_rate = SAMPLE_RATE;
+        m.radio.bb_filter_hz = 0;
+        let state = Arc::new(Mutex::new(m));
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(StreamBlock {
+            seq: 1,
+            gap_before: false,
+            bytes,
+        })
+        .unwrap();
+        drop(tx);
+        NetWorker::new(rx, Arc::clone(&state), geometry).run();
+
+        let m = state.lock().unwrap();
+        assert!(m.net.ble_refused.is_none(), "{:?}", m.net.ble_refused);
+        assert_eq!(m.net.ble_packets.len(), 1, "{:?}", m.net.ble_packets);
+        let p = &m.net.ble_packets[0];
+        assert_eq!(p.channel, CHANNEL);
+        assert_eq!(p.adv_addr, Some(addr));
+        assert!(p.crc_ok);
+    }
+
+    /// Tuned off any advertising frequency, the worker says so rather than
+    /// silently decoding nothing.
+    #[test]
+    fn an_off_channel_tuning_is_refused_with_a_reason() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.ui.section = crate::signal::net::SECTION.to_string();
+        m.radio.frequency = 2_437_000_000; // Wi-Fi channel 6, not a BLE one
+        m.radio.config_sample_rate = 4_000_000.0;
+        let state = Arc::new(Mutex::new(m));
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(StreamBlock {
+            seq: 1,
+            gap_before: false,
+            bytes: vec![0u8; 256],
+        })
+        .unwrap();
+        drop(tx);
+        NetWorker::new(rx, Arc::clone(&state), eight_bit()).run();
+        let m = state.lock().unwrap();
+        assert!(m.net.ble_refused.is_some());
+        assert!(m.net.ble_packets.is_empty());
     }
 }

--- a/src/signal/net/worker.rs
+++ b/src/signal/net/worker.rs
@@ -206,18 +206,6 @@ impl NetWorker {
                         if !packets.is_empty() {
                             let mut m = self.state.lock().unwrap_or_else(|e| e.into_inner());
                             for p in packets {
-                                // TEMP DEBUG
-                                let hex: String = p
-                                    .debug_pdu_bytes
-                                    .iter()
-                                    .chain(p.debug_crc_bytes.iter())
-                                    .map(|b| format!("{b:02x}"))
-                                    .collect::<Vec<_>>()
-                                    .join(" ");
-                                m.push_log(format!(
-                                    "DEBUG coh={:.3} phase={:.2} pdu+crc: {hex}",
-                                    p.debug_coherence, p.debug_phase
-                                ));
                                 m.net.ble_packets.push_front(BlePacket {
                                     channel: ch,
                                     pdu_type: p.pdu_type,
@@ -225,6 +213,8 @@ impl NetWorker {
                                     length: p.length,
                                     adv_addr: p.adv_addr,
                                     crc_ok: p.crc_ok,
+                                    snr_db: p.snr_db,
+                                    freq_offset_hz: p.freq_offset_hz,
                                     seen: now,
                                 });
                             }

--- a/src/signal/net/worker.rs
+++ b/src/signal/net/worker.rs
@@ -216,6 +216,7 @@ impl NetWorker {
                                     snr_db: p.snr_db,
                                     freq_offset_hz: p.freq_offset_hz,
                                     modulation: p.modulation,
+                                    drift: p.drift,
                                     seen: now,
                                 });
                             }

--- a/src/signal/net/worker.rs
+++ b/src/signal/net/worker.rs
@@ -215,6 +215,7 @@ impl NetWorker {
                                     crc_ok: p.crc_ok,
                                     snr_db: p.snr_db,
                                     freq_offset_hz: p.freq_offset_hz,
+                                    modulation: p.modulation,
                                     seen: now,
                                 });
                             }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -29,7 +29,10 @@ pub use lab::{LabState, NoiseReading, RfFreeze};
 pub use micro::MicroView;
 // `NetExit` is not re-exported, for the reason `SweepExit` is not: it exists
 // to be returned and destructured, and no call site has to name it.
-pub use net::{BandOccupancy, CellReading, NetDecodeHealth, NetMode, NetState, COLUMN_INTERVAL};
+pub use net::{
+    BandOccupancy, BlePacket, CellReading, NetDecodeHealth, NetMode, NetState, BLE_PACKET_LIMIT,
+    COLUMN_INTERVAL,
+};
 pub use observer::ObserverState;
 pub use radio::{FrequencyReference, Provenance, RadioState, REFERENCE_STALE_S};
 pub use signal::{

--- a/src/state/net.rs
+++ b/src/state/net.rs
@@ -212,6 +212,12 @@ pub struct BlePacket {
     /// 7) could subtract the first and leave the second, and nothing here
     /// does that yet.
     pub freq_offset_hz: Option<crate::signal::dsp::uncertainty::Uncertain>,
+    /// B8: modulation index, delta-f1 average, delta-f2 maximum and their
+    /// ratio, measured from this packet's own on-air symbols. `None` when
+    /// the packet was too short, or too unlucky in its particular random
+    /// content, to contain a settled run of either kind - see
+    /// `signal::ble::measure`'s own doc for what "settled" means here.
+    pub modulation: Option<crate::signal::ble::measure::ModulationQuality>,
     pub seen: std::time::Instant,
 }
 

--- a/src/state/net.rs
+++ b/src/state/net.rs
@@ -82,6 +82,18 @@ pub struct NetState {
     pub census: CensusState,
     pub health: NetDecodeHealth,
     pub band: BandOccupancy,
+    /// Advertising channel PDUs decoded so far this session, newest first,
+    /// capped at [`BLE_PACKET_LIMIT`].
+    pub ble_packets: std::collections::VecDeque<BlePacket>,
+    /// Why nothing is being decoded, when the radio can otherwise stream.
+    ///
+    /// B6's decoder needs the working rate `signal::ble::receive::front_end`
+    /// states, and needs the tuning to actually be one of the three
+    /// advertising channels - two conditions `net_survey`'s occupancy
+    /// measurement does not share, so this is its own refusal rather than
+    /// reusing `survey_refused`. Same reasoning as that field's own doc: a
+    /// refusal nobody can see is a silence.
+    pub ble_refused: Option<String>,
     /// The tuning the survey interrupted, so it can be given back.
     ///
     /// **In the state rather than in the task**, for the reason
@@ -166,6 +178,28 @@ pub struct NetDecodeHealth {
     pub peak_depth: u64,
     /// When the last block arrived. `None` before the first one.
     pub last_block: Option<std::time::Instant>,
+}
+
+/// How many recent PDUs [`NetState::ble_packets`] keeps. A bench instrument
+/// is read a screenful at a time, not scrolled back through a session's
+/// worth of advertising traffic; old rows fall off the end rather than
+/// growing the list forever.
+pub const BLE_PACKET_LIMIT: usize = 200;
+
+/// One decoded advertising channel PDU, as a panel shows it.
+///
+/// `crate::signal::ble::pdu::Packet` is the decode itself, pure and knowing
+/// nothing about a screen; this adds the two facts a panel needs that decode
+/// alone does not carry - which channel it arrived on and when.
+#[derive(Clone, Debug)]
+pub struct BlePacket {
+    pub channel: u8,
+    pub pdu_type: crate::signal::ble::pdu::PduType,
+    pub tx_add_random: bool,
+    pub length: u8,
+    pub adv_addr: Option<[u8; 6]>,
+    pub crc_ok: bool,
+    pub seen: std::time::Instant,
 }
 
 /// How the census table is being read: what orders it, and where the cursor is.

--- a/src/state/net.rs
+++ b/src/state/net.rs
@@ -218,6 +218,11 @@ pub struct BlePacket {
     /// content, to contain a settled run of either kind - see
     /// `signal::ble::measure`'s own doc for what "settled" means here.
     pub modulation: Option<crate::signal::ble::measure::ModulationQuality>,
+    /// B9: this packet's own frequency offset, read early and late, and the
+    /// drift between them. `None` under the same conditions as
+    /// `modulation` - too short a capture to give each half its own
+    /// variance.
+    pub drift: Option<crate::signal::ble::measure::Drift>,
     pub seen: std::time::Instant,
 }
 

--- a/src/state/net.rs
+++ b/src/state/net.rs
@@ -199,6 +199,19 @@ pub struct BlePacket {
     pub length: u8,
     pub adv_addr: Option<[u8; 6]>,
     pub crc_ok: bool,
+    /// B7: read from the detector's own coherence at the moment this
+    /// packet's sync word was found. `None` only at a coherence of one -
+    /// noiseless, which does not happen on a radio - never because nothing
+    /// was measured.
+    pub snr_db: Option<f64>,
+    /// B7: the discriminator's own mean over the whole capture, with its
+    /// proper uncertainty - see `dsp::uncertainty::mean_with_uncertainty`.
+    /// This one number is both our own receiver's LO error and the
+    /// transmitter's own crystal offset, added together and not yet
+    /// separated; a radio with its own frequency reference (design section
+    /// 7) could subtract the first and leave the second, and nothing here
+    /// does that yet.
+    pub freq_offset_hz: Option<crate::signal::dsp::uncertainty::Uncertain>,
     pub seen: std::time::Instant,
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -63,6 +63,7 @@ pub use panels::lab::timing_stripchart::TimingStripchartPanel;
 pub use panels::lab::timing_vitals::TimingVitalsPanel;
 
 pub use panels::net::ble_packets::NetBlePacketsPanel;
+pub use panels::net::bt_rf::NetBtRfPanel;
 pub use panels::net::capability::NetCapabilityPanel;
 pub use panels::net::census::NetCensusPanel;
 pub use panels::net::coexist::NetCoexistPanel;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -62,6 +62,7 @@ pub use panels::lab::timing_diagnostics::TimingDiagnosticsPanel;
 pub use panels::lab::timing_stripchart::TimingStripchartPanel;
 pub use panels::lab::timing_vitals::TimingVitalsPanel;
 
+pub use panels::net::ble_packets::NetBlePacketsPanel;
 pub use panels::net::capability::NetCapabilityPanel;
 pub use panels::net::census::NetCensusPanel;
 pub use panels::net::coexist::NetCoexistPanel;

--- a/src/ui/panels/net/ble_packets.rs
+++ b/src/ui/panels/net/ble_packets.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! `NetBlePacketsPanel` - what this device is advertising.
+//!
+//! B6's exit condition, on screen: real advertising channel PDUs, CRC-checked,
+//! newest first. No sorting and no cursor - a live packet feed is already in
+//! the order that matters, arrival order, and B6 does not yet decode enough
+//! (no SNR, no frequency offset - both B7's) to make a second ordering useful.
+//!
+//! **Three states, not two.** Design section 13.2's lesson for this section:
+//! silence has more than one cause, and printing zero for all of them is a
+//! lie by omission. Nothing decoding because the radio is not on an
+//! advertising channel, nothing decoding because the sample rate cannot
+//! reach the working rate, and genuinely nothing heard yet on a channel that
+//! is being watched correctly, are three different claims - only the last one
+//! is "we listened and nobody transmitted".
+
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::state::{BlePacket, SdrMetrics};
+use crate::ui::panel::{Panel, PanelChrome, Staleness};
+
+pub struct NetBlePacketsPanel;
+
+const CH_W: usize = 3;
+const TYPE_W: usize = 15;
+const ADDR_W: usize = 17;
+const ATYP_W: usize = 4;
+const LEN_W: usize = 4;
+const CRC_W: usize = 4;
+const AGE_W: usize = 6;
+
+fn header_line(theme: &crate::Theme) -> Line<'static> {
+    Line::from(Span::styled(
+        format!(
+            "{:<CH_W$} {:<TYPE_W$} {:<ADDR_W$} {:<ATYP_W$} {:>LEN_W$} {:>CRC_W$} {:>AGE_W$}",
+            "CH", "TYPE", "ADDRESS", "ATYP", "LEN", "CRC", "AGE"
+        ),
+        Style::default().fg(theme.label),
+    ))
+}
+
+/// `2 s` / `4 min` - how long ago, at the resolution anybody reads it at.
+/// The same shape `NetCensusPanel::ago` uses, for the same reason: one bench
+/// glances at a packet feed, it does not need a stopwatch.
+fn ago(secs: u64) -> String {
+    if secs < 90 {
+        format!("{secs} s")
+    } else {
+        format!("{} min", secs / 60)
+    }
+}
+
+fn address_text(addr: Option<[u8; 6]>) -> String {
+    match addr {
+        Some(a) => a
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(":"),
+        None => "-".to_string(),
+    }
+}
+
+fn row(p: &BlePacket, now: std::time::Instant, theme: &crate::Theme) -> Line<'static> {
+    let crc_ink = if p.crc_ok {
+        theme.status_ok
+    } else {
+        theme.status_crit
+    };
+    let crc_text = if p.crc_ok { "ok" } else { "bad" };
+    let age = ago(now.saturating_duration_since(p.seen).as_secs());
+    Line::from(vec![
+        Span::styled(
+            format!("{:<CH_W$}", p.channel),
+            Style::default().fg(theme.value),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:<TYPE_W$}", truncate(&p.pdu_type.label(), TYPE_W)),
+            Style::default().fg(theme.value),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:<ADDR_W$}", address_text(p.adv_addr)),
+            Style::default().fg(theme.value),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:<ATYP_W$}", if p.tx_add_random { "rnd" } else { "pub" }),
+            Style::default().fg(theme.label),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:>LEN_W$}", p.length),
+            Style::default().fg(theme.value),
+        ),
+        Span::raw(" "),
+        Span::styled(format!("{crc_text:>CRC_W$}"), Style::default().fg(crc_ink)),
+        Span::raw(" "),
+        Span::styled(format!("{age:>AGE_W$}"), Style::default().fg(theme.label)),
+    ])
+}
+
+fn truncate(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        s.to_string()
+    } else {
+        s.chars().take(width).collect()
+    }
+}
+
+impl Panel for NetBlePacketsPanel {
+    fn name(&self) -> &'static str {
+        "net_ble_packets"
+    }
+
+    fn min_size(&self) -> (u16, u16) {
+        (48, 6)
+    }
+
+    fn chrome(&self, state: &SdrMetrics) -> PanelChrome {
+        PanelChrome::new("BLE Advertising")
+            .stale_when(Staleness::NotStreaming)
+            .tag_if(true, state.net.mode.tag())
+    }
+
+    fn render(
+        &self,
+        f: &mut Frame,
+        inner: Rect,
+        state: &SdrMetrics,
+        theme: &crate::Theme,
+        _focused: bool,
+    ) {
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+        let mut lines = vec![header_line(theme)];
+
+        if let Some(reason) = &state.net.ble_refused {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "not decoding".to_string(),
+                Style::default().fg(theme.stale),
+            )));
+            for chunk in crate::ui::chrome::wrap(reason, inner.width as usize, 4) {
+                lines.push(Line::from(Span::styled(
+                    chunk,
+                    Style::default().fg(theme.label),
+                )));
+            }
+            f.render_widget(Paragraph::new(lines), inner);
+            return;
+        }
+
+        if state.net.ble_packets.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "no packets yet".to_string(),
+                Style::default().fg(theme.stale),
+            )));
+            lines.push(Line::from(Span::styled(
+                "watching an advertising channel; nothing decoded so far this",
+                Style::default().fg(theme.label),
+            )));
+            lines.push(Line::from(Span::styled(
+                "session",
+                Style::default().fg(theme.label),
+            )));
+            f.render_widget(Paragraph::new(lines), inner);
+            return;
+        }
+
+        let body = (inner.height as usize).saturating_sub(1);
+        let now = std::time::Instant::now();
+        for p in state.net.ble_packets.iter().take(body) {
+            lines.push(row(p, now, theme));
+        }
+        f.render_widget(Paragraph::new(lines), inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::ble::pdu::PduType;
+    use crate::state::fixture::draw;
+    use std::time::Instant;
+
+    fn packet(channel: u8, crc_ok: bool) -> BlePacket {
+        BlePacket {
+            channel,
+            pdu_type: PduType::AdvInd,
+            tx_add_random: false,
+            length: 9,
+            adv_addr: Some([0xaa, 0xbb, 0xcc, 0x11, 0x22, 0x33]),
+            crc_ok,
+            seen: Instant::now(),
+        }
+    }
+
+    /// Nothing decoding because the tuning is wrong says so, distinctly from
+    /// nothing decoding because nothing has arrived yet.
+    #[test]
+    fn a_refusal_is_shown_rather_than_an_empty_table() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net.ble_refused = Some("not tuned to an advertising channel".to_string());
+        let out = draw(NetBlePacketsPanel, 60, 10, &m).join("\n");
+        assert!(out.contains("not decoding"), "{out}");
+        assert!(out.contains("not tuned"), "{out}");
+    }
+
+    /// A channel correctly watched with nothing heard yet says that, plainly
+    /// distinct from a refusal.
+    #[test]
+    fn an_empty_feed_says_nothing_decoded_yet_rather_than_a_refusal() {
+        let out = draw(
+            NetBlePacketsPanel,
+            60,
+            10,
+            &SdrMetrics::fixture().streaming(),
+        )
+        .join("\n");
+        assert!(out.contains("no packets yet"), "{out}");
+        assert!(!out.contains("not decoding"), "{out}");
+    }
+
+    /// A good and a bad CRC read distinctly, and the newest packet - the
+    /// front of the deque - draws first.
+    #[test]
+    fn packets_show_crc_status_and_arrival_order() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net.ble_packets.push_back(packet(37, true));
+        m.net.ble_packets.push_front(packet(38, false));
+        let out = draw(NetBlePacketsPanel, 60, 10, &m).join("\n");
+        assert!(out.contains("bad"), "{out}");
+        assert!(out.contains("ok"), "{out}");
+        let bad_line = out.find("bad").unwrap();
+        let ok_line = out.find(" ok").unwrap();
+        assert!(bad_line < ok_line, "channel 38 (bad) should draw first");
+    }
+
+    #[test]
+    fn it_fits_every_size_the_layout_can_hand_it() {
+        let mut populated = SdrMetrics::fixture().streaming();
+        for i in 0..5 {
+            populated.net.ble_packets.push_back(packet(37, i % 2 == 0));
+        }
+        for w in 48..90u16 {
+            for h in 6..20u16 {
+                for m in [populated.clone(), SdrMetrics::fixture()] {
+                    for line in draw(NetBlePacketsPanel, w, h, &m) {
+                        assert!(line.chars().count() <= w as usize, "{w}x{h}: {line:?}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/panels/net/ble_packets.rs
+++ b/src/ui/panels/net/ble_packets.rs
@@ -4,9 +4,9 @@
 //! `NetBlePacketsPanel` - what this device is advertising.
 //!
 //! B6's exit condition, on screen: real advertising channel PDUs, CRC-checked,
-//! newest first. No sorting and no cursor - a live packet feed is already in
-//! the order that matters, arrival order, and B6 does not yet decode enough
-//! (no SNR, no frequency offset - both B7's) to make a second ordering useful.
+//! newest first. B7 added the SNR and CFO columns. No sorting and no cursor -
+//! a live packet feed is already in the order that matters, arrival order,
+//! and a second ordering has not earned its own column yet.
 //!
 //! **Three states, not two.** Design section 13.2's lesson for this section:
 //! silence has more than one cause, and printing zero for all of them is a
@@ -24,8 +24,10 @@ use ratatui::{
     Frame,
 };
 
+use crate::signal::dsp::uncertainty::Uncertain;
 use crate::state::{BlePacket, SdrMetrics};
 use crate::ui::panel::{Panel, PanelChrome, Staleness};
+use crate::ui::widgets::reading::Reading;
 
 pub struct NetBlePacketsPanel;
 
@@ -35,16 +37,44 @@ const ADDR_W: usize = 17;
 const ATYP_W: usize = 4;
 const LEN_W: usize = 4;
 const CRC_W: usize = 4;
+const SNR_W: usize = 7;
+const CFO_W: usize = 15;
 const AGE_W: usize = 6;
 
 fn header_line(theme: &crate::Theme) -> Line<'static> {
     Line::from(Span::styled(
         format!(
-            "{:<CH_W$} {:<TYPE_W$} {:<ADDR_W$} {:<ATYP_W$} {:>LEN_W$} {:>CRC_W$} {:>AGE_W$}",
-            "CH", "TYPE", "ADDRESS", "ATYP", "LEN", "CRC", "AGE"
+            "{:<CH_W$} {:<TYPE_W$} {:<ADDR_W$} {:<ATYP_W$} {:>LEN_W$} {:>CRC_W$} {:>SNR_W$} {:>CFO_W$} {:>AGE_W$}",
+            "CH", "TYPE", "ADDRESS", "ATYP", "LEN", "CRC", "SNR", "CFO", "AGE"
         ),
         Style::default().fg(theme.label),
     ))
+}
+
+/// `12.3` or a dash - B7's per-packet SNR, in dB. No unit in the cell itself;
+/// the column header carries it, the way every table in this deck does.
+fn fmt_snr(snr_db: Option<f64>) -> String {
+    match snr_db {
+        Some(db) => format!("{db:.1}"),
+        None => "-".to_string(),
+    }
+}
+
+/// `37.0 ±1.2 kHz` - B7's frequency offset, through the same value-with-
+/// uncertainty cell every measurement in the app uses. Scaled to kHz because
+/// a crystal's error is tens to hundreds of kHz at 2.4 GHz and a raw Hz
+/// figure would be seven digits of which the last five are noise.
+///
+/// **Uncorrected for this radio's own oscillator, and the cell does not
+/// pretend otherwise** - see `state::BlePacket::freq_offset_hz`'s own doc.
+fn fmt_cfo(offset: Option<Uncertain>) -> String {
+    match offset {
+        // No resolution threshold of our own yet to dash against, so this
+        // reads the same way a caller with none of its own does everywhere
+        // else in the app: always show the value.
+        Some(u) => Reading::new(u.scale(0.001), "kHz", f64::INFINITY).text(),
+        None => "-".to_string(),
+    }
 }
 
 /// `2 s` / `4 min` - how long ago, at the resolution anybody reads it at.
@@ -104,6 +134,16 @@ fn row(p: &BlePacket, now: std::time::Instant, theme: &crate::Theme) -> Line<'st
         ),
         Span::raw(" "),
         Span::styled(format!("{crc_text:>CRC_W$}"), Style::default().fg(crc_ink)),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:>SNR_W$}", fmt_snr(p.snr_db)),
+            Style::default().fg(theme.value),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:>CFO_W$}", truncate(&fmt_cfo(p.freq_offset_hz), CFO_W)),
+            Style::default().fg(theme.value),
+        ),
         Span::raw(" "),
         Span::styled(format!("{age:>AGE_W$}"), Style::default().fg(theme.label)),
     ])
@@ -203,6 +243,8 @@ mod tests {
             length: 9,
             adv_addr: Some([0xaa, 0xbb, 0xcc, 0x11, 0x22, 0x33]),
             crc_ok,
+            snr_db: Some(12.3),
+            freq_offset_hz: Some(Uncertain::from_sigma(37_000.0, 1_200.0)),
             seen: Instant::now(),
         }
     }

--- a/src/ui/panels/net/ble_packets.rs
+++ b/src/ui/panels/net/ble_packets.rs
@@ -245,6 +245,7 @@ mod tests {
             crc_ok,
             snr_db: Some(12.3),
             freq_offset_hz: Some(Uncertain::from_sigma(37_000.0, 1_200.0)),
+            modulation: None,
             seen: Instant::now(),
         }
     }

--- a/src/ui/panels/net/ble_packets.rs
+++ b/src/ui/panels/net/ble_packets.rs
@@ -246,6 +246,7 @@ mod tests {
             snr_db: Some(12.3),
             freq_offset_hz: Some(Uncertain::from_sigma(37_000.0, 1_200.0)),
             modulation: None,
+            drift: None,
             seen: Instant::now(),
         }
     }

--- a/src/ui/panels/net/bt_rf.rs
+++ b/src/ui/panels/net/bt_rf.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 MusiThang <viktor.laszlo92@protonmail.com>
+
+//! `NetBtRfPanel` - is this transmitter's own modulation any good?
+//!
+//! B8's exit condition, on screen: modulation index, delta-f1 average,
+//! delta-f2 maximum and their ratio, each against its stated limit, for the
+//! most recently decoded advertising packet. Design section 9.1's idiom B
+//! (`ui::widgets::limit`) is drawn here for the first time - see that
+//! module's own doc for the row shape and why the word "pass" never
+//! appears.
+//!
+//! **The three states `net_ble_packets` already established, reused
+//! here.** Not decoding, nothing decoded yet, and - a fourth this panel
+//! adds of its own - a real packet whose own random content happened not
+//! to contain a settled run of one of the two kinds this measurement needs
+//! (`signal::ble::measure`'s own doc explains which). All three are
+//! refusals, never a zeroed or invented row.
+
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::signal::ble::measure::ModulationQuality;
+use crate::signal::dsp::uncertainty::Uncertain;
+use crate::state::SdrMetrics;
+use crate::ui::panel::{Panel, PanelChrome, Staleness};
+use crate::ui::widgets::limit::{Limit, LimitRow, RowWidths};
+use crate::ui::widgets::reading::Reading;
+
+pub struct NetBtRfPanel;
+
+/// Design section 2.1: "roughly 0.45 to 0.55 for BLE". Cross-checked
+/// informally, not read from a primary copy of the specification this
+/// session - the same standing `signal::ble::channel`'s own table has, and
+/// the same figure `ui::widgets::limit`'s own tests were written against
+/// before this panel gave the widget a real consumer.
+const MOD_INDEX_BAND: Limit = Limit::Band {
+    low: 0.45,
+    high: 0.55,
+};
+
+/// `h = 2 * delta_f / symbol_rate`, so the modulation index band above maps
+/// to exactly this delta-f1 band at LE 1M's 1 Mb/s symbol rate - derived
+/// from the same figure rather than an independently recalled one.
+const DELTA_F1_BAND_KHZ: Limit = Limit::Band {
+    low: 225.0,
+    high: 275.0,
+};
+
+/// Recalled from the BLE RF-PHY test specification's own delta-f2 floor,
+/// **not checked against a primary source this session** - design section
+/// 6's own "facts to verify before building" table lists this exact figure
+/// as open. Kept as a stated limit rather than left out, on the same
+/// reasoning `signal::ble::channel`'s table gives for shipping a
+/// cross-checked-but-unread number: real, and owed a real read before
+/// anything downstream trusts it to the last kHz.
+const DELTA_F2_MAX_FLOOR_KHZ: Limit = Limit::Min(185.0);
+
+/// Recalled from the same source and under the same caveat as
+/// [`DELTA_F2_MAX_FLOOR_KHZ`]: the specification's own ratio requirement
+/// between delta-f2 and delta-f1 averages.
+const RATIO_FLOOR: Limit = Limit::Min(0.8);
+
+/// How much uncertainty each reading can carry before it dashes rather than
+/// prints - a judgement call in the absence of a specification-stated
+/// figure, made the same way `Uncertain::is_resolved`'s own doc asks for:
+/// a fraction of the band width each limit states, generous enough that an
+/// ordinarily noisy real packet still shows a number rather than a dash on
+/// every row.
+const MOD_INDEX_RESOLUTION: f64 = 0.02;
+const DELTA_F1_RESOLUTION_KHZ: f64 = 10.0;
+const RATIO_RESOLUTION: f64 = 0.1;
+
+fn rows(q: &ModulationQuality) -> Vec<LimitRow<'static>> {
+    vec![
+        LimitRow::new(
+            "Mod index",
+            Reading::new(q.modulation_index, "", MOD_INDEX_RESOLUTION),
+            MOD_INDEX_BAND,
+        ),
+        LimitRow::new(
+            "df1 avg",
+            Reading::new(
+                q.delta_f1_avg_hz.scale(0.001),
+                "kHz",
+                DELTA_F1_RESOLUTION_KHZ,
+            ),
+            DELTA_F1_BAND_KHZ,
+        ),
+        LimitRow::new(
+            "df2 max",
+            // Not an `Uncertain` this measurement carries - see
+            // `ModulationQuality::delta_f2_max_hz`'s own doc for why a
+            // maximum gets none - so this reads it as exact rather than
+            // inventing a sigma, and `f64::INFINITY` so it is never dashed
+            // for a reason it did not earn.
+            Reading::new(
+                Uncertain::exact(q.delta_f2_max_hz * 0.001),
+                "kHz",
+                f64::INFINITY,
+            ),
+            DELTA_F2_MAX_FLOOR_KHZ,
+        ),
+        LimitRow::new(
+            "df2/df1",
+            Reading::new(q.ratio, "", RATIO_RESOLUTION),
+            RATIO_FLOOR,
+        ),
+    ]
+}
+
+/// The widest bar that still keeps every row inside `width` columns.
+///
+/// A row's overall length depends on the margin text too, which varies with
+/// the actual value - not just the label, value and sigma columns
+/// [`RowWidths::fit`] measures - so this checks the real rendered length
+/// rather than budgeting columns by hand and hoping.
+fn fit(rows: &[LimitRow], width: usize) -> RowWidths {
+    let mut bar = width;
+    loop {
+        let w = RowWidths::fit(rows, bar);
+        let longest = rows
+            .iter()
+            .map(|r| r.text(w).chars().count())
+            .max()
+            .unwrap_or(0);
+        if longest <= width || bar == 0 {
+            return w;
+        }
+        bar -= 1;
+    }
+}
+
+impl Panel for NetBtRfPanel {
+    fn name(&self) -> &'static str {
+        "net_bt_rf"
+    }
+
+    fn min_size(&self) -> (u16, u16) {
+        (28, 4)
+    }
+
+    fn chrome(&self, state: &SdrMetrics) -> PanelChrome {
+        PanelChrome::new("Modulation Quality")
+            .stale_when(Staleness::NotStreaming)
+            .tag_if(true, state.net.mode.tag())
+    }
+
+    fn render(
+        &self,
+        f: &mut Frame,
+        inner: Rect,
+        state: &SdrMetrics,
+        theme: &crate::Theme,
+        _focused: bool,
+    ) {
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+        let width = inner.width as usize;
+
+        if let Some(reason) = &state.net.ble_refused {
+            let mut lines = vec![Line::from(Span::styled(
+                "not decoding".to_string(),
+                Style::default().fg(theme.stale),
+            ))];
+            for chunk in crate::ui::chrome::wrap(reason, width, 4) {
+                lines.push(Line::from(Span::styled(
+                    chunk,
+                    Style::default().fg(theme.label),
+                )));
+            }
+            f.render_widget(Paragraph::new(lines), inner);
+            return;
+        }
+
+        let Some(latest) = state.net.ble_packets.front() else {
+            f.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    "no packets yet".to_string(),
+                    Style::default().fg(theme.stale),
+                ))),
+                inner,
+            );
+            return;
+        };
+
+        let Some(q) = latest.modulation else {
+            f.render_widget(
+                Paragraph::new(vec![
+                    Line::from(Span::styled(
+                        "not measured".to_string(),
+                        Style::default().fg(theme.stale),
+                    )),
+                    Line::from(Span::styled(
+                        "latest packet too short, or too short a run of either kind",
+                        Style::default().fg(theme.label),
+                    )),
+                ]),
+                inner,
+            );
+            return;
+        };
+
+        let rows = rows(&q);
+        let w = fit(&rows, width);
+        let lines: Vec<Line> = rows.iter().map(|r| Line::from(r.spans(theme, w))).collect();
+        f.render_widget(Paragraph::new(lines), inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::ble::pdu::PduType;
+    use crate::state::fixture::draw;
+    use crate::state::BlePacket;
+    use std::time::Instant;
+
+    fn quality(deviation_hz: f64) -> ModulationQuality {
+        ModulationQuality {
+            delta_f1_avg_hz: Uncertain::from_sigma(deviation_hz, deviation_hz * 0.01),
+            delta_f2_max_hz: deviation_hz * 0.9,
+            modulation_index: Uncertain::from_sigma(2.0 * deviation_hz / 1_000_000.0, 0.005),
+            ratio: Uncertain::from_sigma(0.9, 0.02),
+        }
+    }
+
+    fn packet(modulation: Option<ModulationQuality>) -> BlePacket {
+        BlePacket {
+            channel: 37,
+            pdu_type: PduType::AdvInd,
+            tx_add_random: false,
+            length: 9,
+            adv_addr: Some([0xaa, 0xbb, 0xcc, 0x11, 0x22, 0x33]),
+            crc_ok: true,
+            snr_db: Some(12.0),
+            freq_offset_hz: None,
+            modulation,
+            seen: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn a_refusal_is_shown_rather_than_an_empty_panel() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net.ble_refused = Some("not tuned to an advertising channel".to_string());
+        let out = draw(NetBtRfPanel, 40, 8, &m).join("\n");
+        assert!(out.contains("not decoding"), "{out}");
+        assert!(out.contains("not tuned"), "{out}");
+    }
+
+    #[test]
+    fn an_empty_feed_says_nothing_decoded_yet() {
+        let out = draw(NetBtRfPanel, 40, 8, &SdrMetrics::fixture().streaming()).join("\n");
+        assert!(out.contains("no packets yet"), "{out}");
+    }
+
+    #[test]
+    fn a_packet_with_nothing_measured_refuses_rather_than_inventing_rows() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net.ble_packets.push_back(packet(None));
+        let out = draw(NetBtRfPanel, 40, 8, &m).join("\n");
+        assert!(out.contains("not measured"), "{out}");
+        assert!(!out.contains("Mod index"), "{out}");
+    }
+
+    /// The nominal deviation's own modulation index draws inside its band,
+    /// and none of the four limits' words appear anywhere - the same
+    /// discipline `the_word_pass_appears_nowhere_in_any_rendering` holds
+    /// the widget itself to, now through a real panel.
+    #[test]
+    fn a_good_packet_draws_all_four_rows_and_never_says_pass() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net
+            .ble_packets
+            .push_back(packet(Some(quality(250_000.0))));
+        let out = draw(NetBtRfPanel, 70, 8, &m).join("\n");
+        assert!(out.contains("Mod index"), "{out}");
+        assert!(out.contains("df1 avg"), "{out}");
+        assert!(out.contains("df2 max"), "{out}");
+        assert!(out.contains("df2/df1"), "{out}");
+        let lower = out.to_ascii_lowercase();
+        for word in ["pass", "fail"] {
+            assert!(!lower.contains(word), "{word} in {out:?}");
+        }
+    }
+
+    #[test]
+    fn it_fits_every_size_the_layout_can_hand_it() {
+        let mut populated = SdrMetrics::fixture().streaming();
+        populated
+            .net
+            .ble_packets
+            .push_back(packet(Some(quality(250_000.0))));
+        for w in 20..90u16 {
+            for h in 4..16u16 {
+                for m in [populated.clone(), SdrMetrics::fixture()] {
+                    for line in draw(NetBtRfPanel, w, h, &m) {
+                        assert!(line.chars().count() <= w as usize, "{w}x{h}: {line:?}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/panels/net/bt_rf.rs
+++ b/src/ui/panels/net/bt_rf.rs
@@ -8,14 +8,19 @@
 //! most recently decoded advertising packet. Design section 9.1's idiom B
 //! (`ui::widgets::limit`) is drawn here for the first time - see that
 //! module's own doc for the row shape and why the word "pass" never
-//! appears.
+//! appears. B9 adds two more rows, drift and drift rate, the same panel
+//! design section 3's own table names for both.
 //!
 //! **The three states `net_ble_packets` already established, reused
 //! here.** Not decoding, nothing decoded yet, and - a fourth this panel
 //! adds of its own - a real packet whose own random content happened not
 //! to contain a settled run of one of the two kinds this measurement needs
 //! (`signal::ble::measure`'s own doc explains which). All three are
-//! refusals, never a zeroed or invented row.
+//! refusals, never a zeroed or invented row. B9's drift rows are simpler:
+//! they need only two symbols per half rather than a lucky run of either
+//! kind, so in practice they are present whenever modulation quality is,
+//! and this panel shows them only then rather than inventing a fourth
+//! refusal state for a gap that has not been observed to occur on its own.
 
 use ratatui::{
     layout::Rect,
@@ -25,7 +30,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::signal::ble::measure::ModulationQuality;
+use crate::signal::ble::measure::{Drift, ModulationQuality};
 use crate::signal::dsp::uncertainty::Uncertain;
 use crate::state::SdrMetrics;
 use crate::ui::panel::{Panel, PanelChrome, Staleness};
@@ -66,6 +71,24 @@ const DELTA_F2_MAX_FLOOR_KHZ: Limit = Limit::Min(185.0);
 /// between delta-f2 and delta-f1 averages.
 const RATIO_FLOOR: Limit = Limit::Min(0.8);
 
+/// Recalled from the RF-PHY test specification's own drift limit for LE 1M,
+/// **not checked against a primary source this session** - design section
+/// 6's own facts-to-verify table lists "BLE drift and drift-rate limits,
+/// and the patterns they are measured over" as an open item, unresolved by
+/// B9 same as it was left by B1. A symmetric band, because a burst can
+/// drift either warmer or colder than its own start.
+const DRIFT_BAND_KHZ: Limit = Limit::Band {
+    low: -50.0,
+    high: 50.0,
+};
+
+/// Recalled under the same caveat as [`DRIFT_BAND_KHZ`]: the specification's
+/// own drift-rate limit, in Hz per microsecond.
+const DRIFT_RATE_BAND: Limit = Limit::Band {
+    low: -400.0,
+    high: 400.0,
+};
+
 /// How much uncertainty each reading can carry before it dashes rather than
 /// prints - a judgement call in the absence of a specification-stated
 /// figure, made the same way `Uncertain::is_resolved`'s own doc asks for:
@@ -75,9 +98,11 @@ const RATIO_FLOOR: Limit = Limit::Min(0.8);
 const MOD_INDEX_RESOLUTION: f64 = 0.02;
 const DELTA_F1_RESOLUTION_KHZ: f64 = 10.0;
 const RATIO_RESOLUTION: f64 = 0.1;
+const DRIFT_RESOLUTION_KHZ: f64 = 10.0;
+const DRIFT_RATE_RESOLUTION: f64 = 80.0;
 
-fn rows(q: &ModulationQuality) -> Vec<LimitRow<'static>> {
-    vec![
+fn rows(q: &ModulationQuality, d: Option<&Drift>) -> Vec<LimitRow<'static>> {
+    let mut out = vec![
         LimitRow::new(
             "Mod index",
             Reading::new(q.modulation_index, "", MOD_INDEX_RESOLUTION),
@@ -111,7 +136,20 @@ fn rows(q: &ModulationQuality) -> Vec<LimitRow<'static>> {
             Reading::new(q.ratio, "", RATIO_RESOLUTION),
             RATIO_FLOOR,
         ),
-    ]
+    ];
+    if let Some(d) = d {
+        out.push(LimitRow::new(
+            "Drift",
+            Reading::new(d.drift_hz.scale(0.001), "kHz", DRIFT_RESOLUTION_KHZ),
+            DRIFT_BAND_KHZ,
+        ));
+        out.push(LimitRow::new(
+            "Drift rate",
+            Reading::new(d.drift_rate_hz_per_us, "Hz/us", DRIFT_RATE_RESOLUTION),
+            DRIFT_RATE_BAND,
+        ));
+    }
+    out
 }
 
 /// The widest bar that still keeps every row inside `width` columns.
@@ -207,7 +245,7 @@ impl Panel for NetBtRfPanel {
             return;
         };
 
-        let rows = rows(&q);
+        let rows = rows(&q, latest.drift.as_ref());
         let w = fit(&rows, width);
         let lines: Vec<Line> = rows.iter().map(|r| Line::from(r.spans(theme, w))).collect();
         f.render_widget(Paragraph::new(lines), inner);
@@ -231,7 +269,26 @@ mod tests {
         }
     }
 
+    fn drift(drift_hz: f64) -> Drift {
+        let initial_hz = Uncertain::from_sigma(0.0, 500.0);
+        let final_hz = Uncertain::from_sigma(drift_hz, 500.0);
+        let drift = final_hz.difference(&initial_hz);
+        Drift {
+            initial_hz,
+            final_hz,
+            drift_hz: drift,
+            drift_rate_hz_per_us: drift.scale(0.01),
+        }
+    }
+
     fn packet(modulation: Option<ModulationQuality>) -> BlePacket {
+        packet_with_drift(modulation, None)
+    }
+
+    fn packet_with_drift(
+        modulation: Option<ModulationQuality>,
+        drift: Option<crate::signal::ble::measure::Drift>,
+    ) -> BlePacket {
         BlePacket {
             channel: 37,
             pdu_type: PduType::AdvInd,
@@ -242,6 +299,7 @@ mod tests {
             snr_db: Some(12.0),
             freq_offset_hz: None,
             modulation,
+            drift,
             seen: Instant::now(),
         }
     }
@@ -291,13 +349,44 @@ mod tests {
         }
     }
 
+    /// B9's exit condition on screen: a packet with drift measured shows
+    /// two more rows than one without, and neither row's word is "pass".
+    #[test]
+    fn a_packet_with_drift_draws_two_more_rows() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net.ble_packets.push_back(packet_with_drift(
+            Some(quality(250_000.0)),
+            Some(drift(5_000.0)),
+        ));
+        let out = draw(NetBtRfPanel, 70, 10, &m).join("\n");
+        assert!(out.contains("Drift"), "{out}");
+        assert!(out.contains("Drift rate"), "{out}");
+        let lower = out.to_ascii_lowercase();
+        for word in ["pass", "fail"] {
+            assert!(!lower.contains(word), "{word} in {out:?}");
+        }
+    }
+
+    /// Modulation quality without a drift reading draws its own four rows
+    /// and nothing more, rather than a fifth refusal state for a gap this
+    /// arc has not observed to occur on its own.
+    #[test]
+    fn modulation_without_drift_draws_no_drift_rows() {
+        let mut m = SdrMetrics::fixture().streaming();
+        m.net
+            .ble_packets
+            .push_back(packet(Some(quality(250_000.0))));
+        let out = draw(NetBtRfPanel, 70, 8, &m).join("\n");
+        assert!(!out.contains("Drift"), "{out}");
+    }
+
     #[test]
     fn it_fits_every_size_the_layout_can_hand_it() {
         let mut populated = SdrMetrics::fixture().streaming();
-        populated
-            .net
-            .ble_packets
-            .push_back(packet(Some(quality(250_000.0))));
+        populated.net.ble_packets.push_back(packet_with_drift(
+            Some(quality(250_000.0)),
+            Some(drift(5_000.0)),
+        ));
         for w in 20..90u16 {
             for h in 4..16u16 {
                 for m in [populated.clone(), SdrMetrics::fixture()] {

--- a/src/ui/panels/net/mod.rs
+++ b/src/ui/panels/net/mod.rs
@@ -9,6 +9,7 @@
 //! has to check whether it should be on screen. If it is drawing, it may.
 
 pub mod ble_packets;
+pub mod bt_rf;
 pub mod capability;
 pub mod census;
 pub mod coexist;

--- a/src/ui/panels/net/mod.rs
+++ b/src/ui/panels/net/mod.rs
@@ -8,6 +8,7 @@
 //! presets naming these panels are dropped when it refuses. So nothing in here
 //! has to check whether it should be on screen. If it is drawing, it may.
 
+pub mod ble_packets;
 pub mod capability;
 pub mod census;
 pub mod coexist;

--- a/src/ui/widgets/limit.rs
+++ b/src/ui/widgets/limit.rs
@@ -65,17 +65,23 @@ const COVERAGE_K: f64 = 2.0;
 
 /// What a standard states about a value.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(dead_code)] // idiom B, built ahead of its consumers: B8 is the first stated limit
 pub(crate) enum Limit {
     /// Both sides stated: the value belongs between them.
     Band { low: f64, high: f64 },
     /// A ceiling: the value belongs at or below it.
+    ///
+    /// B8 gave this widget its first real consumer, and every one of its
+    /// four rows is a band or a floor - no ceiling among them. Kept rather
+    /// than removed: a one-sided limit that names a maximum is exactly as
+    /// real a shape as one that names a minimum, and this widget's own
+    /// `carrier_leak` test fixture is what still exercises it, the same
+    /// design-sketch row the module doc's own worked example draws.
+    #[allow(dead_code)]
     Max(f64),
     /// A floor: the value belongs at or above it.
     Min(f64),
 }
 
-#[allow(dead_code)] // idiom B, built ahead of its consumers: B8 is the first stated limit
 impl Limit {
     /// The floor and the ceiling, either of which a one-sided limit lacks.
     fn bounds(&self) -> (Option<f64>, Option<f64>) {
@@ -103,7 +109,6 @@ impl Limit {
 
 /// The four column widths a row is drawn into.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(dead_code)] // idiom B, built ahead of its consumers: B8 is the first stated limit
 pub(crate) struct RowWidths {
     label: usize,
     value: usize,
@@ -111,7 +116,6 @@ pub(crate) struct RowWidths {
     bar: usize,
 }
 
-#[allow(dead_code)] // idiom B, built ahead of its consumers: B8 is the first stated limit
 impl RowWidths {
     /// Measured from a block of rows, so a column of them lines up.
     ///
@@ -136,14 +140,12 @@ impl RowWidths {
 }
 
 /// One measurement against one stated limit.
-#[allow(dead_code)] // idiom B, built ahead of its consumers: B8 is the first stated limit
 pub(crate) struct LimitRow<'a> {
     label: &'a str,
     reading: Reading<'a>,
     limit: Limit,
 }
 
-#[allow(dead_code)] // idiom B, built ahead of its consumers: B8 is the first stated limit
 impl<'a> LimitRow<'a> {
     pub(crate) fn new(label: &'a str, reading: Reading<'a>, limit: Limit) -> Self {
         Self {

--- a/src/ui/widgets/reading.rs
+++ b/src/ui/widgets/reading.rs
@@ -72,14 +72,12 @@ impl Ink {
 }
 
 /// A measurement, ready to be drawn or written out.
-#[allow(dead_code)] // idiom A, drawn by idiom B, whose own consumer is B8
 pub(crate) struct Reading<'a> {
     value: Uncertain,
     unit: &'a str,
     resolution: f64,
 }
 
-#[allow(dead_code)] // idiom A, drawn by idiom B, whose own consumer is B8
 impl<'a> Reading<'a> {
     /// `resolution` is the smallest difference that matters for this reading: a
     /// specification tolerance, a channel spacing, a ppm budget. An uncertainty


### PR DESCRIPTION
Summary

Adds a Bluetooth LE advertising-channel receiver arc (signal::ble), following dev_docs/bluetooth-bench-design.md's B1–B9 steps:

- BLE channel plan (2402–2480 MHz, 40 channels), preamble/access-address detection, timing recovery, whitening (LFSR) and CRC-24, PDU header decode
- Live net_ble preset: net_ble_packets (per-packet CH/TYPE/ADDRESS/LEN/CRC/SNR/CFO) and net_bt_rf (modulation index, delta-f1/f2, drift — limit-and-margin rows)
- Per-packet SNR and CFO with CRLB-consistent uncertainty; frequency drift and drift rate within a packet

Every synthetic test is checked against the specification's own published vectors where they exist (CRC-24 against the RevEng check value, whitening against a worked seed example) rather than only against this arc's own transmitter.

Real-hardware fixes (this session)

Real air surfaced three bugs no synthetic test caught, each fixed and verified:

1. Anti-alias filter, and a reference/signal mismatch it exposed. front_end decimated with no filtering, so out-of-channel energy in a wideband HackRF capture aliased into the working band. Adding a Kaiser anti-alias filter then broke detection outright — correlating a filtered signal against the detector's unfiltered reference collapsed peak coherence from 0.9998 to 0.22. Fixed by having Receiver build its own reference through the identical filter pipeline (matched_reference).
2. Filter-induced timing ambiguity. The anti-alias filter smears the sync/header boundary by several symbols (a real time-bandwidth tradeoff), so the exact header start becomes data-dependent. try_decode now searches ±6 symbols around the nominal boundary and accepts the first CRC-passing candidate, backed by a small lookback buffer.
3. A known, twice-abandoned bias in find_phase. Two-point linear interpolation's noise variance depends on the fractional sampling phase, biasing the timing search toward whichever candidate needs no blending under noise. Replaced with four-point Catmull-Rom cubic interpolation, which measurably (not just theoretically) reduces the bias — new tests reproduce the bias on a noisy signal and confirm the reduction against the closed-form prediction.

Known open issue

CRC still does not pass on real air. The false-trigger flood from (1) is gone and CFO readings are now small and consistent, but real advertising packets still fail CRC. The leading suspect is a fundamental SNR mismatch: net_ble_packets' own SNR column is the matched filter's (with ~20 dB of coherent-integration gain), while the single-sample-per-symbol demodulator gets none — a packet reporting 15 dB there may be well below 0 dB at the symbol level, where no receiver decodes reliably. Untested: a real device held close enough to the antenna for genuine margin. dev_docs/bluetooth-bench-plan.md (gitignored, not in this diff) has the full session notes if useful context is needed later.

The net_ble_packets panel shows this honestly, every packet renders with its real CRC: bad, never a guess.